### PR TITLE
feat(serve): report the default model, and let it be written away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## Unreleased
+
+### Added
+
+- `GET /api/config` reports `default_model`, the model every stage runs on
+  while it is set, and reports it as `null` rather than dropping the key when
+  nothing is pinned. A console could read `default_provider` and not this, so
+  its model picker drew an empty box over a machine that had a model pinned.
+  The key is always sent, so its absence means the server predates the field
+  rather than meaning nothing is set (#746).
+- `PUT /api/config` can write `default_model` away: `"default_model": null`
+  clears it and every stage goes back to the model its blueprint names, an
+  absent key still leaves it alone, and a string still pins it. Setting it was
+  a one-way door before, which matters because unset is usually the better
+  state - a pinned model flattens a blueprint that chose a cheap model for its
+  cheap stages onto one top-tier price. Same explicit-clear shape
+  `remove_gateways` uses for gateways. `"default_model": ""` answers 400 and
+  writes nothing: an empty string is not a model id, and a form that posts its
+  empty box should hear about it rather than lose the setting (#746).
+
 ## 0.5.6 - 2026-08-30
 
 ### Breaking

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -56,6 +56,7 @@ fn redact(
         config_error,
         config_mtime,
         default_provider: c.default_provider.clone(),
+        default_model: c.default_model.clone(),
         has_anthropic_key: c.providers.anthropic_api_key.is_some(),
         has_openai_key: c.providers.openai_api_key.is_some(),
         has_google_key: c.providers.google_api_key.is_some(),
@@ -102,8 +103,24 @@ pub(super) async fn put_config(
     if let Some(v) = req.default_provider {
         config.default_provider = v;
     }
-    if let Some(v) = req.default_model {
-        config.default_model = Some(v);
+    // Three states rather than the two every field around it has: absent
+    // leaves the pin alone, `null` removes it so each blueprint picks its own
+    // model again, and a string pins that one. Written as a `match` because
+    // the read has to distinguish "the key was not sent" from "the key was
+    // sent as null", which an `if let Some` on a single `Option` cannot.
+    match req.default_model {
+        None => {}
+        Some(None) => config.default_model = None,
+        // Refused rather than treated as a clear: `""` is not a model id, and
+        // a form that posts its empty box should be told, not obeyed. The
+        // check runs before anything is saved, so the file is untouched.
+        Some(Some(v)) if v.trim().is_empty() => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                "default_model must not be empty; send null to clear it".to_string(),
+            ));
+        }
+        Some(Some(v)) => config.default_model = Some(v),
     }
     if let Some(v) = req.anthropic_key {
         config.providers.anthropic_api_key = Some(v);
@@ -913,6 +930,7 @@ mod tests {
     fn redacted_config_hides_keys() {
         let config = RedactedConfig {
             default_provider: "anthropic".to_string(),
+            default_model: None,
             has_anthropic_key: true,
             has_openai_key: false,
             has_google_key: false,
@@ -939,6 +957,7 @@ mod tests {
     fn redacted_config_with_ollama_url() {
         let config = RedactedConfig {
             default_provider: "ollama".to_string(),
+            default_model: None,
             has_anthropic_key: false,
             has_openai_key: false,
             has_google_key: false,
@@ -1147,9 +1166,143 @@ mod tests {
         assert_eq!(saved.openrouter_api_key.as_deref(), Some("or-x"));
         assert_eq!(saved.default_model.as_deref(), Some("gpt-5"));
         assert_eq!(
+            rc.default_model.as_deref(),
+            Some("gpt-5"),
+            "the answer reports the pin it just wrote"
+        );
+        assert_eq!(
             saved.ollama_base_url.as_deref(),
             Some("http://ollama:11434")
         );
+    }
+
+    /// A config with `default_model` pinned to `gpt-5`, saved at `path`.
+    ///
+    /// A named helper rather than a closure at each call site: a closure is a
+    /// separate region per site, and four of them are four uncovered regions
+    /// the day one test stops running.
+    fn pinned_config_at(path: &std::path::Path) {
+        let pinned = Config {
+            default_model: Some("gpt-5".to_string()),
+            ..Default::default()
+        };
+        pinned.save_to_path_public(path).unwrap();
+    }
+
+    /// `GET /api/config` says which model is pinned, and says `null` out loud
+    /// when none is.
+    ///
+    /// Serialized unconditionally, like `ollama_base_url` beside it, because
+    /// the third case matters: a daemon too old to report this omits the key
+    /// entirely, and a console has to read that as "cannot say" rather than
+    /// as "nothing is set". Collapsing the two is what left the picker
+    /// drawing an empty box over a machine with a model pinned.
+    #[tokio::test]
+    async fn get_config_reports_the_default_model_when_set_and_null_when_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+        let state = state_watching_config_path(path.clone());
+
+        let unset = get_config_request(state.clone()).await;
+        assert!(
+            unset.get("default_model").is_some(),
+            "the key is always there, so its absence can mean something else"
+        );
+        assert!(
+            unset["default_model"].is_null(),
+            "nothing pinned reads as null"
+        );
+
+        pinned_config_at(&path);
+        bump_mtime(&path);
+
+        let set = get_config_request(state).await;
+        assert_eq!(set["default_model"], "gpt-5");
+    }
+
+    /// The partial-update rule the rest of the body follows: a key this
+    /// request does not mention is left exactly as it was.
+    #[tokio::test]
+    async fn put_config_without_default_model_leaves_the_pin_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        pinned_config_at(&path);
+
+        let body = serde_json::json!({ "default_provider": "openai" }).to_string();
+        let resp = put_config_request(state_with_config_path(path.clone()), &body).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        let saved = Config::load_from_path_public(&path).unwrap();
+        assert_eq!(
+            saved.default_model.as_deref(),
+            Some("gpt-5"),
+            "an absent key changes nothing"
+        );
+        assert_eq!(saved.default_provider, "openai");
+    }
+
+    /// `null` is the other door: it writes the setting away, so every stage
+    /// goes back to the model its blueprint names.
+    ///
+    /// The file is what is checked, not the struct in memory. "Cleared" has
+    /// to survive the save: a `None` that still serialized a `default_model`
+    /// line would read back as pinned on the next load, and the console would
+    /// see its own clear undone one request later.
+    #[tokio::test]
+    async fn put_config_with_null_clears_the_default_model_from_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        pinned_config_at(&path);
+        assert!(
+            std::fs::read_to_string(&path).unwrap().contains("gpt-5"),
+            "the pin starts out on disk"
+        );
+
+        let body = serde_json::json!({ "default_model": null }).to_string();
+        let resp = put_config_request(state_with_config_path(path.clone()), &body).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let answer: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            answer["default_model"].is_null(),
+            "the answer already reports it gone"
+        );
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !on_disk.contains("default_model"),
+            "the key is gone from the file, not merely None in memory"
+        );
+        let reread = Config::load_from_path_public(&path).unwrap();
+        assert_eq!(reread.default_model, None, "and it stays gone on re-read");
+    }
+
+    /// An empty string is not a clear and not a model id, so it is a 400.
+    ///
+    /// The alternative, reading `""` as "unset", makes a form that posts its
+    /// empty box silently destroy a setting - and there is a spelling for
+    /// that already, one character long. Refused the way an
+    /// `openai-compatible` gateway with an empty `base_url` is refused, and
+    /// like that one it is refused before anything is written.
+    #[tokio::test]
+    async fn put_config_refuses_an_empty_default_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        pinned_config_at(&path);
+
+        for body in [r#"{"default_model": ""}"#, r#"{"default_model": "   "}"#] {
+            let resp = put_config_request(state_with_config_path(path.clone()), body).await;
+            assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+            let saved = Config::load_from_path_public(&path).unwrap();
+            assert_eq!(
+                saved.default_model.as_deref(),
+                Some("gpt-5"),
+                "a refused write leaves the file as it was"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -6,12 +6,43 @@
 //! setup rather than a run, and it is the part that grows every time a new
 //! kind of provider becomes configurable.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
+
+/// Read a field that has to tell "absent" apart from "explicitly null".
+///
+/// A plain `Option<T>` collapses the two: serde hands back `None` both for a
+/// key the body never mentioned and for one sent as `null`, so a
+/// partial-update body can say "set this" and "leave this alone" but never
+/// "clear this". The extra layer keeps all three apart on the way in:
+///
+/// | JSON             | Rust            | What it asks for      |
+/// |------------------|-----------------|-----------------------|
+/// | key absent       | `None`          | leave the value alone |
+/// | `"key": null`    | `Some(None)`    | clear the value       |
+/// | `"key": "gpt-5"` | `Some(Some(v))` | set the value         |
+///
+/// Only useful with `#[serde(default)]` beside it: that is what supplies the
+/// outer `None`, because a missing key never reaches this function at all.
+pub(super) fn double_option<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::deserialize(deserializer).map(Some)
+}
 
 #[derive(Serialize, Deserialize)]
 pub(super) struct RedactedConfig {
     pub(super) default_provider: String,
+    /// `default_model`: the one model every stage runs on while it is set.
+    ///
+    /// Always serialized, `null` when nothing is set, which is the
+    /// distinction a console needs. A daemon too old to report this omits the
+    /// key entirely, and that has to read as "cannot say" rather than as
+    /// "nothing is set" - without the field, a picker drew an empty box over
+    /// a machine that had a model pinned.
+    pub(super) default_model: Option<String>,
     pub(super) has_anthropic_key: bool,
     pub(super) has_openai_key: bool,
     pub(super) has_google_key: bool,
@@ -336,7 +367,20 @@ impl ApiLimits {
 #[derive(Debug, Default, Deserialize)]
 pub(super) struct WriteConfigReq {
     pub(super) default_provider: Option<String>,
-    pub(super) default_model: Option<String>,
+    /// Three-state, unlike every field beside it: absent leaves the setting
+    /// alone, `null` clears it, a string sets it. See [`double_option`].
+    ///
+    /// Unset is a real state here, and usually the better one: a pinned
+    /// `default_model` runs every stage of every blueprint on one model,
+    /// which puts the cheap stages on a top-tier price. A route that could
+    /// set it and never unset it was a one-way door, the same gap
+    /// `remove_gateways` exists to close for gateways.
+    ///
+    /// An empty string is refused with a 400 rather than read as a clear.
+    /// `""` is not a model id, and a console that sends one by accident
+    /// should hear about it instead of quietly losing the setting.
+    #[serde(default, deserialize_with = "double_option")]
+    pub(super) default_model: Option<Option<String>>,
     pub(super) anthropic_key: Option<String>,
     pub(super) openai_key: Option<String>,
     pub(super) google_key: Option<String>,

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -1277,6 +1277,7 @@ mod tests {
     fn redacted_config_serde_roundtrip() {
         let config = RedactedConfig {
             default_provider: "anthropic".to_string(),
+            default_model: Some("claude-sonnet-5".to_string()),
             has_anthropic_key: true,
             has_openai_key: false,
             has_google_key: false,
@@ -1294,6 +1295,7 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let parsed: RedactedConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.default_provider, "anthropic");
+        assert_eq!(parsed.default_model.as_deref(), Some("claude-sonnet-5"));
         assert!(parsed.has_anthropic_key);
         assert!(!parsed.has_openai_key);
     }

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -217,7 +217,7 @@ handle that on all of them rather than on a few. The body is a line of plain tex
 | `POST /api/agents/{id}/message` | Steer a running agent |
 | `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question. See [below](#answering-a-question) |
 | `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation. The listing is paginated and takes `q`; the detail carries the manifest, the regions and the [fan-out limits](#fan-out-limits) |
-| `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key. A `PUT` that changes a provider key, a gateway or `default_provider` applies to the next run spawned, with no daemon restart |
+| `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key. A `PUT` that changes a provider key, a gateway, `default_provider` or [`default_model`](#the-default-model) applies to the next run spawned, with no daemon restart |
 | `GET /api/models` | Enumerate models, with each one's token limits and where they came from. An OpenAI-compatible gateway's detected models are listed under the gateway's name |
 | `POST /api/models/probe` *(admin)* | Ask an OpenAI-compatible server what it serves before writing a gateway for it: `{"base_url", "api_key"?, "headers"?}` → `{"models": [ids]}`, or 502 carrying the server's own error text. See [below](#gateways) |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
@@ -981,6 +981,36 @@ omits the field whether or not the file loads, so its absence proves nothing the
 `PUT /api/config` is checked before it writes, with the same rules the loader applies, so this API
 cannot be the thing that breaks the file: a body that would produce a config this build refuses to
 read back answers **400** and the file is left byte for byte as it was.
+
+## The default model
+
+`default_model` on `GET /api/config` is the model every stage runs on while it is set, as a bare
+model id on `default_provider`. It is always sent, `null` included, and that is the point: a server
+that omits the key predates the field, which is a different answer from "nothing is pinned". Read
+the absence as "cannot say" and show that, rather than showing an empty picker over a machine that
+has a model pinned.
+
+On `PUT /api/config` the same key has three states, which no other field in that body has:
+
+| Body                        | What happens                                       |
+|-----------------------------|----------------------------------------------------|
+| no `default_model` key      | the setting is left exactly as it was              |
+| `"default_model": null`     | the setting is written away                        |
+| `"default_model": "gpt-5"`  | the setting is pinned to `gpt-5`                   |
+
+Clearing it matters as much as setting it. A pinned model runs every stage of every blueprint on
+that one model, and the cheap stages then pay a top-tier price, so unset is the state most machines
+want: see [which entry a stage starts on](/docs/providers#which-entry-a-stage-starts-on). Sending
+`null` is the only way to get back there through this API, in the same way `remove_gateways` is the
+only way to delete a gateway.
+
+`"default_model": ""` is a **400**, not a clear. An empty string is not a model id, and a form that
+posts its empty box should be told rather than quietly lose the setting. Nothing is written when it
+is refused.
+
+`default_provider` takes no `null`. It is not optional in `config.toml` - a machine always has one,
+defaulting to `anthropic` - so there is no unset state to write, and sending a different name is the
+whole vocabulary.
 
 ## Gateways
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -46,7 +46,7 @@ update_check         = true          # ask whether a newer release exists
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `default_provider` | string | `"anthropic"` | |
-| `default_model` | string | unset | A bare model id on `default_provider`, not `provider/model`. A leading `<default_provider>/` is dropped and named at load, so `"ollama/qwen3.8:latest"` under `default_provider = "ollama"` still works. See [which entry a stage starts on](/docs/providers#which-entry-a-stage-starts-on) |
+| `default_model` | string | unset | A bare model id on `default_provider`, not `provider/model`. A leading `<default_provider>/` is dropped and named at load, so `"ollama/qwen3.8:latest"` under `default_provider = "ollama"` still works. Unset is usually the better state; over the API, `PUT /api/config` with `"default_model": null` writes it away. See [which entry a stage starts on](/docs/providers#which-entry-a-stage-starts-on) |
 | `agent_paths` | array of paths | `[]` | Searched in addition to `~/.leviath/agents` |
 | `openrouter_api_key` | string | unset | Falls back to `OPENROUTER_API_KEY` |
 | `ollama_base_url` | string | unset | Falls back to `OLLAMA_HOST`, then `http://localhost:11434` |

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -205,6 +205,12 @@ your default still has the blueprint's own entries to fall back to.
 > `default_model` too flattens it, and the cheap stages start paying top-tier prices while the
 > deciding stage loses the model the author chose for it.
 
+Going back is a first-class move, not a repair. Delete the `default_model` line from `config.toml`,
+or over the API send `PUT /api/config` with `{"default_model": null}` - `null` clears it, an absent
+key leaves it alone, and an empty string is refused rather than read as a clear. Either way the next
+run picks per stage again, with no restart. `GET /api/config` reports the current value, `null` when
+nothing is pinned.
+
 Run `lev validate <agent>` to see the result before you spend anything on it. It prints the model
 each stage would actually use on this machine, and, where that differs from the blueprint's own
 order, prints that order underneath so the substitution is visible:

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1723,6 +1723,98 @@
         ],
         "summary": "Replace the configuration",
         "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed. The body is validated with the same checks the loader makes, before anything is written, so a request that would produce a config this build refuses to read back answers 400 and leaves the file byte for byte as it was.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Every field is optional and an absent one is left untouched, so a console can change one setting without reading the rest back and writing it again.",
+                "properties": {
+                  "default_provider": {
+                    "type": "string"
+                  },
+                  "default_model": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Three states, unlike every other field here. Absent leaves the setting alone; `null` clears it, so each blueprint picks its own model per stage again; a string pins that model across every stage. An empty string is a 400, not a clear: `\"\"` is not a model id, and a form that posts its empty box should be told rather than silently lose the setting."
+                  },
+                  "anthropic_key": {
+                    "type": "string"
+                  },
+                  "openai_key": {
+                    "type": "string"
+                  },
+                  "google_key": {
+                    "type": "string"
+                  },
+                  "openrouter_key": {
+                    "type": "string"
+                  },
+                  "ollama_base_url": {
+                    "type": "string"
+                  },
+                  "gateways": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "The `[model_providers]` key. Created when no entry has this name."
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "script",
+                            "openai-compatible"
+                          ],
+                          "description": "Absent leaves the existing kind; an entry created without one is a script."
+                        },
+                        "base_url": {
+                          "type": "string"
+                        },
+                        "api_key": {
+                          "type": "string"
+                        },
+                        "script": {
+                          "type": "string"
+                        },
+                        "headers": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Extra headers for an endpoint, replacing the existing set."
+                        },
+                        "models": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "The ids an endpoint falls back to when its server will not list them."
+                        }
+                      }
+                    },
+                    "description": "Gateways to add or update, by name. A gateway this list does not mention is left as it was."
+                  },
+                  "remove_gateways": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Gateways to delete, by name. Applied after the edits above."
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "The configuration as written, redacted.",
@@ -2927,6 +3019,7 @@
         "description": "The active configuration with every credential reduced to whether one is set, plus what this server can do and how much it accepts.",
         "required": [
           "default_provider",
+          "default_model",
           "has_anthropic_key",
           "has_openai_key",
           "has_google_key",
@@ -2941,6 +3034,13 @@
         "properties": {
           "default_provider": {
             "type": "string"
+          },
+          "default_model": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The model every stage runs on while it is set, as a bare model id on `default_provider`. `null` when nothing is pinned, which is the usual and generally better state: each blueprint then picks its own model per stage. Always sent, so a missing key means the server predates this field rather than meaning nothing is set."
           },
           "has_anthropic_key": {
             "type": "boolean"


### PR DESCRIPTION
Closes #746.

## What changed

**`GET /api/config` reports `default_model`.** `RedactedConfig` carried
`default_provider` and not the model beside it, so the console's picker drew an
empty box over a machine that had one pinned. The field is `Option<String>` and
is **always serialized**, `null` when nothing is set - the same shape
`ollama_base_url` and `config_mtime` already have. Always, because the third
state is the one that matters: a daemon too old to have this field omits the
key entirely, and a client has to read that as "cannot say" rather than as
"nothing is set". It is in `required` in the spec for that reason.

**`PUT /api/config` can write it away.** The field is now
`Option<Option<String>>` behind a new `double_option` helper:

| Body                       | Result                        |
|----------------------------|-------------------------------|
| no `default_model` key     | left exactly as it was        |
| `"default_model": null`    | written away                  |
| `"default_model": "gpt-5"` | pinned to `gpt-5`             |

The same explicit-clear idea `remove_gateways` uses for gateways, for the same
reason: omission has to keep meaning "leave alone", so deletion needs a word of
its own. There is no `double_option` in the tree yet, so this adds one, in
`config_types.rs` beside its only caller (there is no shared serde-helper
module to put it in), with a doc comment spelling out all three JSON shapes.

## The two decisions you asked for

**An empty string is a 400, not a clear.** `"default_model": ""` (or any
whitespace-only string) answers
`{"error": "default_model must not be empty; send null to clear it"}` and
writes nothing. `""` is not a model id, and a console that posts its empty box
by accident should hear about it rather than silently lose the setting - there
is already a four-character spelling for "clear it".

I checked for precedent both ways before choosing. The route does not check
empty strings on the key fields, and `validate_keys` deliberately treats a
blank key as "not configured" rather than warning - but that is a value where
blank *is* a meaningful state (`lev setup` writes one for a provider you
skipped). The closer precedent is `ModelProviderConfig::validate`, which
refuses an `openai-compatible` gateway whose `base_url` is empty, with a 400,
before anything is written. `default_model = ""` is that case, not the key
case: it is a value that cannot work, and the loader would carry it into every
run. So this refuses it the same way and at the same point, before the save.

**`default_provider` does not get the same treatment, and does not have the
same shape.** It is `String` in `Config`, not `Option<String>`, with a
`#[serde(default)]` of `"anthropic"`. A machine always has a default provider,
so there is no unset state for a `null` to write and nothing about it is a
one-way door: every value is reachable from every other by sending a different
name. Giving it `Option<Option<String>>` would add a spelling with no meaning
behind it. Left alone, and `docs/content/api.md` now says why so the next
person does not have to re-derive it.

## Tests

Each behaviour claim was run against the unfixed code first, in two halves.

With `redact` reverted to not reporting the field,
`get_config_reports_the_default_model_when_set_and_null_when_not` fails
`left: Null, right: "gpt-5"`. With the write half reverted to `Option<String>`,
`put_config_with_null_clears_the_default_model_from_the_file` fails on "the
answer already reports it gone" and `put_config_refuses_an_empty_default_model`
fails `left: 200, right: 400`. `put_config_without_default_model_leaves_the_pin_alone`
passes against the old code, which is correct - it is a preserved-behaviour
claim, not a regression probe.

The clearing test checks the **file**, not the struct: it asserts the saved
`config.toml` no longer contains `default_model` and that a fresh
`load_from_path_public` reads back `None`. A `None` that still serialized the
line would read as pinned on the next load and undo the console's clear one
request later, and an in-memory assertion would not have caught it.

No `#[cfg(unix)]` anywhere; every test is a tempdir and an in-process router.

## Docs

- `docs/schema/openapi.json`: `default_model` on the `RedactedConfig` schema
  (and in its `required` list), plus a `requestBody` for `PUT /api/config` -
  the operation had none at all - documenting every field it accepts and
  spelling out the three states. No new status codes, so the handler-status
  drift test is unaffected; 400 was already listed.
- `docs/content/api.md`: a new "The default model" section with the three-state
  table, why clearing matters, the empty-string refusal, and the
  `default_provider` note. The route table row now links to it.
- `docs/content/providers.md`: how to go back, next to the `IMPORTANT` block
  that says why you usually want to.
- `docs/content/configuration.md`: the `default_model` row names the API spelling.
- CHANGELOG under a new `## Unreleased` / `### Added`.

## Live check

`lev serve --allow-admin` on an isolated home (`LEVIATH_HOME=/tmp/lv746`,
`LEVIATH_SKIP_DOTENV=1`, `LEVIATH_API_TOKEN` set, spawned with
`start_new_session=True`), against `perf-tools/mock.py`. The probe blueprint
names `openai/gpt-mock`; the config pinned `claude-mock` so the pin and the
blueprint disagree and the run says which one won.

`config.toml` before:

```toml
default_provider = "openai"
default_model = "claude-mock"
```

`GET /api/config`:

```json
{
  "default_provider": "openai",
  "default_model": "claude-mock",
  "config_mtime": 1788116355
}
```

A run with the pin in force resolved `meta.model: "openai/claude-mock"` - the
pin beat the blueprint, as it should.

`PUT /api/config` with `{"default_model": ""}`:

```
400 {"error": "default_model must not be empty; send null to clear it"}
```

`PUT /api/config` with `{"default_model": null}` answered 200 with:

```json
{
  "default_provider": "openai",
  "default_model": null
}
```

`GET /api/config` again:

```json
{
  "default_provider": "openai",
  "default_model": null,
  "config_mtime": 1788116356
}
```

`config.toml` on disk afterwards, with no `default_model` line anywhere in the
file:

```toml
default_provider = "openai"
agent_paths = []
mcp_servers = []
taint_tracking = false
update_check = true
batch_tool_hint = true
shell_hint = true

[providers]
openai_api_key = "mock"
openai_base_url = "http://127.0.0.1:8121/v1"
claude_code_enabled = false
fallback_order = []
```

And the run after the clear resolved `meta.model: "openai/gpt-mock"` - the
blueprint's own model, with no daemon restart between the two runs.

## Gates

`cargo fmt --all`; `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`
clean; `cargo xtask structure` (436 files, none over 1200); `cargo xtask docs`
(40 pages, 3 schemas, no problems); `cargo xtask coverage --package leviath-cli`
gated at 100% and passing. Pre-commit ran the full suite.
