### PR TITLE
chore(release): 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
-## Unreleased
+## 0.5.6 - 2026-08-30
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "leviath-core",
  "leviath-tools",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "chrono",
  "dirs",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "encoding_rs",
  "leviath-testkit",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "base64 0.23.1",
  "leviath-core",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "fs4",
  "keyring",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "tokio",
  "tracing",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -98,18 +98,18 @@ allow_attributes_without_reason = "deny"
 # to the repo while every crate that dev-depends on it still publishes.
 # No member depends on the facade; it is listed so the version-parity check
 # (`cargo xtask version --check`) sees every published crate in one table.
-leviath = { path = "crates/leviath", version = "0.5.5" }
-leviath-core = { path = "crates/leviath-core", version = "0.5.5" }
-leviath-net = { path = "crates/leviath-net", version = "0.5.5" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.5" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.5" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.5.5" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.5" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.5" }
-leviath-package = { path = "crates/leviath-package", version = "0.5.5" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.5.5" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.5.5" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.5" }
+leviath = { path = "crates/leviath", version = "0.5.6" }
+leviath-core = { path = "crates/leviath-core", version = "0.5.6" }
+leviath-net = { path = "crates/leviath-net", version = "0.5.6" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.6" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.6" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.5.6" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.6" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.6" }
+leviath-package = { path = "crates/leviath-package", version = "0.5.6" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.5.6" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.5.6" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.6" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.5.5", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.5.6", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Leviath HTTP API",
-    "version": "0.5.5",
+    "version": "0.5.6",
     "description": "The REST and WebSocket surface `lev serve` puts in front of the shared-world daemon. Every route requires a bearer token. Paths here are checked against the router in crates/leviath-cli/src/commands/serve/mod.rs by a test in that file, so a route added without a spec entry fails the build. See https://leviath.dev/docs/api.",
     "license": {
       "name": "MIT"


### PR DESCRIPTION
Cuts 0.5.6. A patch on purpose: this cycle added no features, it was cleanup and bug fixes, so nothing in it asks a user to learn anything new.

`cargo xtask version 0.5.6` wrote every version in one pass (the thirteen intra-workspace pins, the allocator pin in `leviath-cli`'s own manifest, the CHANGELOG heading, and `info.version` in the OpenAPI document). `cargo xtask version --check` reports every pin matching, both `[profile.release]` blocks agreeing, and every member in the publish list and the coverage matrix. The API version the server answers comes from `CARGO_PKG_VERSION`, and a test asserts it matches the spec, so the two move together.

Needs the `allow-version-bump` label, which is on.

## What is in 0.5.6

Thirty-one PRs, in four groups.

**Config reaches the daemon without a restart.** Provider keys, gateways, `[[mcp_servers]]`, the outbound network policy, `policy.toml` and `rules/*.rhai`, `[observability]`, and the `[limits]` the world is built with are all re-read when `config.toml` changes. Switching provider used to need the daemon killed: `lev setup`, `PUT /api/config` and a restart of `lev serve` all failed to take effect, because the registry was built once at boot and moved into the world as a resource nothing replaced. Three things still need a restart and are now the only three: `mcp_idle_disconnect_secs`, the daemon's own log verbosity, and a provider key exported as an environment variable.

**A run waits for a person.** An approval prompt no longer expires after an hour; absent `[limits] interaction_timeout_secs` it waits indefinitely, nothing sets one on your behalf, and the stage clock is credited back so `stuck_after_minutes` cannot fire on the first tick after you answer. Shutting the daemon down while a prompt was parked used to hang until the prompt expired, which would have been permanent under the new default. A tool approval can now be denied with feedback that reaches the model.

**Bugs with a measured cause.** A zero `requests_per_minute` livelocked every call to that provider. `tokens_per_minute` throttled nothing on the streaming path, which is the default. A streamed chunk that split a multi-byte character was dropped, so a run carrying CJK or emoji looked like a dead connection. Cached tokens were divided by fresh input, so a well-cached run reported over 100 per cent. A 30 second request deadline killed the MCP browser login. An idle MCP server the pool could not take leaked for the daemon's life. `submit_output` was classified as internal while the API serves it off the machine.

**Hardening and hygiene.** Every read from a remote peer is capped. `lev serve` has a concurrency cap and a request timeout, both configurable. A blueprint with a negative count or a misspelled `[sandbox]` key no longer loads. A `config.toml` that will not load is reported in the API, the dashboard, `lev doctor` and `lev run` instead of only a log line, and the last good config keeps serving. Prices come from a data file refreshed weekly with no person or model in the loop. The docs were checked page by page against the code, and about 2,800 lines of stale comment narration were removed without changing an executable line.

## Checks

The full required set on this PR, plus `cargo xtask version --check`. Nothing else changes: the diff is five files of version strings.
