### PR TITLE
feat(serve): list the .rhai files a picker could offer, not only the declared ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -496,6 +496,22 @@ same list.
 
 ### Added
 
+- `GET /api/scripts?agent=<name>&include=candidates` also lists the `.rhai`
+  files under that agent's directory that nothing declares, as
+  `kind: "unknown"` with `declared: false`, so an editor can offer a picker for
+  `[stages.*.output].validator` and the hooks. Without the parameter the
+  listing holds exactly what it held before: a file appears once something
+  names it, which is circular for a picker but right for "what will load".
+  Every entry now carries `declared`, and an agent-scoped one carries
+  `relative_path`, the spelling that goes into a manifest. The scan is bounded
+  (four levels, 128 directories, 256 files), reports `.rhai` files only, and
+  follows no symlink out of the agent's own directory. A hook or validator
+  declared in a subdirectory is listed rather than dropped, and
+  `GET/PUT/DELETE /api/scripts/{kind}/{name}` opens it under the relative name
+  the listing reports, with the separator percent-encoded
+  (`output_validator/validators%2Fa2ui`); every part of the name is still a
+  safe path component and the result still has to resolve inside the agent's
+  directory. Announced as `scripts.candidates` (#738).
 - `POST /api/update` carries out the update `GET /api/update` describes,
   behind `--allow-admin`: the same plan, run in the background. It answers
   202 with a job id, sends every step as `update_progress` on `/ws` with

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -236,6 +236,12 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // the four agent-owned kinds without serving this one, and a console that
     // offered the kind anyway would put an editor in front of a 400.
     "scripts.providers",
+    // `?include=candidates` on the script listing, plus `relative_path` and
+    // `declared` on every entry. Announced because the fallback is a picker
+    // that can only offer a validator something already names, which is the
+    // circle the parameter exists to break: without it a console cannot tell
+    // "this agent has no other scripts" from "this daemon does not look".
+    "scripts.candidates",
     "config.gateways",
     // `kind`, `header_names` and `models` on each gateway `GET /api/config`
     // reports, and `kind`, `headers` and `models` on what `PUT /api/config`

--- a/crates/leviath-cli/src/commands/serve/scripts.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts.rs
@@ -14,9 +14,18 @@
 //! `resolve_*_scripts` in the daemon refusing any that lands outside it. There
 //! is no `hooks/` or `validators/` directory to list, so the listing derives
 //! those three from what the manifest declares, and the read/write routes
-//! address them at `<agent>/<name>.rhai` - the path a bare declared filename
-//! already resolves to. There is likewise no global directory for them: a hook
-//! only ever loads from beside the agent that declares it.
+//! address them at `<agent>/<name>.rhai` - subdirectories included, since a
+//! manifest may declare `validators/a2ui.rhai` and a route that could not open
+//! it would be a listing entry nobody could act on. There is likewise no global
+//! directory for them: a hook only ever loads from beside the agent that
+//! declares it.
+//!
+//! What the manifest declares is not what a person is choosing between, though.
+//! An editor offering a validator picker needs the files that *could* be named,
+//! and a file is only declared once somebody has named it. `?include=candidates`
+//! is that half: the `.rhai` files under the agent's directory that nothing
+//! declares, reported as a `kind` of `unknown` and `declared: false`, under a
+//! bounded walk that never leaves the agent's own directory.
 //!
 //! A **provider** is the inverse: `~/.leviath/providers/<name>.rhai` and nothing
 //! else. No agent owns one, and a stage reaches it by name rather than by path,
@@ -31,8 +40,8 @@
 //! `lev serve --allow-admin`. The `GET` routes stay open so an editor degrades
 //! to read-only instead of disappearing.
 
-use std::collections::{BTreeMap, HashMap};
-use std::path::{Component, Path, PathBuf};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::StatusCode;
@@ -108,30 +117,113 @@ fn global_providers_dir() -> PathBuf {
 #[derive(Debug, Clone)]
 struct Target {
     kind: ScriptKind,
-    /// The directory the file must live in, and nothing below it.
+    /// The directory the file must resolve inside. A `{name}` may name a
+    /// subdirectory of it, and nothing above or outside it.
     dir: PathBuf,
-    /// `<dir>/<name>.rhai`.
+    /// The directory the file itself sits in: `dir`, or a subdirectory of it
+    /// when the name carries one. Kept apart from `dir` because `dir` is the
+    /// fence and this is only where a write has to create directories.
+    file_dir: PathBuf,
+    /// `<file_dir>/<file>.rhai`.
     path: PathBuf,
+    /// The `{name}` this was addressed by, normalized: `/`-separated, no
+    /// `.rhai`. Spelled back so a response never renames what it was asked for.
+    name: String,
     /// `agent` or `global`.
     scope: &'static str,
     /// The agent that owns it, absent for the global directory.
     agent: Option<String>,
 }
 
+/// A `.rhai` file addressed relative to some directory.
+///
+/// One shape for the two places a relative script path is read: a `{name}` off
+/// the URL, and a path a manifest declares. Both have to end up as the same
+/// three answers - what to call it, where it sits, and what to write into a
+/// manifest - and having them computed twice is how the two disagreed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Addressed {
+    /// The `{name}` the routes address it by: `/`-separated, `.rhai` stripped.
+    name: String,
+    /// The same file relative to the base directory, extension included, always
+    /// with `/` separators because that is what goes into a manifest.
+    relative: String,
+    /// The directory components between the base and the file, in order.
+    dirs: Vec<String>,
+    /// The file name, `.rhai` included.
+    file: String,
+}
+
+impl Addressed {
+    /// Where the file sits under `base`.
+    fn dir_in(&self, base: &Path) -> PathBuf {
+        self.dirs
+            .iter()
+            .fold(base.to_path_buf(), |acc, d| acc.join(d))
+    }
+
+    /// The file itself under `base`.
+    fn path_in(&self, base: &Path) -> PathBuf {
+        self.dir_in(base).join(&self.file)
+    }
+}
+
+/// Read a `{name}` as a path relative to a script directory, or `None` when it
+/// is not one these routes can address.
+///
+/// A name may be a single component (`check`) or a `/`-separated relative path
+/// (`validators/a2ui`), because that is the shape a manifest declares a hook or
+/// a validator in and the shape the listing has to report back. Every component
+/// goes through [`leviath_core::is_safe_path_component`], which is what keeps
+/// `..`, an absolute path, a Windows `\` separator and an empty segment out:
+/// `Path::join` normalizes none of them. Containment is still checked
+/// afterwards by [`guard`], because a component that is safe to spell can still
+/// be a symlink pointing elsewhere.
+///
+/// The `.rhai` extension is fixed here rather than taken from the caller, so no
+/// request can ask for a `.toml`, a manifest, or anything else in the agent's
+/// directory. A name that already carries the extension means the same file,
+/// since that is how a manifest and this listing both spell one.
+fn addressed_path(name: &str) -> Option<Addressed> {
+    let stem = name.strip_suffix(".rhai").unwrap_or(name);
+    let mut dirs: Vec<String> = Vec::new();
+    let mut file = String::new();
+    for part in stem.split('/') {
+        if !leviath_core::is_safe_path_component(part) {
+            return None;
+        }
+        // Which component is the file is only known once the walk ends, so
+        // whatever was holding that place becomes a directory as soon as
+        // another component arrives. An empty `file` is the first turn.
+        if !file.is_empty() {
+            dirs.push(std::mem::take(&mut file));
+        }
+        file = part.to_string();
+    }
+    Some(Addressed {
+        name: stem.to_string(),
+        relative: format!("{stem}.rhai"),
+        file: format!("{file}.rhai"),
+        dirs,
+    })
+}
+
 /// Resolve `{kind}/{name}` plus an optional `?agent=` into the one file the
 /// request may touch.
 ///
 /// Both `name` and `agent` arrive in a URL and are joined onto a directory, so
-/// both go through [`leviath_core::is_safe_path_component`] first, the way
-/// `blueprint_dir` does in `blueprints.rs`: `Path::join` neither normalizes
-/// `..` nor resists an absolute path, and the bug that check exists for was a
-/// REST route writing attacker-chosen content outside the directory it meant to
-/// and then recursively deleting whatever it had landed on.
+/// every component of both goes through
+/// [`leviath_core::is_safe_path_component`] first, the way `blueprint_dir` does
+/// in `blueprints.rs`: `Path::join` neither normalizes `..` nor resists an
+/// absolute path, and the bug that check exists for was a REST route writing
+/// attacker-chosen content outside the directory it meant to and then
+/// recursively deleting whatever it had landed on.
 ///
-/// The `.rhai` extension is fixed here rather than taken from the caller, so no
-/// request can ask for a `.toml`, a manifest, or anything else in the agent's
-/// directory. A `name` that already carries the extension is accepted and means
-/// the same file, since that is how the listing spells a path back.
+/// `name` may address a subdirectory (`validators/a2ui`, percent-encoded in the
+/// URL as `validators%2Fa2ui`), because a manifest names a hook or a validator
+/// by a path relative to the agent's directory and a route that could only
+/// address one component could not open the file the listing had just reported.
+/// [`guard`] still checks where the result lands.
 fn resolve(
     config: &crate::config::Config,
     kind: &str,
@@ -144,16 +236,15 @@ fn resolve(
             format!("Unknown script kind '{kind}': expected {KIND_LIST}"),
         ));
     };
-    let stem = name.strip_suffix(".rhai").unwrap_or(name);
-    if !leviath_core::is_safe_path_component(stem) {
+    let Some(addressed) = addressed_path(name) else {
         return Err(err(
             StatusCode::BAD_REQUEST,
             format!(
-                "Invalid script name '{name}': names may contain only letters, digits, \
-                 '.', '_' and '-'"
+                "Invalid script name '{name}': each '/'-separated part may contain only \
+                 letters, digits, '.', '_' and '-'"
             ),
         ));
-    }
+    };
 
     let (dir, scope, owner) = match (agent, kind) {
         // A provider is machine-wide. Scoping one to an agent would write a file
@@ -190,11 +281,14 @@ fn resolve(
         }
     };
 
-    let path = dir.join(format!("{stem}.rhai"));
+    let file_dir = addressed.dir_in(&dir);
+    let path = addressed.path_in(&dir);
     Ok(Target {
         kind,
         dir,
+        file_dir,
         path,
+        name: addressed.name,
         scope,
         agent: owner,
     })
@@ -211,13 +305,15 @@ enum Presence {
 
 /// The containment gate every read and write passes through.
 ///
-/// The name is already a single safe component joined onto a fixed directory,
-/// so nothing the caller wrote can carry the path elsewhere. What is left is
-/// what the *filesystem* can do: a symlink planted at that exact name would
-/// send a read or a write straight through it, outside the directory this route
-/// is fenced to. `symlink_metadata` does not follow, so anything that is not a
-/// plain file is refused before it is opened, and the resolved path is then
-/// checked against the directory it came from.
+/// The name is already safe components joined onto a fixed directory, so
+/// nothing the caller wrote can carry the path elsewhere lexically. What is left
+/// is what the *filesystem* can do: a symlink planted at that exact name, or at
+/// a directory along the way, would send a read or a write straight through it,
+/// outside the directory this route is fenced to. `symlink_metadata` does not
+/// follow, so anything that is not a plain file is refused before it is opened,
+/// and the resolved path is then checked against the directory it came from -
+/// `resolves_within` canonicalizes, so a link at any component is caught, not
+/// only one at the last.
 ///
 /// The existence check runs first on purpose. Containment canonicalizes, and a
 /// directory that does not exist yet cannot be canonicalized, so asking that
@@ -309,6 +405,21 @@ pub(super) struct ScriptQuery {
     agent: Option<String>,
 }
 
+/// What the listing takes: an `?agent=`, and what else to put in the answer.
+///
+/// Its own type rather than an `include` bolted onto [`ScriptQuery`], so the
+/// read and write routes do not appear to take a parameter they would ignore.
+#[derive(Debug, Deserialize)]
+pub(super) struct ListScriptsQuery {
+    /// Scope to this agent's own directory.
+    agent: Option<String>,
+    /// Comma-separated extras. `candidates` adds the `.rhai` files beside the
+    /// agent that nothing declares. Only meaningful with `agent`: the global
+    /// directories are already listed file by file from disk, so there is
+    /// nothing undeclared left there to add.
+    include: Option<String>,
+}
+
 /// What a provider script's leading `// @` comments declare.
 ///
 /// Carried as one nested object rather than as six more optional fields on
@@ -366,9 +477,11 @@ fn provider_meta(kind: ScriptKind, content: &str) -> Option<ProviderScriptMeta> 
 /// One script in the listing.
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct ScriptItem {
-    /// `tool`, `region_hook`, `stage_hook`, `output_validator` or `provider`.
+    /// `tool`, `region_hook`, `stage_hook`, `output_validator` or `provider`,
+    /// or [`CANDIDATE_KIND`] for a file nothing has claimed yet.
     pub(super) kind: String,
-    /// The `{name}` the read and write routes address it by.
+    /// The `{name}` the read and write routes address it by, once a caller has
+    /// picked a `kind` for it. `/`-separated for a file in a subdirectory.
     pub(super) name: String,
     /// `agent` when it belongs to one agent, `global` when every agent gets it.
     pub(super) source: String,
@@ -377,8 +490,19 @@ pub(super) struct ScriptItem {
     pub(super) agent: Option<String>,
     /// The file on disk.
     pub(super) path: String,
-    /// Whether it compiles right now.
-    pub(super) compiles: bool,
+    /// The same file relative to the agent's own directory, which is the
+    /// spelling a manifest wants (`validators/a2ui.rhai`). Absent for a
+    /// machine-wide script, which no blueprint contains.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) relative_path: Option<String>,
+    /// Whether something loads this file as this `kind`: a `tools/` directory
+    /// the daemon scans, or a manifest that names it. `false` for a candidate.
+    pub(super) declared: bool,
+    /// Whether it compiles right now. Absent for a candidate: nothing says
+    /// which of the five compilers such a file is for, and picking one would be
+    /// a claim about the file rather than a fact about it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) compiles: Option<bool>,
     /// Why not, when it does not.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) error: Option<String>,
@@ -467,24 +591,17 @@ pub(super) struct ValidateScriptResp {
 
 // ─── Listing ────────────────────────────────────────────────────────────────
 
-/// The `{name}` these routes would address a declared script by, or `None` when
-/// the manifest declared something they cannot address.
+/// How a manifest-declared path is addressed, or `None` when the manifest
+/// declared something these routes cannot address.
 ///
 /// A manifest may name any path inside the agent's directory, a subdirectory
-/// included. These routes address `<agent>/<name>.rhai`: one component, one
-/// fixed extension. Anything else is left out of the listing rather than listed
-/// under a name that would fetch a different file or none at all.
-fn addressable_name(declared: &str) -> Option<String> {
-    let mut components = Path::new(declared).components();
-    let (Some(Component::Normal(only)), None) = (components.next(), components.next()) else {
-        return None;
-    };
-    let file = only.to_string_lossy();
-    let stem = file.strip_suffix(".rhai")?;
-    match leviath_core::is_safe_path_component(stem) {
-        true => Some(stem.to_string()),
-        false => None,
-    }
+/// included, and [`addressed_path`] handles those. What it does not handle is a
+/// declaration that is not a `.rhai` file at all: `addressed_path` appends the
+/// extension, so a declared `notes.txt` would be reported as `notes.txt.rhai`,
+/// a different file. Requiring the suffix here keeps the listing off it.
+fn declared_address(declared: &str) -> Option<Addressed> {
+    let stem = declared.strip_suffix(".rhai")?;
+    addressed_path(stem)
 }
 
 /// Every hook and validator the manifest declares, keyed by kind and declared
@@ -571,17 +688,18 @@ fn collect_tools(dir: &Path, scope: &'static str, agent: Option<&str>, out: &mut
             Some(reason) => (false, Some(reason.clone())),
             None => (true, None),
         };
+        let name = stem_of(&path);
         out.push(ScriptItem {
             kind: ScriptKind::Tool.as_str().to_string(),
-            name: path
-                .file_stem()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .into(),
+            // A tool sits in `tools/`, so its manifest-relative path carries
+            // that directory even though the route addresses it without one.
+            relative_path: agent.map(|_| format!("tools/{name}.rhai")),
+            name,
             source: scope.to_string(),
             agent: agent.map(str::to_string),
             path: path.display().to_string(),
-            compiles,
+            declared: true,
+            compiles: Some(compiles),
             error,
             provider: None,
         });
@@ -618,7 +736,9 @@ fn collect_providers(dir: &Path, out: &mut Vec<ScriptItem>) {
             source: "global".to_string(),
             agent: None,
             path: label,
-            compiles,
+            relative_path: None,
+            declared: true,
+            compiles: Some(compiles),
             error,
             provider: meta,
         });
@@ -639,11 +759,13 @@ fn collect_declared(dir: &Path, agent: &str, out: &mut Vec<ScriptItem>) {
     };
 
     for ((kind, declared), hooks) in declared_scripts(&bp) {
-        let Some(name) = addressable_name(&declared) else {
+        let Some(addressed) = declared_address(&declared) else {
             continue;
         };
-        // `name` is a single safe component, so this join cannot leave `dir`.
-        let path = dir.join(format!("{name}.rhai"));
+        // Every component is a safe one, so this join cannot leave `dir`
+        // lexically; a symlink at one of them still can, which is what the
+        // read route's `guard` is for. Nothing is opened here but the file.
+        let path = addressed.path_in(dir);
         let hook_refs: Vec<&str> = hooks.iter().map(String::as_str).collect();
         let (compiles, error) = match std::fs::read_to_string(&path) {
             Ok(content) => status_pair(compile_status(kind, &declared, &content, &hook_refs)),
@@ -654,15 +776,175 @@ fn collect_declared(dir: &Path, agent: &str, out: &mut Vec<ScriptItem>) {
         };
         out.push(ScriptItem {
             kind: kind.as_str().to_string(),
-            name,
+            name: addressed.name,
             source: "agent".to_string(),
             agent: Some(agent.to_string()),
             path: path.display().to_string(),
-            compiles,
+            relative_path: Some(addressed.relative),
+            declared: true,
+            compiles: Some(compiles),
             error,
             provider: None,
         });
     }
+}
+
+// ─── Candidates ─────────────────────────────────────────────────────────────
+
+/// The `kind` a candidate is reported under.
+///
+/// Not a lie about the file: a `.rhai` beside an agent that nothing declares
+/// could be a region hook, a stage hook, a validator or a tool, and the file
+/// itself does not say which. The declaration does, which is the thing that has
+/// not happened yet. `ScriptKind::parse` rejects this spelling, so a client
+/// cannot hand it back as a kind either.
+const CANDIDATE_KIND: &str = "unknown";
+
+/// How deep below the agent's own directory the candidate scan walks.
+///
+/// The convention the docs use puts a script one level down
+/// (`validators/a2ui.rhai`), and nothing anybody writes goes past two. Four
+/// leaves room and still stops the walk from descending a whole source tree,
+/// which is what `[agent_paths]` pointed at a working checkout would be.
+const CANDIDATE_MAX_DEPTH: usize = 4;
+
+/// How many candidate files one listing reports. A picker shows a list a person
+/// reads, and past a couple of hundred the honest answer is not a longer list.
+const CANDIDATE_MAX_FILES: usize = 256;
+
+/// How many directories one scan opens. Depth alone does not bound a *wide*
+/// tree, and this walk runs on a request anybody holding the token can repeat.
+const CANDIDATE_MAX_DIRS: usize = 128;
+
+/// Every `.rhai` file under the agent's own directory that nothing already
+/// listed, so a picker can offer a validator no manifest names yet.
+///
+/// The manifest-derived listing is circular for a picker: a file appears once
+/// something declares it, and declaring it is what the picker is for. This is
+/// the other half - what *could* be named - which is why it is kept behind
+/// `?include=candidates`: a client reading the listing as "what will load"
+/// still gets exactly that.
+///
+/// Bounded three ways, by [`CANDIDATE_MAX_DEPTH`], [`CANDIDATE_MAX_DIRS`] and
+/// [`CANDIDATE_MAX_FILES`], because the directory being walked is one a config
+/// file chose and a request anybody can repeat.
+///
+/// Containment is asked per entry rather than assumed from where the walk
+/// started: the agents directory itself may be a symlink, and a link inside the
+/// agent's directory pointing out of it is followed by `read_dir` and by
+/// nothing here. A name that is not a safe path component is skipped rather
+/// than guessed at - a file this cannot spell back is one no manifest could
+/// name and no route could fetch.
+fn collect_candidates(base: &Path, agent: &str, out: &mut Vec<ScriptItem>) {
+    let seen: HashSet<String> = out.iter().map(|item| item.path.clone()).collect();
+    let mut found = 0usize;
+    let mut opened = 0usize;
+    // Breadth first, so when a cap cuts the walk short what survives is the
+    // shallow half - `validators/` rather than `vendor/a/b/c/`.
+    let mut queue: std::collections::VecDeque<(Vec<String>, usize)> =
+        std::collections::VecDeque::from([(Vec::new(), 0usize)]);
+
+    while let Some((dirs, depth)) = queue.pop_front() {
+        if opened == CANDIDATE_MAX_DIRS {
+            return;
+        }
+        opened += 1;
+        let here = dirs.iter().fold(base.to_path_buf(), |acc, d| acc.join(d));
+        let Ok(entries) = std::fs::read_dir(&here) else {
+            continue;
+        };
+        // Sorted for the same reason `rhai_files` sorts: a listing that
+        // reorders itself between two calls is one nobody can edit against.
+        let mut names: Vec<String> = entries
+            .filter_map(|entry| entry.ok())
+            // Lossy on purpose: a name that is not UTF-8 comes back with a
+            // replacement character, which `is_safe_path_component` then
+            // refuses along with every other name this could not spell back.
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| leviath_core::is_safe_path_component(name))
+            .collect();
+        names.sort();
+
+        for name in names {
+            let path = here.join(&name);
+            if !leviath_core::resolves_within(&path, base) {
+                continue;
+            }
+            // `is_dir` follows symlinks, which the check above has already
+            // confined to this agent's directory. A dangling link is not a
+            // directory and is reported as the file the directory says is
+            // there; reading it is where it fails, honestly and with a reason.
+            if path.is_dir() {
+                if depth < CANDIDATE_MAX_DEPTH {
+                    let mut below = dirs.clone();
+                    below.push(name);
+                    queue.push_back((below, depth + 1));
+                }
+                continue;
+            }
+            let Some(stem) = name.strip_suffix(".rhai") else {
+                continue;
+            };
+            // A file called exactly `.rhai` has no name left to address it by.
+            if stem.is_empty() {
+                continue;
+            }
+            if seen.contains(&path.display().to_string()) {
+                continue;
+            }
+            if found == CANDIDATE_MAX_FILES {
+                return;
+            }
+            found += 1;
+            let mut parts = dirs.clone();
+            parts.push(stem.to_string());
+            let addressed = parts.join("/");
+            out.push(ScriptItem {
+                kind: CANDIDATE_KIND.to_string(),
+                name: addressed.clone(),
+                source: "agent".to_string(),
+                agent: Some(agent.to_string()),
+                path: path.display().to_string(),
+                relative_path: Some(format!("{addressed}.rhai")),
+                declared: false,
+                compiles: None,
+                error: None,
+                provider: None,
+            });
+        }
+    }
+}
+
+/// The one `?include=` token the listing recognizes.
+const INCLUDE_CANDIDATES: &str = "candidates";
+
+/// Whether `?include=` asked for candidates.
+///
+/// A comma-separated list, so a later listing can add a second thing to include
+/// without a second parameter. An unrecognized token is a 400 rather than a
+/// silent no-op: the whole point of the parameter is that its absence and its
+/// presence give different answers, so a client that misspells it would read a
+/// short listing as "this agent has no files".
+fn wants_candidates(include: Option<&str>) -> Result<bool, ApiError> {
+    let Some(raw) = include else {
+        return Ok(false);
+    };
+    let mut wanted = false;
+    for token in raw.split(',') {
+        match token.trim() {
+            // `?include=` with nothing after it asks for nothing, which is what
+            // a console sends when its checkbox is clear.
+            "" => {}
+            INCLUDE_CANDIDATES => wanted = true,
+            other => {
+                return Err(err(
+                    StatusCode::BAD_REQUEST,
+                    format!("Unknown include '{other}': expected {INCLUDE_CANDIDATES}"),
+                ));
+            }
+        }
+    }
+    Ok(wanted)
 }
 
 // ─── Handlers ───────────────────────────────────────────────────────────────
@@ -677,15 +959,24 @@ fn collect_declared(dir: &Path, agent: &str, out: &mut Vec<ScriptItem>) {
 /// Providers are listed either way. Nothing scopes one to an agent, so leaving
 /// them out of the agent view would only mean a console had to make a second
 /// request to draw the same page.
+///
+/// `?include=candidates` adds the `.rhai` files beside the agent that nothing
+/// declares, marked `declared: false` under [`CANDIDATE_KIND`]. Only the agent
+/// half of the answer grows: every file in the two global directories is
+/// already listed from disk, so "undeclared" describes nothing there.
 pub(super) async fn list_scripts(
     State(state): State<AppState>,
-    Query(q): Query<ScriptQuery>,
+    Query(q): Query<ListScriptsQuery>,
 ) -> Result<Json<ScriptsResp>, ApiError> {
+    let candidates = wants_candidates(q.include.as_deref())?;
     let mut scripts = Vec::new();
     if let Some(name) = q.agent.as_deref() {
         let dir = agent_dir(&state.current_config(), name)?;
         collect_tools(&dir.join("tools"), "agent", Some(name), &mut scripts);
         collect_declared(&dir, name, &mut scripts);
+        if candidates {
+            collect_candidates(&dir, name, &mut scripts);
+        }
     }
     collect_tools(&global_tools_dir(), "global", None, &mut scripts);
     collect_providers(&global_providers_dir(), &mut scripts);
@@ -726,7 +1017,7 @@ fn read_script(target: &Target) -> Result<Json<ScriptSource>, ApiError> {
     // write the redaction back over the real script.
     Ok(Json(ScriptSource {
         kind: target.kind.as_str().to_string(),
-        name: stem_of(&target.path),
+        name: target.name.clone(),
         source: target.scope.to_string(),
         agent: target.agent.clone(),
         path: label,
@@ -766,6 +1057,16 @@ pub(super) async fn put_script(
     // After the directory exists, so containment is asked of a path that can be
     // canonicalized rather than of one that merely might be.
     guard(&target, Presence::Optional)?;
+    // Only now: a name may carry a subdirectory, and creating one before the
+    // containment check would let a symlink planted at an intermediate name
+    // make this `mkdir` outside the agent's directory. `guard` has just proved
+    // the whole path resolves inside it.
+    if let Err(e) = std::fs::create_dir_all(&target.file_dir) {
+        return Err(err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("cannot create '{}': {e}", target.file_dir.display()),
+        ));
+    }
     write_script(&target, &body.content)
 }
 

--- a/crates/leviath-cli/src/commands/serve/scripts_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts_tests.rs
@@ -348,7 +348,9 @@ fn a_path_that_cannot_be_shown_to_be_contained_is_refused() {
     let target = Target {
         kind: ScriptKind::Tool,
         dir: PathBuf::new(),
+        file_dir: PathBuf::new(),
         path: PathBuf::from("no-such-file-for-the-guard-test.rhai"),
+        name: "no-such-file-for-the-guard-test".to_string(),
         scope: "global",
         agent: None,
     };
@@ -370,7 +372,9 @@ async fn a_write_the_filesystem_refuses_is_reported() {
         let target = Target {
             kind: ScriptKind::Tool,
             dir: dir.clone(),
+            file_dir: dir.join("missing"),
             path: dir.join("missing").join("x.rhai"),
+            name: "missing/x".to_string(),
             scope: "global",
             agent: None,
         };
@@ -388,8 +392,10 @@ async fn a_delete_the_filesystem_refuses_is_reported() {
         std::fs::create_dir_all(&path).expect("the directory");
         let target = Target {
             kind: ScriptKind::Tool,
-            dir,
+            dir: dir.clone(),
+            file_dir: dir,
             path,
+            name: "adirectory".to_string(),
             scope: "global",
             agent: None,
         };
@@ -399,17 +405,57 @@ async fn a_delete_the_filesystem_refuses_is_reported() {
     .await;
 }
 
-// ─── addressable_name ───────────────────────────────────────────────────────
+// ─── addressed_path ─────────────────────────────────────────────────────────
 
+/// The `{name}` off a URL: one component or a `/`-separated path, with or
+/// without the extension, and nothing that could leave the directory.
 #[test]
-fn only_a_bare_rhai_filename_is_addressable() {
-    assert_eq!(addressable_name("hooks.rhai"), Some("hooks".to_string()));
-    // A subdirectory, a traversal, a missing extension and a name that is not a
-    // safe component are all things these routes cannot address.
-    assert_eq!(addressable_name("nested/hooks.rhai"), None);
-    assert_eq!(addressable_name("../hooks.rhai"), None);
-    assert_eq!(addressable_name("hooks.txt"), None);
-    assert_eq!(addressable_name("..rhai"), None);
+fn a_name_is_read_as_a_relative_path_of_safe_components() {
+    let one = addressed_path("hooks").expect("a bare name");
+    assert_eq!(one.name, "hooks");
+    assert_eq!(one.relative, "hooks.rhai");
+    assert_eq!(one.dirs, Vec::<String>::new());
+    assert_eq!(one.file, "hooks.rhai");
+    // The extension is optional and means the same file either way.
+    assert_eq!(addressed_path("hooks.rhai"), Some(one));
+
+    let deep = addressed_path("validators/a2ui.rhai").expect("a relative path");
+    assert_eq!(deep.name, "validators/a2ui");
+    assert_eq!(deep.relative, "validators/a2ui.rhai");
+    assert_eq!(deep.dirs, vec!["validators".to_string()]);
+    assert_eq!(deep.file, "a2ui.rhai");
+
+    // A traversal, an absolute path, an empty segment, a Windows separator and
+    // a name with nothing left after the extension are all unaddressable.
+    for bad in [
+        "../hooks",
+        "validators/../../hooks",
+        "/etc/hooks",
+        "validators//a2ui",
+        "validators\\a2ui",
+        ".rhai",
+        "",
+    ] {
+        assert_eq!(addressed_path(bad), None, "{bad}");
+    }
+}
+
+/// A declared path is read the same way, except that it must already *be* a
+/// `.rhai` file: `addressed_path` appends the extension, so a declared
+/// `notes.txt` would otherwise be reported as `notes.txt.rhai`.
+#[test]
+fn a_declared_path_must_already_name_a_rhai_file() {
+    assert_eq!(
+        declared_address("hooks.rhai").map(|a| a.name),
+        Some("hooks".to_string())
+    );
+    assert_eq!(
+        declared_address("hooks/deep.rhai").map(|a| a.relative),
+        Some("hooks/deep.rhai".to_string())
+    );
+    assert_eq!(declared_address("hooks.txt"), None);
+    assert_eq!(declared_address("..rhai"), None);
+    assert_eq!(declared_address("../hooks.rhai"), None);
 }
 
 // ─── GET /api/scripts ───────────────────────────────────────────────────────
@@ -521,10 +567,12 @@ async fn a_declared_hook_with_no_file_is_listed_as_failing() {
     .await;
 }
 
-/// A hook declared in a subdirectory is outside what these routes can address,
-/// so it is left out rather than listed under a name that fetches nothing.
+/// A hook declared in a subdirectory is listed, addressed by the relative path
+/// the manifest wrote, and the read route opens that exact file. It used to be
+/// dropped from the listing entirely, so a console could not show a validator
+/// declared the way the docs themselves declare one.
 #[tokio::test]
-async fn a_hook_declared_in_a_subdirectory_is_left_out() {
+async fn a_hook_declared_in_a_subdirectory_is_listed_and_readable() {
     with_home(|home| async move {
         let agent = agent_root(&home, "nested");
         let manifest = r#"
@@ -551,7 +599,62 @@ on_stage_enter = "hooks/deep.rhai"
 system = { kind = "pinned", max_tokens = 1000 }
 "#;
         write(&agent.join("agent.leviath"), manifest);
+        write(
+            &agent.join("hooks").join("deep.rhai"),
+            "fn on_stage_enter(ctx) { () }",
+        );
         let (status, body) = get_json("/api/scripts?agent=nested").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let scripts = body["scripts"].as_array().expect("an array");
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0]["kind"], "stage_hook");
+        assert_eq!(scripts[0]["name"], "hooks/deep");
+        assert_eq!(scripts[0]["relative_path"], "hooks/deep.rhai");
+        assert_eq!(scripts[0]["compiles"], true);
+        assert_eq!(scripts[0]["declared"], true);
+
+        // The name the listing reports is one the read route opens, with the
+        // separator percent-encoded so it stays one path segment.
+        let (status, body) = get_json("/api/scripts/stage_hook/hooks%2Fdeep?agent=nested").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["name"], "hooks/deep");
+        assert_eq!(body["content"], "fn on_stage_enter(ctx) { () }");
+    })
+    .await;
+}
+
+/// A manifest that declares something these routes still cannot address - a
+/// path that is not a `.rhai` file, or one that climbs out of the agent's
+/// directory - is left out rather than listed under a name that would fetch a
+/// different file.
+#[tokio::test]
+async fn a_declaration_that_cannot_be_addressed_is_left_out() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "odd");
+        let manifest = r#"
+[agent]
+name = "odd"
+version = "0.1.0"
+description = "d"
+
+[agent.output]
+validator = "../outside.rhai"
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+description = "Main"
+max_iterations = 5
+
+[stages.main.hooks]
+on_stage_enter = "notes.txt"
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+"#;
+        write(&agent.join("agent.leviath"), manifest);
+        let (status, body) = get_json("/api/scripts?agent=odd").await;
 
         assert_eq!(status, StatusCode::OK);
         assert!(body["scripts"].as_array().expect("an array").is_empty());
@@ -597,6 +700,364 @@ async fn the_listing_refuses_a_traversing_agent_name() {
     with_home(|_home| async move {
         let (status, _) = get_json("/api/scripts?agent=..%2F..%2Fetc").await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+// ─── GET /api/scripts?include=candidates ────────────────────────────────────
+
+/// An agent whose directory holds one declared tool, one declared validator in
+/// a subdirectory, and one `.rhai` nothing names.
+fn agent_with_a_draft(home: &Path) -> PathBuf {
+    let agent = agent_root(home, "picker");
+    write(
+        &agent.join("agent.leviath"),
+        r#"
+[agent]
+name = "picker"
+version = "0.1.0"
+description = "d"
+
+[agent.output]
+validator = "validators/a2ui.rhai"
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+description = "Main"
+max_iterations = 5
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+"#,
+    );
+    write(&agent.join("tools").join("summarize.rhai"), GOOD_TOOL);
+    write(
+        &agent.join("validators").join("a2ui.rhai"),
+        "fn validate(content) { #{ valid: true } }",
+    );
+    write(
+        &agent.join("validators").join("draft.rhai"),
+        "fn validate(content) { #{ valid: false, reason: \"wip\" } }",
+    );
+    agent
+}
+
+/// Without the parameter the answer is the one a client already gets: the
+/// declared scripts and nothing else, whatever else is lying beside the agent.
+///
+/// Asserted as whole objects rather than field by field, because the promise
+/// being kept here is about the shape a current client parses, not about one
+/// key of it.
+#[tokio::test]
+async fn the_default_listing_holds_only_what_is_declared() {
+    with_home(|home| async move {
+        let agent = agent_with_a_draft(&home);
+        let (status, body) = get_json("/api/scripts?agent=picker").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "scripts": [
+                    {
+                        "kind": "tool",
+                        "name": "summarize",
+                        "source": "agent",
+                        "agent": "picker",
+                        "path": agent.join("tools").join("summarize.rhai").display().to_string(),
+                        "relative_path": "tools/summarize.rhai",
+                        "declared": true,
+                        "compiles": true,
+                    },
+                    {
+                        "kind": "output_validator",
+                        "name": "validators/a2ui",
+                        "source": "agent",
+                        "agent": "picker",
+                        "path": agent
+                            .join("validators")
+                            .join("a2ui.rhai")
+                            .display()
+                            .to_string(),
+                        "relative_path": "validators/a2ui.rhai",
+                        "declared": true,
+                        "compiles": true,
+                    },
+                ]
+            })
+        );
+    })
+    .await;
+}
+
+/// With it, the file nothing declares is offered too - which is the whole
+/// point: a picker cannot ask somebody to declare a validator it will only
+/// show once it has been declared.
+#[tokio::test]
+async fn include_candidates_adds_the_files_nothing_declares() {
+    with_home(|home| async move {
+        let agent = agent_with_a_draft(&home);
+        let (status, body) = get_json("/api/scripts?agent=picker&include=candidates").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let scripts = body["scripts"].as_array().expect("an array");
+        // The two declared entries are unchanged and the draft is the third.
+        assert_eq!(scripts.len(), 3);
+        assert_eq!(
+            scripts[2],
+            serde_json::json!({
+                "kind": "unknown",
+                "name": "validators/draft",
+                "source": "agent",
+                "agent": "picker",
+                "path": agent
+                    .join("validators")
+                    .join("draft.rhai")
+                    .display()
+                    .to_string(),
+                "relative_path": "validators/draft.rhai",
+                "declared": false,
+            })
+        );
+        // A declared file is not repeated as a candidate, and neither is a
+        // tool the `tools/` scan already reported.
+        let names: Vec<&str> = scripts
+            .iter()
+            .map(|s| s["name"].as_str().expect("a name"))
+            .collect();
+        assert_eq!(names, ["summarize", "validators/a2ui", "validators/draft"]);
+
+        // `kind` is not a spelling the routes accept, so a client has to pick
+        // one - and the name the candidate carries opens the file under it.
+        let (status, _) = get_json("/api/scripts/unknown/validators%2Fdraft?agent=picker").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let (status, body) =
+            get_json("/api/scripts/output_validator/validators%2Fdraft?agent=picker").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["name"], "validators/draft");
+        assert_eq!(body["compiles"], true);
+    })
+    .await;
+}
+
+/// Only `.rhai` files, and only ones these routes could name. A directory that
+/// ends in `.rhai` is a directory, and a file with nothing before the extension
+/// has no name left to be addressed by.
+#[tokio::test]
+async fn a_candidate_is_a_rhai_file_with_a_name_that_can_be_addressed() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "mixed");
+        write(&agent.join("notes.txt"), "not a script");
+        write(&agent.join("real.rhai"), "1");
+        write(&agent.join(".rhai"), "1");
+        write(&agent.join("has a space.rhai"), "1");
+        std::fs::create_dir_all(agent.join("looks.rhai")).expect("the directory");
+
+        let (status, body) = get_json("/api/scripts?agent=mixed&include=candidates").await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<&str> = body["scripts"]
+            .as_array()
+            .expect("an array")
+            .iter()
+            .map(|s| s["name"].as_str().expect("a name"))
+            .collect();
+        assert_eq!(names, ["real"]);
+    })
+    .await;
+}
+
+/// An agent with no directory at all answers with an empty listing rather than
+/// an error: `?include=candidates` is a question about files, and "none" is a
+/// perfectly good answer to it.
+#[tokio::test]
+async fn an_agent_with_no_directory_has_no_candidates() {
+    with_home(|_home| async move {
+        let (status, body) = get_json("/api/scripts?agent=ghost&include=candidates").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["scripts"].as_array().expect("an array").is_empty());
+    })
+    .await;
+}
+
+/// The scan stops at [`CANDIDATE_MAX_DEPTH`], so an agent directory that
+/// happens to contain a source tree cannot be walked to the bottom by anybody
+/// holding the token.
+#[tokio::test]
+async fn the_candidate_scan_stops_at_the_depth_limit() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "deep");
+        let mut dir = agent.clone();
+        // One file at every level, including one past the limit.
+        for level in 0..=CANDIDATE_MAX_DEPTH + 1 {
+            write(&dir.join(format!("at{level}.rhai")), "1");
+            dir = dir.join(format!("d{level}"));
+        }
+
+        let (status, body) = get_json("/api/scripts?agent=deep&include=candidates").await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<&str> = body["scripts"]
+            .as_array()
+            .expect("an array")
+            .iter()
+            .map(|s| s["name"].as_str().expect("a name"))
+            .collect();
+        assert_eq!(names.len(), CANDIDATE_MAX_DEPTH + 1);
+        assert!(names.contains(&"at0"), "{names:?}");
+        assert!(
+            !names
+                .iter()
+                .any(|n| n.ends_with(&format!("at{}", CANDIDATE_MAX_DEPTH + 1)))
+        );
+    })
+    .await;
+}
+
+/// And at [`CANDIDATE_MAX_FILES`], so a directory holding thousands of scripts
+/// answers with a list rather than with all of them.
+#[tokio::test]
+async fn the_candidate_scan_stops_at_the_file_limit() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "many");
+        for n in 0..CANDIDATE_MAX_FILES + 5 {
+            write(&agent.join(format!("s{n:04}.rhai")), "1");
+        }
+
+        let (status, body) = get_json("/api/scripts?agent=many&include=candidates").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["scripts"].as_array().expect("an array").len(),
+            CANDIDATE_MAX_FILES
+        );
+    })
+    .await;
+}
+
+/// And at [`CANDIDATE_MAX_DIRS`], because depth alone does not bound a tree
+/// that is wide rather than deep.
+#[tokio::test]
+async fn the_candidate_scan_stops_at_the_directory_limit() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "wide");
+        // Each subdirectory holds one script, so the count of files reported is
+        // the count of directories the walk got to open.
+        for n in 0..CANDIDATE_MAX_DIRS + 5 {
+            write(&agent.join(format!("d{n:04}")).join("s.rhai"), "1");
+        }
+
+        let (status, body) = get_json("/api/scripts?agent=wide&include=candidates").await;
+        assert_eq!(status, StatusCode::OK);
+        // The agent's own directory is the first one opened, so one fewer of
+        // the subdirectories is reached.
+        assert_eq!(
+            body["scripts"].as_array().expect("an array").len(),
+            CANDIDATE_MAX_DIRS - 1
+        );
+    })
+    .await;
+}
+
+/// A symlink out of the agent's directory is not followed and not reported.
+/// The scan runs over a directory a config file chose, and the agents directory
+/// itself may be a symlink, so containment is asked of every entry rather than
+/// assumed from where the walk started.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_symlink_out_of_the_agent_directory_is_not_a_candidate() {
+    with_home(|home| async move {
+        let outside = tempfile::tempdir().expect("a temp dir");
+        std::fs::write(outside.path().join("stolen.rhai"), "1").expect("the file");
+        let agent = agent_root(&home, "linked");
+        write(&agent.join("own.rhai"), "1");
+        std::os::unix::fs::symlink(outside.path(), agent.join("escape")).expect("the link");
+        std::os::unix::fs::symlink(
+            outside.path().join("stolen.rhai"),
+            agent.join("escape.rhai"),
+        )
+        .expect("the link");
+
+        let (status, body) = get_json("/api/scripts?agent=linked&include=candidates").await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<&str> = body["scripts"]
+            .as_array()
+            .expect("an array")
+            .iter()
+            .map(|s| s["name"].as_str().expect("a name"))
+            .collect();
+        assert_eq!(names, ["own"]);
+    })
+    .await;
+}
+
+/// Windows twin of `a_symlink_out_of_the_agent_directory_is_not_a_candidate`.
+/// Windows spells the two links `symlink_dir` and `symlink_file`; the fence is
+/// the same one, because `resolves_within` canonicalizes before comparing.
+#[cfg(windows)]
+#[tokio::test]
+async fn a_symlink_out_of_the_agent_directory_is_not_a_candidate_windows() {
+    with_home(|home| async move {
+        let outside = tempfile::tempdir().expect("a temp dir");
+        std::fs::write(outside.path().join("stolen.rhai"), "1").expect("the file");
+        let agent = agent_root(&home, "linked");
+        write(&agent.join("own.rhai"), "1");
+        std::os::windows::fs::symlink_dir(outside.path(), agent.join("escape")).expect("the link");
+        std::os::windows::fs::symlink_file(
+            outside.path().join("stolen.rhai"),
+            agent.join("escape.rhai"),
+        )
+        .expect("the link");
+
+        let (status, body) = get_json("/api/scripts?agent=linked&include=candidates").await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<&str> = body["scripts"]
+            .as_array()
+            .expect("an array")
+            .iter()
+            .map(|s| s["name"].as_str().expect("a name"))
+            .collect();
+        assert_eq!(names, ["own"]);
+    })
+    .await;
+}
+
+/// `include` takes a comma-separated list, an empty one asks for nothing, and
+/// a token nobody serves is a 400 rather than a silently short answer.
+#[tokio::test]
+async fn include_refuses_a_token_it_does_not_serve() {
+    with_home(|home| async move {
+        agent_with_a_draft(&home);
+
+        let (status, body) = get_json("/api/scripts?agent=picker&include=candidate").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let reason = body["error"].as_str().expect("a reason");
+        assert!(reason.contains("candidate"), "{reason}");
+
+        let (status, body) = get_json("/api/scripts?agent=picker&include=").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["scripts"].as_array().expect("an array").len(), 2);
+
+        let (status, body) = get_json("/api/scripts?agent=picker&include=,candidates").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["scripts"].as_array().expect("an array").len(), 3);
+    })
+    .await;
+}
+
+/// Without an agent the parameter changes nothing, and says so rather than
+/// failing: every file in the two global directories is already listed from
+/// disk, so there is no undeclared half of that answer to add.
+#[tokio::test]
+async fn include_candidates_without_an_agent_changes_nothing() {
+    with_home(|home| async move {
+        write(&global_root(&home).join("shared.rhai"), GOOD_TOOL);
+        write(&providers_root(&home).join("groq.rhai"), GOOD_PROVIDER);
+
+        let (plain_status, plain) = get_json("/api/scripts").await;
+        let (status, body) = get_json("/api/scripts?include=candidates").await;
+        assert_eq!(plain_status, StatusCode::OK);
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(plain, body);
+        assert_eq!(body["scripts"].as_array().expect("an array").len(), 2);
     })
     .await;
 }
@@ -786,6 +1247,119 @@ async fn a_directory_that_cannot_be_created_is_reported() {
         .await;
 
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    })
+    .await;
+}
+
+/// A name the routes cannot address is refused on the way in, so no read can
+/// be talked into opening a file outside the directory it is fenced to.
+#[tokio::test]
+async fn reading_a_name_that_cannot_be_addressed_is_refused() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "researcher");
+        write(&agent.join("hooks.rhai"), "fn on_stage_enter(ctx) { () }");
+        for name in [
+            "..%2F..%2Fevil",
+            "%2Fetc%2Fpasswd",
+            "hooks%2F..%2F..%2Fevil",
+        ] {
+            let (status, _) =
+                get_json(&format!("/api/scripts/stage_hook/{name}?agent=researcher")).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{name}");
+        }
+    })
+    .await;
+}
+
+/// A write may address a subdirectory too, and creates it - so a console that
+/// can show a validator declared as `validators/a2ui.rhai` can also save one.
+#[tokio::test]
+async fn writing_into_a_subdirectory_creates_it() {
+    with_home(|home| async move {
+        let (status, body) = send(
+            "PUT",
+            "/api/scripts/output_validator/validators%2Fa2ui?agent=researcher",
+            serde_json::json!({ "content": "fn validate(content) { #{ valid: true } }" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["compiles"], true);
+        let written = agent_root(&home, "researcher")
+            .join("validators")
+            .join("a2ui.rhai");
+        assert!(written.exists());
+    })
+    .await;
+}
+
+/// A subdirectory that cannot be created is reported rather than swallowed,
+/// the same way the agent's own directory is. An ordinary file where the
+/// subdirectory should be is the portable way to arrange that.
+#[tokio::test]
+async fn a_subdirectory_that_cannot_be_created_is_reported() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "researcher");
+        write(&agent.join("validators"), "a file, not a directory");
+        let (status, _) = send(
+            "PUT",
+            "/api/scripts/output_validator/validators%2Fa2ui?agent=researcher",
+            serde_json::json!({ "content": "fn validate(content) { #{ valid: true } }" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    })
+    .await;
+}
+
+/// A symlink planted at a directory along the way is refused, and refused
+/// *before* anything is created through it: the containment check runs first,
+/// so the write neither lands outside the agent's directory nor leaves a new
+/// directory there.
+#[cfg(unix)]
+#[tokio::test]
+async fn writing_through_a_symlinked_subdirectory_is_refused() {
+    with_home(|home| async move {
+        let outside = tempfile::tempdir().expect("a temp dir");
+        let agent = agent_root(&home, "researcher");
+        std::fs::create_dir_all(&agent).expect("the agent directory");
+        std::os::unix::fs::symlink(outside.path(), agent.join("validators")).expect("the link");
+
+        let (status, _) = send(
+            "PUT",
+            "/api/scripts/output_validator/validators%2Fdeep%2Fa2ui?agent=researcher",
+            serde_json::json!({ "content": "fn validate(content) { #{ valid: true } }" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert!(!outside.path().join("deep").exists());
+    })
+    .await;
+}
+
+/// Windows twin of `writing_through_a_symlinked_subdirectory_is_refused`.
+/// Windows spells a directory link `symlink_dir`; the fence is the same one.
+#[cfg(windows)]
+#[tokio::test]
+async fn writing_through_a_symlinked_subdirectory_is_refused_windows() {
+    with_home(|home| async move {
+        let outside = tempfile::tempdir().expect("a temp dir");
+        let agent = agent_root(&home, "researcher");
+        std::fs::create_dir_all(&agent).expect("the agent directory");
+        std::os::windows::fs::symlink_dir(outside.path(), agent.join("validators"))
+            .expect("the link");
+
+        let (status, _) = send(
+            "PUT",
+            "/api/scripts/output_validator/validators%2Fdeep%2Fa2ui?agent=researcher",
+            serde_json::json!({ "content": "fn validate(content) { #{ valid: true } }" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert!(!outside.path().join("deep").exists());
     })
     .await;
 }

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -221,7 +221,7 @@ handle that on all of them rather than on a few. The body is a line of plain tex
 | `GET /api/models` | Enumerate models, with each one's token limits and where they came from. An OpenAI-compatible gateway's detected models are listed under the gateway's name |
 | `POST /api/models/probe` *(admin)* | Ask an OpenAI-compatible server what it serves before writing a gateway for it: `{"base_url", "api_key"?, "headers"?}` → `{"models": [ids]}`, or 502 carrying the server's own error text. See [below](#gateways) |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
-| `GET /api/scripts?agent=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks and validators, and the global model providers. Writes need admin. See [below](#tools-and-scripts) |
+| `GET /api/scripts?agent=&include=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks and validators, and the global model providers. `include=candidates` also lists the files nothing declares yet. Writes need admin. See [below](#tools-and-scripts) |
 | `GET /api/mcp/servers` · `POST …` *(admin)* · `DELETE …/{name}` *(admin)* · `GET …/{name}/status` · `POST …/{name}/login` *(admin)* · `POST …/{name}/test` *(admin)* | List, add, remove, check, log in, test. The writes need admin. A server added or removed here reaches the next run, with no daemon restart |
 | `GET /api/doctor` · `POST /api/doctor/live` *(admin)* | The checks `lev doctor` runs, as data. `GET` is `lev doctor --offline`: config, search and resolve, nothing billed. `POST .../live` runs the whole chain (two billed calls and a throwaway run) and answers 409 while one is already going. A failing check is `ok: false` inside a 200, never an HTTP error |
 | `GET /api/update` | Whether anything newer exists, how this copy was installed, and the command that upgrades it. See [below](#asking-how-to-upgrade) |
@@ -862,13 +862,60 @@ can carry: `tool`, `region_hook`, `stage_hook`, `output_validator` and `provider
 directory an agent owns (`<agent>/tools/`, plus the global one); the hooks and the validator are
 named by path in the manifest and resolved against the agent's own directory, so the listing derives
 them from what the manifest declares and the read and write routes address them at
-`<agent>/<name>.rhai`. A hook a manifest declares inside a subdirectory is outside what `{name}` can
-address, and is left out rather than listed under a name that would fetch nothing.
+`<agent>/<name>.rhai`.
+
+Every entry carries a `declared` flag, and an agent-scoped one also carries `relative_path`: where
+the file sits relative to the agent's own directory, `validators/a2ui.rhai`, which is the spelling
+that goes into a manifest. A machine-wide script has no `relative_path`, since no blueprint contains
+it.
 
 `GET/PUT/DELETE /api/scripts/{kind}/{name}` reads and writes one file, scoped by `?agent=<name>` or,
-with no `agent`, the machine's own directory for that kind. `POST /api/scripts/validate` takes `kind`
+with no `agent`, the machine's own directory for that kind. `{name}` is the file without its `.rhai`
+extension, and it may be a relative path when the manifest declared one: percent-encode the
+separator, so `validators/a2ui.rhai` is `output_validator/validators%2Fa2ui`. Every part of it may
+hold only letters, digits, `.`, `_` and `-`, and the result has to land inside the directory the
+route is fenced to once symlinks are followed, so a declaration that climbs out of the agent's
+directory or names something that is not a `.rhai` file is left out of the listing rather than
+reported under a name that would fetch a different file. `POST /api/scripts/validate` takes `kind`
 and `content` and compiles without writing, so an editor can check before saving instead of saving
 and waiting for a run to fail.
+
+### Offering a file nobody has named yet
+
+The listing above answers "what will load", which is circular for a picker: a hook or a validator
+appears once the manifest declares it, and declaring it is the thing the picker exists to do. So
+`GET /api/scripts?agent=<name>&include=candidates` adds the other half, the `.rhai` files under that
+agent's directory that nothing declares:
+
+```json
+{
+  "kind": "unknown",
+  "name": "validators/draft",
+  "source": "agent",
+  "agent": "picker",
+  "path": "/home/you/.leviath/agents/picker/validators/draft.rhai",
+  "relative_path": "validators/draft.rhai",
+  "declared": false
+}
+```
+
+`kind` is `unknown` because nothing about the file says which of the four agent-owned kinds it is;
+the declaration says that, and it has not happened yet. `unknown` is not a `{kind}` the read and
+write routes accept, so a client picks a real one to open the file with, and `compiles` is absent
+for the same reason: which compiler would have to accept it is not yet decided. Write
+`relative_path` into `validator = "..."` or a `[stages.<name>.hooks]` entry and the next listing
+reports the same file as declared.
+
+Without the parameter the listing is exactly what it was, so a client that reads it as "what will
+load" keeps getting that. `include` takes a comma-separated list and refuses a token it does not
+serve, rather than answering a misspelling with a short list. With no `?agent=` it changes nothing:
+both global directories are already listed file by file, so nothing there is undeclared. Check
+`scripts.candidates` in the `capabilities` list before offering the picker.
+
+The scan is bounded and stays inside the agent's directory: four levels deep, 128 directories and
+256 files per request, `.rhai` files only, and no symlink is followed out of the agent's own
+directory. A file whose name could not be written into a manifest, because of a space or a character
+that is not a safe path component, is left out rather than guessed at.
 
 > [!WARNING]
 > `PUT` and `DELETE` are **not mounted at all** without `lev serve --allow-admin`, exactly like the
@@ -1043,6 +1090,7 @@ than that feature, not broken.
 | `scripts.read` | The `GET` half of the scripts routes |
 | `scripts.write` | That this build serves the write half. Whether *this* daemon mounts it is `--allow-admin`, which you find out by calling one and reading the status |
 | `scripts.providers` | `provider` as a fifth script `kind`, the machine's drop-in model providers |
+| `scripts.candidates` | `?include=candidates` on the script listing, plus `relative_path` and `declared` on every entry |
 | `config.gateways` | `gateways` on `GET /api/config`, the custom providers this machine has |
 | `config.gateways.kinds` | `kind`, `header_names` and `models` on each gateway, and `kind`, `headers` and `models` accepted by `PUT /api/config`: a gateway can be an OpenAI-compatible endpoint rather than a script |
 | `models.probe` | `POST /api/models/probe`, which asks an OpenAI-compatible server what it serves before a gateway for it is written; admin only |

--- a/docs/content/scripting.md
+++ b/docs/content/scripting.md
@@ -35,6 +35,13 @@ can copy and change. [rhai.rs](https://rhai.rs) has the language reference if yo
 
 Each page walks its point end to end with a complete, copy-pasteable example.
 
+A region hook, a stage hook and an output validator are all named by path in the manifest, so a file
+sitting beside the agent is invisible until something names it. If you are building an editor rather
+than writing the manifest by hand,
+[`GET /api/scripts?agent=<name>&include=candidates`](/docs/api#offering-a-file-nobody-has-named-yet)
+lists the `.rhai` files under an agent's directory that nothing declares yet, each with the
+manifest-relative path to write into `validator = "..."` or `[stages.<name>.hooks]`.
+
 ## The sandbox they all share
 
 Every script runs in a hardened engine: no `eval`, no `import`, no ambient filesystem or

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1978,7 +1978,7 @@
           "scripts"
         ],
         "summary": "Rhai scripts this scope can see",
-        "description": "Script tools from the agent's `tools/` and the global directory, the region hooks, stage hooks and output validators the agent's manifest declares, and the model providers in `~/.leviath/providers`. Each entry carries its kind, its source (`agent` or `global`) and whether it compiles right now; a provider also carries a `provider` object with what its `// @` annotations declare. Providers are listed with or without `agent`, since nothing scopes one to an agent.",
+        "description": "Script tools from the agent's `tools/` and the global directory, the region hooks, stage hooks and output validators the agent's manifest declares, and the model providers in `~/.leviath/providers`. Each entry carries its kind, its source (`agent` or `global`), a `declared` flag and whether it compiles right now; an agent-scoped entry also carries `relative_path`, where the file sits relative to the agent's own directory, which is the spelling a manifest wants. A provider also carries a `provider` object with what its `// @` annotations declare. Providers are listed with or without `agent`, since nothing scopes one to an agent.",
         "parameters": [
           {
             "name": "agent",
@@ -1987,11 +1987,25 @@
               "type": "string"
             },
             "description": "Scope to this agent's own directory."
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "candidates"
+              ]
+            },
+            "description": "Comma-separated extras. `candidates` also lists the `.rhai` files under the agent's directory that nothing declares, as `kind: \"unknown\"` with `declared: false` and no `compiles`, so an editor can offer a validator or a hook that no manifest names yet. Only meaningful with `agent`: both global directories are already listed file by file. The scan is bounded (four levels deep, 128 directories, 256 files) and follows no symlink out of the agent's directory. An unrecognized token is a 400."
           }
         ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -2060,7 +2074,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The file's name without its `.rhai` extension."
+            "description": "The file's name without its `.rhai` extension. May be a relative path when the manifest declared one, with the separator percent-encoded so it stays one segment: `validators%2Fa2ui`. Every part may hold only letters, digits, `.`, `_` and `-`, and the result must resolve inside the directory the route is fenced to."
           },
           {
             "name": "agent",
@@ -2115,7 +2129,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The file's name without its `.rhai` extension."
+            "description": "The file's name without its `.rhai` extension. May be a relative path when the manifest declared one, with the separator percent-encoded so it stays one segment: `validators%2Fa2ui`. Every part may hold only letters, digits, `.`, `_` and `-`, and the result must resolve inside the directory the route is fenced to."
           },
           {
             "name": "agent",
@@ -2176,7 +2190,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The file's name without its `.rhai` extension."
+            "description": "The file's name without its `.rhai` extension. May be a relative path when the manifest declared one, with the separator percent-encoded so it stays one segment: `validators%2Fa2ui`. Every part may hold only letters, digits, `.`, `_` and `-`, and the result must resolve inside the directory the route is fenced to."
           },
           {
             "name": "agent",


### PR DESCRIPTION
Closes #738.

## The two gaps

**A picker had nothing to pick from.** `GET /api/scripts?agent=<name>` reports the agent's `tools/*.rhai` from disk plus the hooks and validators the manifest already declares. For a validator that is circular: the file is listed once something names it, and naming it is what the picker exists to do.

**A declared subdirectory script was dropped entirely.** `addressable_name` required a single safe component, so a validator written the way `docs/content/rhai-validators.md` writes one, `validator = "validators/a2ui.rhai"`, never appeared in the listing at all, not even as an already-declared script.

## The shape, and why

Option 1 from the issue, plus the relative path it asks for.

`GET /api/scripts?agent=<name>&include=candidates` adds the `.rhai` files under the agent's own directory that nothing declares:

```json
{
  "kind": "unknown",
  "name": "validators/draft",
  "source": "agent",
  "agent": "picker",
  "path": "/tmp/lv738/.leviath/agents/picker/validators/draft.rhai",
  "relative_path": "validators/draft.rhai",
  "declared": false
}
```

- `kind: "unknown"` because nothing about the file says which of the four agent-owned kinds it is. The declaration says that, and it has not happened yet. `ScriptKind::parse` rejects that spelling, so a client cannot hand it back as a kind.
- `compiles` is **absent** on a candidate rather than `true` or `false`. Which compiler would have to accept the file is exactly what is undecided, so any verdict there would be a claim about the file rather than a fact about it. It is now `Option<bool>`, skipped when `None`; every declared entry still carries it.
- Without the parameter the listing membership is what it was. `include` takes a comma-separated list, an empty one asks for nothing, and an unrecognized token is a **400** rather than a short answer a client would read as "this agent has no files".
- **Without `?agent=` it changes nothing**, and says so rather than failing. Both global directories (`~/.leviath/tools`, `~/.leviath/providers`) are already listed file by file from disk, so "undeclared" describes nothing there. A console that always appends the parameter is not punished for it.
- Every entry gained `declared`, and every agent-scoped one gained `relative_path` (`validators/a2ui.rhai`, `tools/summarize.rhai`) which is the spelling that goes into a manifest. The absolute `path` is untouched. A machine-wide script has no `relative_path`, since no blueprint contains it. These two fields are the only additions to the default response: the issue asks for the relative path on **every** entry, so "byte-for-byte identical" and "every entry carries a relative path" cannot both hold; what is held is that no new *entries* appear without the parameter, asserted as a whole-object comparison in `the_default_listing_holds_only_what_is_declared`.
- Announced as `scripts.candidates` in `capabilities`, because otherwise a console cannot tell "this agent has no other scripts" from "this daemon does not look".

### The subdirectory: the fetch route was extended

Of the two options offered, I extended `GET/PUT/DELETE /api/scripts/{kind}/{name}` to take a relative path, rather than listing a file the client cannot open.

`{name}` is now read as a `/`-separated path whose every part must pass `is_safe_path_component`, percent-encoded so it stays one path segment: `output_validator/validators%2Fa2ui`. The route pattern is unchanged, so the OpenAPI path template and the router-drift test stay as they are (a `{*name}` wildcard would have needed a path template OpenAPI cannot express). Axum percent-decodes path params, and the repo already relied on that: `writing_with_a_traversing_name_is_refused` sends `..%2F..%2Fevil` and expects the 400.

This keeps the promise the old code kept by dropping the entry, from the other side: a listing entry is never addressable under a name that would fetch a different file. A declaration these routes still cannot address (not a `.rhai` file, or one that climbs out of the agent's directory) is still left out.

The write half takes the same names, so an editor that can show a subdirectory validator can also save one. `PUT` creates the subdirectory **after** `guard` has proved the whole path resolves inside the agent's directory, never before: a symlink planted at an intermediate name would otherwise make the `mkdir` land outside.

## Security

- The scan is bounded by three named constants with the reasoning beside each: `CANDIDATE_MAX_DEPTH = 4` (the docs' own layout is one level; four survives a nested one without descending a checkout somebody pointed `agent_paths` at), `CANDIDATE_MAX_DIRS = 128` (depth alone does not bound a *wide* tree), `CANDIDATE_MAX_FILES = 256`.
- Containment is asked of **every entry** via `leviath_core::resolves_within`, not assumed from where the walk started, because the agents directory itself may be a symlink. A link out of the agent's directory is neither followed nor reported.
- `.rhai` files only. A directory named `looks.rhai` is a directory; a file named exactly `.rhai` has no name left to be addressed by and is skipped.
- Every name goes through `leviath_core::is_safe_path_component`; a non-UTF-8 name comes back lossy and is refused by the same check. A path that cannot be represented safely is omitted, never guessed at.
- `agent_dir` is untouched, so the picker resolves an agent through `discover_blueprints` exactly as a run does.
- No new path logic: `is_safe_path_component` and `resolves_within` are the two helpers, the same ones `blueprint_dir` and the daemon's `script_within_blueprint` use.

## Tests

`crates/leviath-cli/src/commands/serve/scripts_tests.rs`, all new unless noted:

- `the_default_listing_holds_only_what_is_declared` - the exact JSON a current client sees, whole objects, with an undeclared file sitting right there.
- `include_candidates_adds_the_files_nothing_declares` - the candidate appears, declared entries are unchanged, a declared file and a `tools/` file are not repeated as candidates, `unknown` is a 400 as a `{kind}`, and the candidate's name opens the file under a real kind.
- `a_hook_declared_in_a_subdirectory_is_listed_and_readable` (was `..._is_left_out`) - listed under `hooks/deep`, and the read route returns that file's text.
- `a_declaration_that_cannot_be_addressed_is_left_out` - `notes.txt` and `../outside.rhai` are still dropped.
- `a_candidate_is_a_rhai_file_with_a_name_that_can_be_addressed` - a `.txt`, a bare `.rhai`, a name with a space and a directory ending in `.rhai` are all passed over.
- `the_candidate_scan_stops_at_the_depth_limit` / `..._file_limit` / `..._directory_limit`.
- `a_symlink_out_of_the_agent_directory_is_not_a_candidate` **plus its `#[cfg(windows)]` twin** (`symlink_dir`/`symlink_file`), following the `serve/fs.rs` pattern.
- `writing_through_a_symlinked_subdirectory_is_refused` **plus its Windows twin** - 403, and nothing created outside.
- `reading_a_name_that_cannot_be_addressed_is_refused` - `..%2F..%2Fevil`, `%2Fetc%2Fpasswd`, `hooks%2F..%2F..%2Fevil`.
- `include_refuses_a_token_it_does_not_serve`, `include_candidates_without_an_agent_changes_nothing`, `an_agent_with_no_directory_has_no_candidates`.
- `writing_into_a_subdirectory_creates_it`, `a_subdirectory_that_cannot_be_created_is_reported`.
- `a_name_is_read_as_a_relative_path_of_safe_components` and `a_declared_path_must_already_name_a_rhai_file` replace `only_a_bare_rhai_filename_is_addressable`.

Gates: `cargo fmt`, `clippy --all-targets --all-features -p leviath-cli -D warnings`, `cargo xtask structure`, `cargo xtask docs`, and `cargo xtask coverage --package leviath-cli` at a hard 100% on regions, lines and functions.

Docs: `docs/content/api.md` (the parameter, the new fields, the relative-path `{name}`, and a `scripts.candidates` capability row), `docs/schema/openapi.json` (the `include` parameter, a 400 on the listing, the `name` description on all three operations), a pointer in `docs/content/scripting.md`, and CHANGELOG under Added.

## Live check

`lev serve --allow-admin` against an isolated home (`LEVIATH_HOME=/tmp/lv738`, `LEVIATH_SKIP_DOTENV=1`, token set, spawned detached), with a blueprint declaring `validators/a2ui.rhai`, an undeclared `validators/draft.rhai`, a declared `tools/summarize.rhai`, and two symlinks pointing at `/tmp/lv738-outside` (`escape.rhai` at a file there, `escape` at the directory).

```
=== GET /api/scripts?agent=picker -> 200
{
  "scripts": [
    {
      "kind": "tool",
      "name": "summarize",
      "source": "agent",
      "agent": "picker",
      "path": "/tmp/lv738/.leviath/agents/picker/tools/summarize.rhai",
      "relative_path": "tools/summarize.rhai",
      "declared": true,
      "compiles": true
    },
    {
      "kind": "output_validator",
      "name": "validators/a2ui",
      "source": "agent",
      "agent": "picker",
      "path": "/tmp/lv738/.leviath/agents/picker/validators/a2ui.rhai",
      "relative_path": "validators/a2ui.rhai",
      "declared": true,
      "compiles": true
    }
  ]
}

=== GET /api/scripts?agent=picker&include=candidates -> 200
{
  "scripts": [
    { ... the two above, unchanged ... },
    {
      "kind": "unknown",
      "name": "validators/draft",
      "source": "agent",
      "agent": "picker",
      "path": "/tmp/lv738/.leviath/agents/picker/validators/draft.rhai",
      "relative_path": "validators/draft.rhai",
      "declared": false
    }
  ]
}
```

Neither symlink appears in either listing. The rest of the probe:

```
=== GET /api/scripts?agent=picker&include=nope -> 400
{ "error": "Unknown include 'nope': expected candidates" }

=== GET /api/scripts/output_validator/validators%2Fa2ui?agent=picker -> 200
{
  "kind": "output_validator",
  "name": "validators/a2ui",
  "source": "agent",
  "agent": "picker",
  "path": "/tmp/lv738/.leviath/agents/picker/validators/a2ui.rhai",
  "content": "fn validate(content) { #{ valid: true } }\n",
  "compiles": true
}

=== GET /api/scripts/output_validator/escape?agent=picker -> 403
{ "error": "'/tmp/lv738/.leviath/agents/picker/escape.rhai' is not a plain file, so it will not be read or written through" }

=== GET /api/config -> capabilities
["scripts.read", "scripts.write", "scripts.providers", "scripts.candidates"]
```
