### PR TITLE
test(telemetry): give each telemetry_reload test its own install counter

### DIFF
--- a/crates/leviath-cli/src/daemon/telemetry_reload.rs
+++ b/crates/leviath-cli/src/daemon/telemetry_reload.rs
@@ -27,7 +27,15 @@ use leviath_core::telemetry::NoopSink;
 /// How the OTLP log bridge reaches the process subscriber. Injected so a test
 /// can watch what a rebuild asked for without racing other tests over the
 /// process-wide reload handle, which only one of them can ever park.
-type InstallLayer = fn(Option<leviath_telemetry::LogLayer>) -> bool;
+///
+/// A boxed closure rather than a bare `fn` pointer so an injected installer can
+/// capture state a single test owns. A `fn` pointer forces the recorder to be a
+/// `static`, which every test in the module then shares, and libtest runs those
+/// tests on threads of one process: one test's reset lands between another's
+/// write and its read, and the assertion sees a value no test ever asked for.
+/// The daemon still installs exactly `logging::set_otel_layer`, on the same
+/// schedule as before.
+type InstallLayer = Box<dyn Fn(Option<leviath_telemetry::LogLayer>) -> bool + Send + Sync>;
 
 /// Keeps the telemetry pipeline in step with `[observability]`.
 pub struct TelemetryReload {
@@ -41,7 +49,9 @@ pub struct TelemetryReload {
 impl TelemetryReload {
     /// One that forwards the OTLP log bridge to the process subscriber.
     pub fn for_daemon() -> Arc<Self> {
-        Arc::new(Self::with_installer(crate::logging::set_otel_layer))
+        Arc::new(Self::with_installer(Box::new(
+            crate::logging::set_otel_layer,
+        )))
     }
 
     /// One that reports its layer changes to `install_layer` instead.
@@ -114,20 +124,29 @@ mod tests {
     use leviath_core::config::TelemetryExporterKind;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    /// What the last injected install call asked for: 1 for a layer, 2 for
-    /// clearing the slot. A static because the injection point is a plain `fn`
-    /// pointer (a closure would need the layer type to be nameable at the call
-    /// site), and the tests that read it run in one thread each.
-    static LAST_INSTALL: AtomicUsize = AtomicUsize::new(0);
+    /// What the injected installer was last asked for: 1 for a layer, 2 for
+    /// clearing the slot, 0 for never called.
+    ///
+    /// One counter per test, handed back by [`reload`], rather than one
+    /// `static` the whole module shares. libtest runs these tests on threads
+    /// of a single process, so a shared counter is written by every test at
+    /// once: whichever test resets it between another's install and that
+    /// test's `load` makes the reader see a value nothing asked for. That is a
+    /// real flake, not a theoretical one - it was reproduced here as
+    /// `left: 0, right: 2` after the reset landed in the middle of a passing
+    /// test. Nothing in the pipeline itself is process-wide, so there is
+    /// nothing here to serialize: the counter simply belongs to the test.
+    type Installs = Arc<AtomicUsize>;
 
-    fn record_install(layer: Option<leviath_telemetry::LogLayer>) -> bool {
-        LAST_INSTALL.store(if layer.is_some() { 1 } else { 2 }, Ordering::SeqCst);
-        true
-    }
-
-    fn reload() -> TelemetryReload {
-        LAST_INSTALL.store(0, Ordering::SeqCst);
-        TelemetryReload::with_installer(record_install)
+    /// A reload whose installs land in a counter only the calling test holds.
+    fn reload() -> (TelemetryReload, Installs) {
+        let installs: Installs = Arc::new(AtomicUsize::new(0));
+        let recorder = Arc::clone(&installs);
+        let reload = TelemetryReload::with_installer(Box::new(move |layer| {
+            recorder.store(if layer.is_some() { 1 } else { 2 }, Ordering::SeqCst);
+            true
+        }));
+        (reload, installs)
     }
 
     fn cfg(enabled: bool, exporter: TelemetryExporterKind) -> ObservabilityConfig {
@@ -166,7 +185,7 @@ mod tests {
 
     #[test]
     fn the_first_refresh_installs_and_a_repeat_of_it_does_not() {
-        let reload = reload();
+        let (reload, _installs) = reload();
         let (_rt, mut world) = world();
         let enabled = cfg(true, TelemetryExporterKind::Stdout);
         assert!(reload.refresh_into(&mut world, &enabled));
@@ -183,7 +202,7 @@ mod tests {
     /// reaches the collector rather than the no-op.
     #[test]
     fn turning_export_on_after_boot_swaps_the_sink() {
-        let reload = reload();
+        let (reload, _installs) = reload();
         let (_rt, mut world) = world();
         assert!(reload.refresh_into(&mut world, &cfg(false, TelemetryExporterKind::Stdout)));
         let off = sink_ptr(&mut world);
@@ -198,7 +217,7 @@ mod tests {
 
     #[test]
     fn turning_export_off_puts_the_noop_sink_back_and_clears_the_bridge() {
-        let reload = reload();
+        let (reload, installs) = reload();
         let (_rt, mut world) = world();
         reload.refresh_into(&mut world, &cfg(true, TelemetryExporterKind::Stdout));
         let on = sink_ptr(&mut world);
@@ -206,7 +225,7 @@ mod tests {
         assert!(reload.refresh_into(&mut world, &cfg(false, TelemetryExporterKind::Stdout)));
         assert_ne!(sink_ptr(&mut world), on);
         assert_eq!(
-            LAST_INSTALL.load(Ordering::SeqCst),
+            installs.load(Ordering::SeqCst),
             2,
             "the daemon's own log lines must stop reaching a collector that was turned off"
         );
@@ -217,10 +236,10 @@ mod tests {
         // `exporter = "none"` with `enabled = true` is the config-level way to
         // say "build no pipeline"; a failed OTLP construction reaches the same
         // arm, having warned.
-        let reload = reload();
+        let (reload, installs) = reload();
         let (_rt, mut world) = world();
         assert!(reload.refresh_into(&mut world, &cfg(true, TelemetryExporterKind::None)));
-        assert_eq!(LAST_INSTALL.load(Ordering::SeqCst), 2);
+        assert_eq!(installs.load(Ordering::SeqCst), 2);
         // Emitting into it is a no-op rather than a panic.
         world
             .world_mut()
@@ -235,7 +254,7 @@ mod tests {
     /// connected until an export flush, which nothing here triggers.
     #[test]
     fn the_otlp_exporter_brings_the_daemon_log_bridge_with_it() {
-        let reload = reload();
+        let (reload, installs) = reload();
         let (_rt, mut world) = world();
         let otlp = ObservabilityConfig {
             enabled: true,
@@ -245,14 +264,14 @@ mod tests {
         };
         assert!(reload.refresh_into(&mut world, &otlp));
         assert_eq!(
-            LAST_INSTALL.load(Ordering::SeqCst),
+            installs.load(Ordering::SeqCst),
             1,
             "the daemon's own log lines go to the collector the user just named"
         );
 
         assert!(reload.refresh_into(&mut world, &cfg(true, TelemetryExporterKind::Stdout)));
         assert_eq!(
-            LAST_INSTALL.load(Ordering::SeqCst),
+            installs.load(Ordering::SeqCst),
             2,
             "and stop when the exporter they go through is no longer configured"
         );
@@ -260,7 +279,7 @@ mod tests {
 
     #[test]
     fn a_changed_endpoint_is_a_change() {
-        let reload = reload();
+        let (reload, _installs) = reload();
         let (_rt, mut world) = world();
         let mut first = cfg(true, TelemetryExporterKind::Stdout);
         reload.refresh_into(&mut world, &first);


### PR DESCRIPTION
## The flake

`daemon::telemetry_reload::tests::the_otlp_exporter_brings_the_daemon_log_bridge_with_it`
failed once on `Test (windows-latest)` reading `0` where `2` was expected, then
passed on a rerun with no code change. It is a real latent race, not a one-off.

## What shared the global

`crates/leviath-cli/src/daemon/telemetry_reload.rs` recorded what the injected
layer installer was last asked for in a module-level
`static LAST_INSTALL: AtomicUsize` (1 for a layer, 2 for clearing the slot).
Six of the module's seven tests touched it:

| test | writes 0 via `reload()` | writes 1/2 via the installer | reads |
| --- | --- | --- | --- |
| `the_first_refresh_installs_and_a_repeat_of_it_does_not` | yes | yes | no |
| `turning_export_on_after_boot_swaps_the_sink` | yes | yes | no |
| `turning_export_off_puts_the_noop_sink_back_and_clears_the_bridge` | yes | yes | **yes (expects 2)** |
| `an_exporter_that_builds_nothing_leaves_a_working_silent_sink` | yes | yes | **yes (expects 2)** |
| `the_otlp_exporter_brings_the_daemon_log_bridge_with_it` | yes | yes | **yes (expects 1, then 2)** |
| `a_changed_endpoint_is_a_change` | yes | yes | no |
| `for_daemon_starts_with_nothing_applied` | no | no | no |

libtest runs the tests of one binary on threads of a single process, so those
writes interleave freely. When one test's `reload()` reset landed between
another test's install and its `load`, the reader saw `0`. That is exactly the
CI symptom.

## Reproduced

A plain loop does not hit it locally: 60 runs of
`cargo test -p leviath-cli --lib daemon::telemetry_reload -- --test-threads=8`
all passed, because the module is 7 tests finishing in 0.08 s and the window is
nanoseconds wide. On CI the same binary schedules 4265 tests at once.

So the interleaving was forced instead. A temporary test was added to the
module that did nothing but what `reload()` already does, store `0` to the same
static, in a loop. With that, **5 of 5 runs failed**, including the reported
symptom verbatim:

```
---- ...::the_otlp_exporter_brings_the_daemon_log_bridge_with_it stdout ----
assertion `left == right` failed: the daemon's own log lines go to the collector the user just named
  left: 0
 right: 1

---- ...::turning_export_off_puts_the_noop_sink_back_and_clears_the_bridge stdout ----
assertion `left == right` failed: the daemon's own log lines must stop reaching a collector that was turned off
  left: 0
 right: 2

---- ...::an_exporter_that_builds_nothing_leaves_a_working_silent_sink stdout ----
  left: 0
 right: 2
```

The amplifier was removed before the fix; it is not in this branch.

## The fix

The tests no longer share process-wide state at all, which is the preferred
shape rather than a mutex. `reload()` now hands back an `Arc<AtomicUsize>` that
only the calling test holds, and the installer it injects writes into that one.
Nothing is shared, so there is no ordering to serialize and no starting value to
assume.

Serialising with a mutex was not needed here because nothing under test is
inherently process-wide. The `tracing` reload handle genuinely is (a process
installs one subscriber, once) but it was already behind the injected
`install_layer` seam, so the tests never touch it. Only the recorder was global,
and a recorder does not have to be.

The assertions are unchanged. The OTLP test still proves what it proved before:
turning the OTLP exporter on installs the daemon's log bridge (`1`), and moving
off it takes the bridge back out (`2`).

## Production change

One, and it is only the seam's type:

```rust
-type InstallLayer = fn(Option<leviath_telemetry::LogLayer>) -> bool;
+type InstallLayer = Box<dyn Fn(Option<leviath_telemetry::LogLayer>) -> bool + Send + Sync>;
```

A bare `fn` pointer cannot capture, which is what forced the recorder to be a
`static` in the first place (the old comment claimed a closure would need an
unnameable layer type; `leviath_telemetry::LogLayer` is a public alias, so that
was not so). `TelemetryReload::for_daemon` still builds with exactly
`crate::logging::set_otel_layer` and `refresh_into` still calls it on exactly
the same schedule. The cost is one boxed closure at daemon start and one
indirect call per `[observability]` change. **No runtime behaviour change.**

## Neighbouring globals

Swept every module-scope `static` in `crates/` for the same shape. No other
instance of this bug:

- `leviath-net/src/lib.rs` `RESOLVER_CALLS` is module-scope, but only one test
  uses `counting_resolver`, and it asserts on a delta from a value it reads
  first rather than on a starting value.
- `dashboard/state.rs` `LOADS`, `credentials.rs` `PROBED`,
  `runtime/host_tests.rs` `TICKS` / `RESUMED` / `RESUMED_ORPHAN` / `SEEN_LIVE`
  are declared inside the single test function that uses them, so no other test
  can name them.
- `serve/agents.rs` `COUNTER` and `embed/spawner.rs` `COUNTER` are monotonic id
  sources, never read for a specific value.
- `credentials.rs` `STORE`, `script_host.rs` `HTTP_LIMITS`,
  `serve/doctor.rs` `LIVE` and `scripting/tool.rs` `PANIC_HOOK_LOCK` are already
  serialising mutexes over genuinely process-wide state.
- `logging.rs` already handles its process-wide statics the other correct way:
  one test drives each whole lifecycle, with a comment saying why.

## Gates

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`: clean
- `cargo test -p leviath-cli --lib daemon::telemetry_reload -- --test-threads=8`
  run **100 times** after the fix: 100 runs, 0 failures. The full `leviath-cli`
  lib binary (4265 tests, all concurrent, which is the CI condition) run green
  three times over, including twice under the coverage gate.
- `cargo xtask structure`: 436 files, none over the limit
- `cargo xtask docs`: 40 pages, 3 schemas, no problems
- `cargo xtask coverage --package leviath-cli`: exit 0 (stale
  `target/llvm-cov-target` removed first)
- No `#[cfg(unix)]`-only tests added; the change is platform-neutral.

No CHANGELOG entry: this is test-only plus a private type alias, so nothing a
user of `lev` can observe changes.
