### PR TITLE
fix(taint): keep the gate's audit when the run ends on the waived call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,18 @@ same list.
 
 ### Fixed
 
+- A run's taint-gate audit (`stages/<n>/taint_audit.json`) keeps the decisions it
+  recorded just before the run ended. The persistence lane keeps only the newest
+  snapshot per run when several are queued together, and the sender marked the
+  audit written when it built the job rather than when the job reached disk, so a
+  coalesced-away snapshot took its gate events with it. Mid-run the next gate event
+  rewrote the whole log and healed it; the last events before the run finished had
+  no next event and were lost. What that cost in practice: a `--yolo` run waives
+  the gate and records the override as `YoloAutoApprove`, and for an inline
+  `submit_output` (the fast path, no tool lane between the block and the finish)
+  that record never reached the file, so a run that published Private context to
+  `GET /api/agents/{id}/result` left nothing behind saying so. The snapshot that
+  records a run going terminal now always carries the whole log.
 - The daemon rebuilds its provider registry when `config.toml` changes, so a provider you
   configure, replace or remove is picked up by the next run instead of at the next daemon
   restart. The registry was built once at boot: a user who ran out of credits on one provider,

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -46,6 +46,15 @@ pub struct RunArgs {
     /// everything after it writes code. Such a run parks in `Waiting` until
     /// somebody answers; set `[limits] interaction_timeout_secs` to bound the
     /// wait.
+    ///
+    /// It also waives the taint gate. An attended run asks before an outbound
+    /// tool sends data more sensitive than its clearance, and `submit_output`
+    /// counts: `lev serve` hands the answer to whoever reads
+    /// `GET /api/agents/{id}/result`. Unattended there is nobody to ask, so the
+    /// call goes through and the override is recorded in the run's
+    /// `stages/<n>/taint_audit.json` as `YoloAutoApprove`. Think twice before
+    /// combining `--yolo` with an agent whose `[read_paths]` reach private
+    /// files.
     #[arg(long)]
     pub yolo: bool,
 

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -1797,6 +1797,65 @@ system = { kind = "pinned", max_tokens = 1000 }
         );
     }
 
+    /// A tool the user granted outright still answers to the taint gate.
+    ///
+    /// `[tool_permissions]` and the gate are separate layers asking separate
+    /// questions - "may this agent call `shell` at all" and "may *this* data
+    /// reach it" - and only `--yolo` waives the second. Granting a tool must
+    /// not quietly grant the data too: measured live, a run with
+    /// `shell = "allow"` and a Private read still raised the leak prompt, and
+    /// denying it kept the command from running.
+    #[tokio::test]
+    async fn build_agent_tool_permission_allow_does_not_waive_the_taint_gate() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"sec\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [security]\ntaint_tracking = true\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\
+             available_tools = [\"shell\"]\n",
+        )
+        .unwrap();
+        let mut config = Config::default();
+        config
+            .tool_permissions
+            .insert("shell".to_string(), crate::config::ToolPolicy::Allow);
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let entity = build_agent(
+            world.world_mut(),
+            SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &config,
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                mcp_tool_owners: &Default::default(),
+                hub: &hub,
+                now_secs: 100,
+                subagent_tx: sub_tx(),
+            },
+            &spawn_args(&manifest.to_string_lossy()),
+        )
+        .expect("spawn succeeds");
+
+        assert!(
+            world
+                .world()
+                .get::<leviath_runtime::TaintGate>(entity)
+                .is_some(),
+            "the gate is attached regardless of tool permissions"
+        );
+        assert!(
+            world
+                .world()
+                .get::<leviath_runtime::components::GateAutoApprove>(entity)
+                .is_none(),
+            "only --yolo waives the gate; a tool grant does not"
+        );
+    }
+
     #[tokio::test]
     async fn build_agent_marks_root_runs_for_titling_but_not_subagents() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/leviath-runtime/src/gate_prompt.rs
+++ b/crates/leviath-runtime/src/gate_prompt.rs
@@ -291,6 +291,75 @@ mod tests {
         assert_eq!(out.resolution, GateResolution::AlwaysAllow);
     }
 
+    fn gated_call() -> GatedCall {
+        GatedCall {
+            entity: Entity::from_raw_u32(1)
+                .expect("a small literal index is always a valid entity id"),
+            agent_id: "run".to_string(),
+            tool_id: "c1".to_string(),
+            tool_name: "submit_output".to_string(),
+            taint: TaintLevel::Private,
+            clearance: TaintLevel::Public,
+        }
+    }
+
+    /// A gate prompt nobody answers before `[limits] interaction_timeout_secs`
+    /// resolves as a **deny**, not as an allow: the hub hands back the same
+    /// neutral response a cancel does, and a neutral response has no choice
+    /// index. Nothing over-cleared leaves the machine because a person walked
+    /// away from the terminal.
+    #[tokio::test(start_paused = true)]
+    async fn an_unanswered_gate_prompt_denies_when_the_timeout_elapses() {
+        let hub = InteractionHub::new();
+        hub.set_timeout_secs(Some(30));
+        let (tx, mut rx) = unbounded_channel();
+        let task = tokio::spawn(run_gate_prompt(
+            gated_call(),
+            PromptLane {
+                hub: hub.clone(),
+                outcomes: tx,
+                wake: Arc::new(Notify::new()),
+            },
+        ));
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(hub.pending().len(), 1, "the prompt is open");
+        tokio::time::advance(std::time::Duration::from_secs(31)).await;
+        task.await.unwrap();
+        let out = rx.recv().await.unwrap();
+        assert_eq!(out.resolution, GateResolution::Deny);
+        assert!(hub.pending().is_empty(), "the expired prompt is dropped");
+    }
+
+    /// With no `interaction_timeout_secs` configured - the shipped default -
+    /// the same prompt waits indefinitely. The run stays parked rather than
+    /// resolving itself either way, which is the behaviour a deployment that
+    /// wants a bound has to opt out of.
+    #[tokio::test(start_paused = true)]
+    async fn a_gate_prompt_waits_indefinitely_with_no_timeout_configured() {
+        let hub = InteractionHub::new();
+        assert_eq!(hub.timeout_secs(), None);
+        let (tx, mut rx) = unbounded_channel();
+        let _task = tokio::spawn(run_gate_prompt(
+            gated_call(),
+            PromptLane {
+                hub: hub.clone(),
+                outcomes: tx,
+                wake: Arc::new(Notify::new()),
+            },
+        ));
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(std::time::Duration::from_secs(24 * 60 * 60)).await;
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(hub.pending().len(), 1, "still waiting a day later");
+        assert!(rx.try_recv().is_err(), "no resolution was invented");
+    }
+
     fn collect_world() -> (World, UnboundedSender<GatePromptOutcome>) {
         let (tx, rx) = unbounded_channel();
         let mut world = World::new();

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -561,11 +561,25 @@ pub(crate) fn dispatch_persistence(
         // means the file on disk is already current - re-serializing the whole
         // log every heartbeat was an O(events) allocation that grew with the
         // run.
+        //
+        // ...except on the snapshot that records the run going terminal, which
+        // always carries the whole log. The watermark advances when the job is
+        // *built*, but the lane coalesces superseded snapshots away (keeping
+        // only the newest per run), so a job whose audit was dropped there
+        // leaves the watermark claiming a write that never happened. Mid-run
+        // that self-heals: the next gate event makes the count differ again and
+        // the whole log is rewritten. The last events before the run ends have
+        // no "next event", so without this they were lost for good - which is
+        // how a `--yolo` run's waived block (`YoloAutoApprove`) reached disk
+        // after a `shell` call and not after an inline `submit_output`, the one
+        // finishing fast enough to be coalesced. Same failure shape as issue
+        // #276, which fixed it for the `final_output` sidecar.
+        let final_snapshot = is_terminal_status(&state.status) && watermark_changed;
         let taint_audit = taint_gate
             .filter(|g| !g.audit_log().is_empty())
             .and_then(|g| {
                 let key = (cursor.index, g.audit_log().len());
-                if watermark.last_taint == Some(key) {
+                if watermark.last_taint == Some(key) && !final_snapshot {
                     return None;
                 }
                 watermark.last_taint = Some(key);

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -3215,6 +3215,56 @@ fn dispatch_persistence_taint_audit_is_not_rewritten_when_unchanged() {
     );
 }
 
+/// ...but the snapshot that records the run going terminal carries the whole
+/// log again, unchanged or not.
+///
+/// The watermark advances when the job is built, while the lane keeps only the
+/// newest snapshot per run, so a job whose audit was coalesced away leaves the
+/// watermark claiming a write that never landed. Mid-run the next gate event
+/// heals it; the last events before the run ends have no next event. Measured
+/// live: a `--yolo` run whose waived block was a `shell` call recorded
+/// `YoloAutoApprove` on disk, and the same run submitting through the inline
+/// `submit_output` recorded nothing at all.
+#[test]
+fn dispatch_persistence_resends_the_taint_audit_on_the_terminal_snapshot() {
+    let (mut world, mut prx) = world_with_persistence();
+    let (jtx, _jrx) = mpsc::unbounded_channel();
+    world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    let e = world
+        .spawn((
+            run_metadata(),
+            agent_state(),
+            infer_with(vec![tc("c_shell", "shell")]),
+            tainted_conv_window(),
+            ReadyForTools,
+            enabled_gate(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+        ))
+        .id();
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+    run_dispatch_persistence(&mut world);
+    // This is the snapshot the lane would coalesce away: it carried the audit,
+    // and it advanced the watermark past it.
+    let coalesced = snapshot_job(prx.try_recv().expect("first job"));
+    assert!(coalesced.taint_audit.is_some());
+
+    // The run finishes with no further gate events.
+    world.get_mut::<AgentState>(e).unwrap().status = AgentStatus::Complete;
+    run_dispatch_persistence(&mut world);
+
+    let terminal = snapshot_job(prx.try_recv().expect("terminal job"));
+    let (idx, json) = terminal
+        .taint_audit
+        .expect("the terminal snapshot re-sends the audit");
+    assert_eq!(idx, 0);
+    assert!(json.contains("shell"), "{json}");
+}
+
 #[test]
 fn dispatch_persistence_skips_taint_audit_when_the_gate_is_empty() {
     let (mut world, mut prx) = world_with_persistence();
@@ -6155,6 +6205,73 @@ async fn dispatch_tools_auto_approves_a_gate_block_under_yolo() {
     assert!(
         recorded_yolo_override,
         "expected a YoloAutoApprove audit entry"
+    );
+}
+
+/// The same waiver over `submit_output`, which is the one that carries the
+/// data off the machine rather than merely running a command with it: the
+/// answer is recorded and `GET /api/agents/{id}/result` serves it.
+///
+/// Pinned on its own because `submit_output` takes the inline path rather than
+/// the lane, so the `shell` test above says nothing about it - and because this
+/// is the case measured live: a `--yolo` run over a Private read published its
+/// context to the result endpoint with no prompt. `--yolo` waives enforcement
+/// deliberately; what must not drift is that the waiver is still *recorded*.
+#[tokio::test]
+async fn dispatch_tools_under_yolo_submits_over_tainted_context_and_records_it() {
+    let (jtx, mut jrx) = mpsc::unbounded_channel();
+    let (gtx, _grx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    world.insert_resource(crate::interaction_hub::InteractionHub::new());
+    world.insert_resource(crate::gate_prompt::GatePromptStage {
+        outcomes: gtx,
+        wake: std::sync::Arc::new(tokio::sync::Notify::new()),
+        runtime: tokio::runtime::Handle::current(),
+    });
+    let e = world
+        .spawn((
+            agent_state(),
+            infer_with(vec![submit_call("o1", "the secret")]),
+            tainted_output_window(),
+            ReadyForTools,
+            enabled_gate(),
+            crate::components::GateAutoApprove,
+        ))
+        .id();
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    assert!(
+        world
+            .get::<crate::gate_prompt::AwaitingGatePrompt>(e)
+            .is_none(),
+        "unattended: nothing is asked"
+    );
+    assert!(
+        jrx.try_recv().is_err(),
+        "a submission is applied inline, never sent to the lane"
+    );
+    let recorded = world
+        .get::<crate::persistence::FinalOutput>(e)
+        .expect("the waived submission became the run's answer");
+    assert_eq!(recorded.0.content, "the secret");
+    let audit: Vec<_> = world
+        .get::<crate::taint::TaintGate>(e)
+        .unwrap()
+        .audit_log()
+        .iter()
+        .map(|ev| ev.decision_source.clone())
+        .collect();
+    assert!(
+        audit.contains(&leviath_core::taint::GateDecisionSource::AutoBlock),
+        "the gate is evaluated, not skipped: {audit:?}"
+    );
+    assert!(
+        audit.contains(&leviath_core::taint::GateDecisionSource::YoloAutoApprove),
+        "the waiver is recorded: {audit:?}"
     );
 }
 

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -173,6 +173,15 @@ tool-approval. There, **Allow for this session** raises the tool's clearance for
 run, and **Deny** blocks it. It offers no per-stage option, because a clearance is not keyed on
 what a call runs.
 
+That prompt's unanswered cases go the safe way. Left open past
+`[limits] interaction_timeout_secs`, it resolves as a deny and the model gets `[blocked]`, the same
+as if you had pressed it: the hub hands the waiting call the neutral response a cancelled prompt
+produces, and a neutral response carries no choice. With no `interaction_timeout_secs` configured,
+which is the default, it waits for as long as the daemon is up and the run stays in
+`waiting_input`. The one case that does not park and does not deny is `--yolo`, which waives the
+gate and lets the call through; [security](/docs/security#when-there-is-nobody-to-ask) has the whole
+table.
+
 ## Interaction points
 
 An interaction point is a checkpoint you write into the blueprint rather than one the agent chooses

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -304,6 +304,13 @@ recorded. Your policy decides what happens: allow it, deny it, or ask. A blocked
 recorded as the run's answer, and the model is told, so the stage can submit something else. Taint
 tracking is off unless you turn it on, so this changes nothing for an install that leaves it alone.
 
+An unattended run is the exception. `--yolo` waives the gate along with everything else it stops
+asking about, so the submission goes through and the answer, private regions and all, is served from
+`GET /api/agents/{id}/result`. The waiver is recorded rather than silent: the run's
+`stages/<n>/taint_audit.json` carries the block and the `YoloAutoApprove` that overrode it. See
+[when there is nobody to ask](/docs/security#when-there-is-nobody-to-ask) for what every other
+unattended shape does, which is not the same thing.
+
 ## Large results
 
 An answer is one model response. That is a hard ceiling, not a policy. `submit_output` takes its

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -242,6 +242,33 @@ lev policy test bash --target example.com
 `lev policy add` and `lev policy test` take the tool name as a **positional** argument
 (`lev policy add <tool> …`, `lev policy test <tool> --target …`).
 
+### When there is nobody to ask
+
+The prompt above assumes a person. Most runs do not have one, and the gate does not answer the same
+way in each case. What actually happens, measured against a real daemon with a granted `[read_paths]`
+read (which is Private) flowing into `submit_output` and into `shell`:
+
+| The run | What the gate does | Does the private data leave? |
+| --- | --- | --- |
+| Attended, through `lev serve` or the dashboard | Raises the leak prompt and parks the run in `waiting_input` | Only if you pick **Allow once** or **Allow for this session** |
+| `--yolo`, or the dashboard's unattended toggle | Waives enforcement and lets the call through, with no prompt | **Yes** |
+| A tool set to `allow` in `[tool_permissions]` | Still prompts. Granting a tool is not granting the data | Only if you allow it |
+| An embedded host with no interaction hub wired | Blocks the call outright and hands the model `[blocked]` | No |
+| A prompt nobody answers before `[limits] interaction_timeout_secs` | Resolves as a deny once the deadline passes | No |
+| The same with no `interaction_timeout_secs` set, which is the default | Waits indefinitely; the run stays in `waiting_input` | No |
+
+`--yolo` is the row to read twice. It means "run unattended", and the gate's prompt is one of the
+things it stops raising, so an unattended run over private data hands that data to whatever its
+outbound tools reach, `GET /api/agents/{id}/result` included. Nothing is hidden: the gate is still
+evaluated, and the waived block is written to the run's `stages/<n>/taint_audit.json` with
+`decision_source: "YoloAutoApprove"` beside the `AutoBlock` it overrode. That file is the record to
+read after an unattended run, and `lev policy test` is how to find out beforehand what a given tool
+would have done.
+
+If you want an unattended run that cannot leak rather than one that reports having done so, keep the
+sensitive paths out of it: drop the `[read_paths]` grant, or set the outbound tool to `deny` in
+`[tool_permissions]`, which no launch flag lifts.
+
 ## Response size caps
 
 The daemon stops reading a remote peer at a fixed size rather than buffering


### PR DESCRIPTION
## The question

#719 made `submit_output` an outbound channel, so the taint gate now fires on it. The test that
covers the blocked case uses `ToolStage::detached`, which is not the same as a run started with
`--yolo`, or one whose tool policy is `allow`, or one whose prompt nobody answers. Nobody had
established what those do. This measures each of them, pins them, documents them, and fixes the one
thing that turned out to be broken.

## What actually happens

Measured against a real daemon (`lev serve` + a mock provider), with a probe blueprint whose
`[read_paths]` grant makes a `read_file` result **Private**, flowing into `submit_output` and into
`shell`. Canary string in the file, checked for at `GET /api/agents/{id}/result` and in the workdir.

| # | Case | Gate outcome | Private data out? | Audit on disk |
| --- | --- | --- | --- | --- |
| 1 | Attended, prompt lane wired | **Prompts.** `multiple_choice`, stage `taint_gate`, "would send Private-level data over a channel cleared only for Public" | Deny: no, `final_output: null`, `[blocked]` in the transcript. Allow once: yes | `AutoAllow`, `AutoBlock`, `UserDenied` / `UserAllowOnce` |
| 2 | `--yolo` / unattended | **Allowed silently.** No prompt raised | **Yes.** `submit_output`: canary in `/result`. `shell`: the command ran, `leaked.txt` written | `AutoBlock` + `YoloAutoApprove`, *but see below* |
| 3 | `[tool_permissions] shell = "allow"`, attended | **Prompts.** Tool policy and the gate are independent layers | No (denied); `leaked.txt` not created | `AutoAllow`, `AutoBlock`, `UserDenied` |
| 4 | No prompt lane (embedded host with no hub) | **Blocked inline**, `[blocked]` as the tool result | No | `AutoBlock` |
| 5a | Prompt unanswered, `interaction_timeout_secs = 8` | **Denied** when the deadline passes | No | `AutoBlock`, `UserDenied` |
| 5b | Prompt unanswered, no timeout configured (the default) | **Waits.** Still `waiting_input` after 60 s | No | `AutoBlock` |

Live transcripts for every row are reproducible with the probe described at the bottom.

## The code trace

`dispatch_tools` (`pipeline/tools.rs`) runs the gate before the inline `submit_output` application.
`auto_approve_gates = auto_gate.is_some()`, from the `GateAutoApprove` component that
`daemon/spawn/mod.rs` attaches when `args.yolo`. On a block it takes the waiver branch, calls
`gate.record_allow(.., YoloAutoApprove)` and falls through to dispatch. Non-yolo, it either pushes a
`pending_prompts` entry (hub **and** `GatePromptStage` both present) or returns
`taint_block_message`. `check_with_policy` consults the taint allowlist and Rhai rules; it never
sees `ToolPolicy`, which is why row 3 prompts. A timed-out prompt comes back from
`InteractionHub::submit` as the neutral response a cancel produces, and `resolution_from_answer`
maps a missing `choice_index` to `Deny`, which is row 5a. With no deadline, `submit` awaits the
oneshot with nothing racing it, which is row 5b.

## Verdict

**Row 2 is deliberate, and I have not changed it.** `GateAutoApprove`'s own doc says so: "enforcement
is waived, accountability is kept", on the grounds that a headless run must not park on a prompt
nobody can answer. `--yolo` is an explicit statement of consent, and flipping it to deny would turn
every unattended run over granted read paths into `[blocked]`. That is a defaults change and belongs
to the user, not to this PR. It is worth saying plainly that rows 4, 5a and 5b all answer "no human
available" by refusing, and row 2 is the only one that answers by allowing; if that inconsistency
should be closed, say so and it is a small follow-up.

**The accountability half was broken, and that is fixed here.** Row 2 measured differently depending
on the tool:

```
--yolo + shell           audit_sources: ["AutoAllow", "AutoBlock", "YoloAutoApprove"]   leaked.txt written
--yolo + submit_output   audit_sources: ["AutoAllow"]                                   canary in /result
```

A `--yolo` run published Private context to `GET /api/agents/{id}/result` and left **nothing on
disk** saying it had. That is the "silently bypasses with no record" shape, arrived at from the
persistence side rather than the gate side.

### Cause

`dispatch_persistence` sends the gate's audit only when `(stage index, event count)` differs from
its watermark, and advances the watermark when it **builds** the job. The persistence worker keeps
only the newest snapshot per run when several are queued together, so a coalesced-away job takes
its gate events with it while the watermark claims they were written. Mid-run this heals: the next
gate event makes the count differ again and the whole (append-only) log is rewritten. The last
events before a run ends have no next event. `submit_output` is applied inline rather than through
the tool lane, so nothing spaces the block and the finish apart, and it lost every time; `shell`
survived only because the lane round trip bought it a tick.

This is the same failure shape as #276, which fixed it for the `final_output` sidecar. That fix
moved the decision into the lane; the taint audit was never given the same treatment.

### Fix

The snapshot that records a run going terminal always carries the whole log, watermark or not. One
condition, in `pipeline/persist.rs`. It preserves the reason the watermark exists (a busy run still
does not re-serialize an O(events) log every heartbeat) and closes the only case where a loss is
permanent.

### Fail-first evidence

`dispatch_persistence_resends_the_taint_audit_on_the_terminal_snapshot`, run with the fix stashed:

```
test pipeline::tests::dispatch_persistence_resends_the_taint_audit_on_the_terminal_snapshot ... FAILED
panicked at crates/leviath-runtime/src/pipeline/tests.rs:3261:10:
the terminal snapshot re-sends the audit
```

Re-verified live after the fix, same probe, same run shape:

```
"audit_sources": ["AutoAllow", "AutoBlock", "YoloAutoApprove"]
stages/0/taint_audit.json:
  {"tool_name":"submit_output","taint_level":"Private","clearance":"Public",
   "allowed":false,"decision_source":"AutoBlock"},
  {"tool_name":"submit_output","taint_level":"Private","clearance":"Public",
   "allowed":true,"decision_source":"YoloAutoApprove"}
```

## Tests

- `dispatch_persistence_resends_the_taint_audit_on_the_terminal_snapshot` (fails first, above).
- `dispatch_tools_under_yolo_submits_over_tainted_context_and_records_it` - row 2 for
  `submit_output`, which the existing `shell` test said nothing about: no prompt, applied inline
  rather than sent to the lane, becomes the run's answer, and both `AutoBlock` and `YoloAutoApprove`
  are in the log.
- `build_agent_tool_permission_allow_does_not_waive_the_taint_gate` - row 3, pinned where the two
  layers meet: a config granting `shell` outright attaches the gate and no `GateAutoApprove`.
- `an_unanswered_gate_prompt_denies_when_the_timeout_elapses` - row 5a, driven through a real hub
  on a paused clock.
- `a_gate_prompt_waits_indefinitely_with_no_timeout_configured` - row 5b, still pending a simulated
  day later, with no resolution invented.
- Rows 1 and 4 already had tests (`dispatch_tools_prompts_for_a_tainted_submission_and_applies_it_once_approved`,
  `dispatch_tools_gates_a_submission_over_tainted_context`); they are unchanged.

## Docs

- `docs/content/security.md`: a "When there is nobody to ask" subsection carrying the table above,
  what `--yolo` does and where its record lands, and what to do instead if you want an unattended
  run that cannot leak rather than one that reports having done so.
- `docs/content/outputs.md`: the `--yolo` exception beside the existing "your policy decides".
- `docs/content/interaction.md`: the timeout and no-timeout behaviour of the gate prompt.
- `--yolo`'s own help text, which said nothing about the gate at all.

## Gates

`cargo fmt --all`; `cargo clippy --all-targets --all-features` on `leviath-runtime` and
`leviath-cli`, clean; `cargo test -p leviath-runtime --lib` (1683) and `-p leviath-cli --lib`
(4265), green; `cargo xtask structure`; `cargo xtask docs`; `cargo xtask coverage --package
leviath-runtime` and `--package leviath-cli`, both exit 0 after `rm -rf target/llvm-cov-target`.
No em dashes.

## Reproducing the probe

An isolated `LEVIATH_HOME` with a `taintprobe` blueprint (`[security] taint_tracking = true`,
`[read_paths] allow = ["~/vault"]`, `available_tools = ["read_file", "shell", "submit_output"]`), a
config with `allow_blueprint_read_paths = true`, and a two-step OpenAI-shaped mock that calls
`read_file` on the vault file and then the outbound tool under test. Spawn over
`POST /api/agents` with `yolo` set per row, watch `GET /api/agents/{id}/interaction`, answer through
`POST /api/agents/{id}/interaction`, and read `stages/*/taint_audit.json` after
`lev daemon stop` so the lane has flushed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
