### PR TITLE
refactor(mcp): drop the discard of a response id nothing reads

### DIFF
--- a/crates/leviath-mcp/src/transport/http.rs
+++ b/crates/leviath-mcp/src/transport/http.rs
@@ -587,7 +587,7 @@ impl HttpTransport {
             .unwrap_or("")
             .to_string();
 
-        let mut parsed = if content_type.starts_with("text/event-stream") {
+        let parsed = if content_type.starts_with("text/event-stream") {
             self.read_sse_reply(response, id).await?
         } else if content_type.starts_with("application/json") {
             Self::read_json_reply(response).await?
@@ -599,7 +599,6 @@ impl HttpTransport {
         };
 
         self.learn_session(&response_headers, &parsed);
-        parsed.id.take();
         Ok(parsed)
     }
 }


### PR DESCRIPTION
## What

Deletes one statement, `parsed.id.take();`, from `HttpTransport::streamable_request` in `crates/leviath-mcp/src/transport/http.rs`. The `let mut parsed` on the same expression loses its `mut`, since nothing mutates it any more.

**Which option I took: I deleted it.** Nothing depends on the id being cleared, so there was no true comment to write in its place.

## Why

The line arrived with the original transport commit `083e6b5b`, carrying the comment "Take the id out of the borrow so `learn_session` can mutate self". That was false, and `77b61c49` removed it: `learn_session` takes `&JsonRpcResponse` and has already returned on the previous line, so there is no live borrow to break.

## Evidence: everything I checked

Line numbers below are as of `origin/main` before this change, so `http.rs:602` names the deleted statement.

The claim to establish is that nothing reads `JsonRpcResponse::id` after that point.

**The field's visibility bounds the search.** `JsonRpcResponse` (`transport/jsonrpc.rs:61`) is `pub(crate)`, re-exported only as `pub(crate) use jsonrpc::{JsonRpcRequest, JsonRpcResponse}` in `transport/mod.rs:19`. No other crate in the workspace can name the type, let alone its field. A workspace-wide `grep -rn JsonRpcResponse --include='*.rs'` returns hits in `leviath-mcp` only.

**Every read of the field, workspace-wide.** `grep -rn '\.id\b' crates/leviath-mcp/` returns three lines, and only one of them is a response id:

- `http.rs:602` - the statement being deleted (a write).
- `http.rs:613` - `response_matches`, `match (&response.id, id)`. The one and only reader.
- `http.rs:737` - `let id = req.id`, which is the *request* id on `JsonRpcRequest`, a different type.

**The one reader runs strictly earlier.** `response_matches` is called from exactly one place in production code, `handle_frame` (`http.rs:420`), which is reached from `read_sse_reply` (`http.rs:405`) and from `legacy_request` (`http.rs:556`). Both are the calls that *produce* `parsed`, several lines above the deleted statement. By the time the deleted line ran, the id had already done its only job: selecting this frame as the answer to our request.

**Callers of the function.** `streamable_request` has two call sites:

- `http.rs:741`, in `Transport::send_request` for `Mode::Streamable`. It wraps the call in `tokio::time::timeout` and returns the `JsonRpcResponse` unread.
- `http.rs:576`, its own fallback arm, which returns `legacy_request(...)` instead and so never reaches the deleted line.

**Callers of `send_request`.** In production there is exactly one: `MCPClient::request_with_timeout` (`client.rs:412-424`), which does `self.transport.send_request(&request, timeout).await?.into_result()`. `into_result` (`jsonrpc.rs:81`) consumes `self`, reads `error` and `result`, and drops everything else. It never touches `id`. Its own two callers, `tools/list` (`client.rs:332`) and `tools/call` (`client.rs:373`), receive a plain `Value` and never see a response struct at all.

**No serialization or equality path exists.** `JsonRpcResponse` derives `Deserialize` and nothing else - no `Serialize`, no `PartialEq`, no `Debug`. So there is no way for a test or any other code to observe the id via a round-trip or an `assert_eq!` on the whole struct.

**Tests.** I searched the crate's tests for anything asserting a response id is `None` after a call. There is none - the `grep` for `.id` above covers the test modules too, since they are inline `#[cfg(test)] mod tests`. The only tests that concern ids are the four `response_matching_*` cases at `http.rs:1649-1668`, which build their input with the local `fn resp(id: Value)` helper (`http.rs:1641`) and call `response_matches` directly. They never go through `streamable_request`, so deleting the line cannot reach them. The ~60 `send_request` call sites in `http.rs`'s and `stdio.rs`'s test modules all assert on the *result* or on the error text.

**The two paths already disagreed.** `legacy_request` never cleared the id, so a response returned over the legacy path has always carried the server's id out to the caller. "The id is `None` after a call" was therefore never a property of this transport, only an accident of one of its two branches. Nothing could have been pinning it.

## Behaviour

None intended and none found. The returned value's `id` now holds whatever the server sent on the streamable path, matching what the legacy path has always done, but no code reads it, so the change is not observable. No changelog entry, since a user cannot notice it.

## Gates

`cargo fmt --all`, `cargo clippy --all-targets --all-features -p leviath-mcp -- -D warnings`, `cargo test -p leviath-mcp` (413 passed), `cargo xtask structure`, `cargo xtask docs`, and `cargo xtask coverage --package leviath-mcp` at 100% all pass, as does the full pre-commit suite.
