### PR TITLE
Sign in to Codex from lev setup, and make its credential check real

### DIFF
--- a/crates/leviath-cli/src/commands/auth.rs
+++ b/crates/leviath-cli/src/commands/auth.rs
@@ -131,7 +131,9 @@ pub async fn execute(args: AuthArgs, env: AuthEnv) -> anyhow::Result<()> {
             let config = Config::load_from_path_public(&path)?;
             logout(&config, &provider, env.grant_path)
         }
-        AuthCommand::Migrate { to_file, dry_run } => migrate(&path, to_file, dry_run),
+        AuthCommand::Migrate { to_file, dry_run } => {
+            migrate(&path, to_file, dry_run, env.grant_path.as_deref())
+        }
     }
 }
 
@@ -464,7 +466,12 @@ pub(crate) fn render_status(s: &Status) -> String {
 }
 
 /// Move secrets between the config file and the OS credential store.
-fn migrate(path: &std::path::Path, to_file: bool, dry_run: bool) -> anyhow::Result<()> {
+fn migrate(
+    path: &std::path::Path,
+    to_file: bool,
+    dry_run: bool,
+    grant_path: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
     let config = Config::load_from_path_public(path)?;
     let plan = plan_migration(&config, to_file);
 
@@ -482,7 +489,7 @@ fn migrate(path: &std::path::Path, to_file: bool, dry_run: bool) -> anyhow::Resu
         return Ok(());
     }
 
-    apply_migration(&config, path, to_file)?;
+    apply_migration(&config, path, to_file, grant_path)?;
     println!("\nDone. {}", plan.done);
     Ok(())
 }
@@ -535,7 +542,12 @@ pub(crate) fn plan_migration(config: &Config, to_file: bool) -> MigrationPlan {
 /// The order matters in both directions: write the destination first, verify it
 /// took, and only then remove the source. A migration that cleared the config
 /// file before the keychain write succeeded would destroy the user's API keys.
-fn apply_migration(config: &Config, path: &std::path::Path, to_file: bool) -> anyhow::Result<()> {
+fn apply_migration(
+    config: &Config,
+    path: &std::path::Path,
+    to_file: bool,
+    grant_path: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
     let resolved = crate::credentials::store_for(CredentialStoreKind::Keychain);
     apply_migration_with(
         config,
@@ -543,7 +555,12 @@ fn apply_migration(config: &Config, path: &std::path::Path, to_file: bool) -> an
         to_file,
         resolved,
         leviath_mcp::AuthStore::default_path().as_deref(),
-        leviath_providers::codex::ProviderAuthStore::default_path().as_deref(),
+        // The caller's, not `default_path()`. Resolving it here reached the
+        // real `~/.leviath/provider-auth.json` from `AuthEnv`-driven tests,
+        // so running the suite on a machine signed in to Codex moved that
+        // grant into a mock keychain and rewrote the file. `AuthEnv` already
+        // carries the path for exactly this reason.
+        grant_path,
     )
 }
 
@@ -1435,7 +1452,10 @@ mod tests {
             AuthEnv {
                 // Never the real one: a test must not launch a browser.
                 opener: std::sync::Arc::new(|_| false),
-                grant_path: leviath_providers::codex::ProviderAuthStore::default_path(),
+                // Beside the caller's config, which is already a tempdir.
+                // `default_path()` here is the developer's own home, and
+                // `migrate` writes to whatever it is handed.
+                grant_path: Some(path.with_file_name("provider-auth.json")),
                 client: reqwest::Client::new(),
                 issuer: leviath_providers::codex::ISSUER.to_string(),
                 ports: vec![0],
@@ -1874,19 +1894,19 @@ mod tests {
         let path = dir.path().join("config.toml");
         Config::default().save_to_path_public(&path).unwrap();
 
-        temp_env::with_var("LEVIATH_HOME", Some(dir.path()), || {
-            let grants =
-                leviath_providers::codex::ProviderAuthStore::default_path().expect("a home is set");
-            write_grant_store(&grants);
+        // Beside the config rather than under a `$LEVIATH_HOME` override:
+        // `temp_env` sets that for the whole process, so a wizard built on
+        // another thread while this ran read *this* home and reported itself
+        // signed in to a grant that is about to be deleted.
+        let grants = path.with_file_name("provider-auth.json");
+        write_grant_store(&grants);
 
-            run_auth(&path, AuthArgs::logout_for_test("codex")).expect("logout succeeds");
-            let store =
-                leviath_providers::codex::ProviderAuthStore::load(&grants).expect("a store");
-            assert!(store.get("codex").is_none());
+        run_auth(&path, AuthArgs::logout_for_test("codex")).expect("logout succeeds");
+        let store = leviath_providers::codex::ProviderAuthStore::load(&grants).expect("a store");
+        assert!(store.get("codex").is_none());
 
-            // And again, which reports there was nothing to do.
-            run_auth(&path, AuthArgs::logout_for_test("codex")).expect("a second logout is fine");
-        });
+        // And again, which reports there was nothing to do.
+        run_auth(&path, AuthArgs::logout_for_test("codex")).expect("a second logout is fine");
     }
 
     /// A provider that signs in with a key is refused by both halves.

--- a/crates/leviath-cli/src/commands/auth/codex.rs
+++ b/crates/leviath-cli/src/commands/auth/codex.rs
@@ -237,5 +237,8 @@ pub fn logout(
     Ok(removed)
 }
 
+// Visible to the rest of the crate's tests: `setup::signin` drives a whole
+// sign-in through the same stub browser, and a second copy of that harness
+// would be a second thing to keep true.
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/crates/leviath-cli/src/commands/auth/codex/tests.rs
+++ b/crates/leviath-cli/src/commands/auth/codex/tests.rs
@@ -12,7 +12,9 @@ use std::sync::Mutex;
 
 /// A stub opener that plays the browser: it parses the authorize URL and hits
 /// the loopback callback with the code and the state it was given.
-fn browser_that_redirects(recorder: Arc<Mutex<Vec<String>>>) -> leviath_mcp::BrowserOpener {
+pub(crate) fn browser_that_redirects(
+    recorder: Arc<Mutex<Vec<String>>>,
+) -> leviath_mcp::BrowserOpener {
     Arc::new(move |url: &str| {
         recorder.lock().expect("recorder").push(url.to_string());
         let parsed = url::Url::parse(url).expect("a URL");
@@ -61,7 +63,7 @@ fn browser_that_does_nothing() -> leviath_mcp::BrowserOpener {
 ///
 /// Encoded by hand rather than through a crate: `base64` is not a dependency
 /// of the CLI, and adding one for a single test fixture is a poor trade.
-fn id_token() -> String {
+pub(crate) fn id_token() -> String {
     let claims = serde_json::json!({
         "email": "someone@example.com",
         "https://api.openai.com/auth": {
@@ -90,7 +92,11 @@ fn base64url(bytes: &[u8]) -> String {
     out
 }
 
-fn env_for(issuer: &str, dir: &tempfile::TempDir, opener: leviath_mcp::BrowserOpener) -> LoginEnv {
+pub(crate) fn env_for(
+    issuer: &str,
+    dir: &tempfile::TempDir,
+    opener: leviath_mcp::BrowserOpener,
+) -> LoginEnv {
     LoginEnv {
         opener,
         store_path: dir.path().join("provider-auth.json"),

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -182,33 +182,7 @@ pub(crate) fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> 
     // guessing where Leviath's files live, so the path is supplied here or the
     // provider is not offered at all.
     if config.providers.codex_enabled {
-        let mut options = std::collections::HashMap::new();
-        // Extended from an `Option` rather than branched on: with no home
-        // there is no path, the option is simply absent, and the registry
-        // skips the provider - which it is tested to do.
-        options.extend(
-            leviath_providers::codex::ProviderAuthStore::default_path()
-                .map(|path| ("auth_store_path".to_string(), path.display().to_string())),
-        );
-        if let Some(originator) = &config.providers.codex_originator {
-            options.insert("originator".to_string(), originator.clone());
-        }
-        if let Some(effort) = &config.providers.codex_reasoning_effort {
-            options.insert("effort".to_string(), effort.clone());
-        }
-        if let Some(verbosity) = &config.providers.codex_verbosity {
-            options.insert("verbosity".to_string(), verbosity.clone());
-        }
-        options.insert(
-            "replay_reasoning".to_string(),
-            config.providers.codex_replay_reasoning.to_string(),
-        );
-        // The runtime has no view of `[security]`, and a grant only the CLI
-        // could read would leave the keychain backend silently signing the
-        // daemon out.
-        if config.security.credential_store == leviath_core::CredentialStoreKind::Keychain {
-            options.insert("credential_store".to_string(), "keychain".to_string());
-        }
+        let options = codex_options(config);
         creds.push(ProviderCreds {
             name: leviath_providers::codex::PROVIDER_NAME.to_string(),
             api_key: None,
@@ -226,6 +200,54 @@ pub(crate) fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> 
     }
 
     creds
+}
+
+/// The `options` a Codex [`ProviderCreds`] carries.
+///
+/// Shared with `lev setup`, whose credential check has to build the provider
+/// the same way this does. It reads the grant from disk, so a wizard that
+/// pointed somewhere else would be checking a sign-in no run would ever use.
+pub(crate) fn codex_options(config: &Config) -> std::collections::HashMap<String, String> {
+    let mut options = std::collections::HashMap::new();
+    // Extended from an `Option` rather than branched on: with no home
+    // there is no path, the option is simply absent, and the registry
+    // skips the provider - which it is tested to do.
+    options.extend(
+        leviath_providers::codex::ProviderAuthStore::default_path()
+            .map(|path| ("auth_store_path".to_string(), path.display().to_string())),
+    );
+    options.extend(
+        config
+            .providers
+            .codex_originator
+            .clone()
+            .map(|v| ("originator".to_string(), v)),
+    );
+    options.extend(
+        config
+            .providers
+            .codex_reasoning_effort
+            .clone()
+            .map(|v| ("effort".to_string(), v)),
+    );
+    options.extend(
+        config
+            .providers
+            .codex_verbosity
+            .clone()
+            .map(|v| ("verbosity".to_string(), v)),
+    );
+    options.insert(
+        "replay_reasoning".to_string(),
+        config.providers.codex_replay_reasoning.to_string(),
+    );
+    // The runtime has no view of `[security]`, and a grant only the CLI
+    // could read would leave the keychain backend silently signing the
+    // daemon out.
+    if config.security.credential_store == leviath_core::CredentialStoreKind::Keychain {
+        options.insert("credential_store".to_string(), "keychain".to_string());
+    }
+    options
 }
 
 /// Convenience wrapper: build a [`ProviderRegistry`] straight from a [`Config`].

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -19,7 +19,7 @@ use ratatui::layout::Rect;
 use super::catalog::Credential;
 use super::state::{
     ConfirmPurpose, DetailAction, Edit, EditTarget, EndpointCursor, EndpointField, FieldValue,
-    Picker, Step, Wizard,
+    Picker, SigninAction, Step, Wizard,
 };
 use crate::tui::keymap;
 use crate::tui::widgets::confirm::ConfirmOutcome;
@@ -243,27 +243,44 @@ impl Wizard {
         }
         if self.step == Step::ProviderDetail
             && let Some(index) = self.detail_row()
-            && self.is_endpoint_preset(index)
         {
-            self.activate_endpoint_row(index);
+            // An endpoint preset's screen is its entries' own form; every
+            // other one is a credential row (where there is something to type)
+            // followed by its buttons.
+            if self.is_endpoint_preset(index) {
+                self.activate_endpoint_row(index);
+            } else {
+                self.activate_detail_row(index);
+            }
             return Action::Continue;
         }
         match self.step {
             Step::Providers | Step::Agents | Step::Mcp => self.toggle(),
-            Step::ProviderDetail => match self.detail_actions().get(self.cursor.wrapping_sub(1)) {
-                // Row 0 is the credential: it opens its editor. `wrapping_sub`
-                // turns that row into an index no action has.
-                None => self.open_credential_editor(),
-                Some(DetailAction::OpenSignup) => self.open_signup_page(),
-                Some(DetailAction::Verify) => self.verify_current(),
-            },
             Step::Defaults | Step::Limits => self.activate_field(),
             // Rowless steps put the cursor on their button, so these arms are
             // reachable only with a hand-forced cursor; acting on nothing is
-            // correct then.
-            Step::Welcome | Step::Review => {}
+            // correct then. `ProviderDetail` joins them for a different
+            // reason: reaching it at all needs a selected provider, so the
+            // screen with no row to act on is one the wizard never opens.
+            Step::Welcome | Step::Review | Step::ProviderDetail => {}
         }
         Action::Continue
+    }
+
+    /// Enter on the credential screen of the provider at `index`.
+    ///
+    /// Row 0 is the credential on every screen that has one, and it opens its
+    /// editor; `detail_action_at` answers `None` there. A browser sign-in has
+    /// nothing to type, so its buttons start at row 0 instead and the `None`
+    /// arm is only the cursor past the last of them.
+    fn activate_detail_row(&mut self, index: usize) {
+        match self.detail_action_at(index, self.cursor) {
+            None => self.open_credential_editor(),
+            Some(DetailAction::OpenSignup) => self.open_signup_page(),
+            Some(DetailAction::SignIn) => self.request_signin(index, SigninAction::In),
+            Some(DetailAction::SignOut) => self.request_signin(index, SigninAction::Out),
+            Some(DetailAction::Verify) => self.verify_current(),
+        }
     }
 
     /// Enter on an endpoint preset's screen (the preset at provider row

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -1033,6 +1033,73 @@ fn a_provider_without_a_key_page_offers_only_the_check() {
     assert_eq!(w.row_count(), 2, "the credential row plus the one action");
 }
 
+/// The sign-in screen's buttons start at row 0, and pressing the first row
+/// must not open a text editor: there is no credential behind it to edit.
+#[test]
+fn a_sign_in_screen_has_no_credential_to_edit() {
+    let (_dir, mut w) = wizard();
+    let index = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "codex")
+        .expect("the codex row is offered");
+    for row in &mut w.providers {
+        row.selected = false;
+    }
+    w.providers[index].selected = true;
+    w.enter(Step::ProviderDetail);
+
+    // Row 1 is the plans-page button, not a field. (Row 0 is the sign-in,
+    // which would ask the lane rather than opening an editor either way.)
+    let (x, y) = point_of_row(&w, 1);
+    w.handle_mouse(click(x, y), AREA);
+    assert!(w.edit.is_none(), "an editor opened over nothing to type");
+    assert!(
+        w.message
+            .as_deref()
+            .is_some_and(|m| m.starts_with("Opened")),
+        "{:?}",
+        w.message
+    );
+}
+
+/// Enter on the sign-in button asks the lane rather than doing it inline, so
+/// the wizard keeps drawing while the browser is open.
+#[test]
+fn the_sign_in_button_asks_the_lane() {
+    let (_dir, mut w) = wizard();
+    let index = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "codex")
+        .expect("the codex row is offered");
+    for row in &mut w.providers {
+        row.selected = false;
+    }
+    w.providers[index].selected = true;
+    w.enter(Step::ProviderDetail);
+    let (mut requests, _events) = w.take_signin_ends().expect("first take");
+
+    let (x, y) = point_of_row(&w, 0);
+    w.handle_mouse(click(x, y), AREA);
+
+    let request = requests.try_recv().expect("the lane was asked");
+    assert_eq!(request.provider_id, "codex");
+    assert!(w.providers[index].signing_in);
+
+    // And with a sign-in stored the rows shift: check, sign in again, then
+    // sign out, which is the third.
+    w.providers[index].signed_in = Some("a@b.c".to_string());
+    w.providers[index].signing_in = false;
+    let (x, y) = point_of_row(&w, 2);
+    w.handle_mouse(click(x, y), AREA);
+    let request = requests.try_recv().expect("the lane was asked again");
+    assert_eq!(
+        request.action,
+        crate::commands::setup::state::SigninAction::Out
+    );
+}
+
 #[test]
 fn a_click_outside_the_body_does_nothing() {
     let (_dir, mut w) = wizard();

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -1045,6 +1045,9 @@ fn a_sign_in_screen_has_no_credential_to_edit() {
         .expect("the codex row is offered");
     for row in &mut w.providers {
         row.selected = false;
+        // See `render::tests::codex_card`: the ambient grant store is shared
+        // with whatever else is running.
+        row.signed_in = None;
     }
     w.providers[index].selected = true;
     w.enter(Step::ProviderDetail);
@@ -1075,6 +1078,9 @@ fn the_sign_in_button_asks_the_lane() {
         .expect("the codex row is offered");
     for row in &mut w.providers {
         row.selected = false;
+        // See `render::tests::codex_card`: the ambient grant store is shared
+        // with whatever else is running.
+        row.signed_in = None;
     }
     w.providers[index].selected = true;
     w.enter(Step::ProviderDetail);

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -22,6 +22,7 @@
 //! * `catalog` - which providers exist and how each is configured.
 //! * [`import`] - MCP servers found in other tools.
 //! * [`verify`] - proving a credential works.
+//! * [`signin`] - taking a browser sign-in for a provider that has no key.
 //!
 //! The terminal is a *front-end*, not the feature: everything it collects lands
 //! in a `plan::SetupPlan`, and `--non-interactive` builds the same struct
@@ -35,6 +36,7 @@ pub mod import;
 pub(crate) mod input;
 pub(crate) mod plan;
 pub(crate) mod render;
+pub mod signin;
 pub(crate) mod state;
 pub mod verify;
 
@@ -98,9 +100,9 @@ pub struct SetupArgs {
     pub claude_code_effort: Option<String>,
 
     /// Enable the Codex transport (runs on your ChatGPT subscription instead
-    /// of an API key). Sign in separately with `lev auth login codex`; this
-    /// flag never opens a browser, because nothing is watching one in a
-    /// non-interactive run.
+    /// of an API key). This flag only flips the switch: interactive `lev setup`
+    /// signs in from its own screen, and a non-interactive run has nobody
+    /// watching a browser, so on this path sign in with `lev auth login codex`.
     #[arg(long)]
     pub codex: Option<bool>,
 
@@ -353,6 +355,7 @@ pub(crate) async fn run_wizard_loop<B: ratatui::backend::Backend>(
     loop {
         wizard.ticks += 1;
         wizard.drain_verifications();
+        wizard.drain_signins();
         // The area is taken from the frame that was actually drawn, so a click
         // resolves against the layout the user was looking at rather than
         // against a size asked for separately afterwards.

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -642,21 +642,34 @@ fn build_provider_detail(wizard: &Wizard) -> Screen {
                 Style::default().fg(C_DIM),
             )));
         }
-        // Nothing is typed here: the credential is a browser sign-in taken by
-        // a separate command, and this card reports whether it has been.
+        // Nothing is typed here, so this is a status line rather than a
+        // cursor row, and the buttons below it are the whole screen.
         Credential::Signin => {
-            let (text, colour) = match &row.signed_in {
-                Some(who) => (format!("Signed in: {who}"), C_WHITE),
-                None => ("Not signed in yet.".to_string(), C_WARN),
+            let (text, colour) = match (row.signing_in, &row.signed_in) {
+                (true, _) => ("Waiting for your browser…".to_string(), C_ACCENT),
+                (false, Some(who)) => (format!("Signed in: {who}"), C_WHITE),
+                (false, None) => ("Not signed in yet.".to_string(), C_WARN),
             };
-            lines.push(Line::from(vec![
-                Span::styled(row_marker, Style::default().fg(C_ACCENT)),
-                Span::styled(text, Style::default().fg(colour)),
-            ]));
-            if row.signed_in.is_none() {
+            lines.push(Line::from(Span::styled(
+                format!("  {text}"),
+                Style::default().fg(colour),
+            )));
+            if let Some(url) = &row.authorize_url {
+                // In full rather than shortened: this is here to be copied by
+                // someone whose browser did not open, and half a URL is no
+                // use to them.
                 lines.push(Line::from(Span::styled(
-                    "Run `lev auth login codex` to sign in with your ChatGPT account. \
-                     It opens a browser and stores the grant outside config.toml.",
+                    "If it did not open, go to:",
+                    Style::default().fg(C_DIM),
+                )));
+                lines.push(Line::from(Span::styled(
+                    url.clone(),
+                    Style::default().fg(C_MUTED),
+                )));
+            } else if row.signed_in.is_none() {
+                lines.push(Line::from(Span::styled(
+                    "Signing in opens your browser and stores the grant outside config.toml. \
+                     Nothing to type here.",
                     Style::default().fg(C_DIM),
                 )));
             }
@@ -669,15 +682,22 @@ fn build_provider_detail(wizard: &Wizard) -> Screen {
     lines.push(status_line(wizard, index));
     lines.push(Line::from(""));
 
+    // A sign-in screen has no credential row, so its buttons are its only
+    // rows and the first of them is row 0.
+    let has_credential_row = wizard.detail_has_credential_row(index);
     let mut screen = Screen {
         lines,
-        rows: vec![credential_row],
+        rows: if has_credential_row {
+            vec![credential_row]
+        } else {
+            Vec::new()
+        },
     };
-    for (offset, action) in wizard.detail_actions().iter().enumerate() {
-        // Row 0 is the credential itself, so the actions start after it.
-        let focused = wizard.cursor == offset + 1;
+    let offset = usize::from(has_credential_row);
+    for (position, action) in wizard.detail_actions().iter().enumerate() {
+        let focused = wizard.cursor == position + offset;
         screen.row();
-        screen.push(button_line(&action.label(row.provider.display), focused));
+        screen.push(button_line(&action.label(row), focused));
     }
     screen.finish(wizard)
 }
@@ -1432,34 +1452,82 @@ mod tests {
         assert!(!screen.contains("sk-oai"), "a key leaked:\n{screen}");
     }
 
-    /// A browser sign-in has nothing to type, so the card reports the account
-    /// instead of offering a field, and names the command when there is none.
-    #[test]
-    fn a_sign_in_card_reports_the_account_rather_than_asking_for_one() {
-        let (_dir, mut w) = wizard();
+    /// Put the codex card on screen, with nothing else selected.
+    fn codex_card() -> (tempfile::TempDir, Wizard, usize) {
+        let (dir, mut w) = wizard();
         let index = w
             .providers
             .iter()
             .position(|r| r.provider.id == "codex")
             .expect("the codex row is offered");
-        // The only selected row, so the detail card is this one.
         for row in &mut w.providers {
             row.selected = false;
         }
         w.providers[index].selected = true;
         w.enter(Step::ProviderDetail);
+        (dir, w, index)
+    }
+
+    /// A browser sign-in has nothing to type, so the card reports the account
+    /// instead of offering a field, and offers the sign-in as a button rather
+    /// than as a command to go and run somewhere else.
+    #[test]
+    fn a_sign_in_card_reports_the_account_rather_than_asking_for_one() {
+        let (_dir, mut w, index) = codex_card();
 
         let waiting = rendered(&w);
         assert!(waiting.contains("Not signed in yet"), "{waiting}");
-        assert!(waiting.contains("lev auth login codex"), "{waiting}");
-        assert!(!waiting.contains("API key"), "{waiting}");
+        assert!(waiting.contains("Sign in with your browser"), "{waiting}");
+        assert!(
+            !waiting.contains("API key:"),
+            "no field is offered:\n{waiting}"
+        );
+        assert!(
+            !waiting.contains("lev auth login"),
+            "setup sends nobody to another command:\n{waiting}"
+        );
+        // Nothing to check and nothing to forget until there is a sign-in.
+        assert!(!waiting.contains("Check this credential"), "{waiting}");
+        assert!(!waiting.contains("Sign out"), "{waiting}");
 
         w.providers[index].signed_in = Some("someone@example.com (plus plan)".to_string());
         let signed_in = rendered(&w);
         assert!(signed_in.contains("someone@example.com"), "{signed_in}");
+        assert!(signed_in.contains("Check this credential"), "{signed_in}");
+        assert!(signed_in.contains("Sign out"), "{signed_in}");
+    }
+
+    /// While the browser is open the card says so, and shows the URL for a
+    /// session where no browser opened.
+    #[test]
+    fn a_sign_in_in_flight_shows_the_url_to_copy() {
+        let (_dir, mut w, index) = codex_card();
+        w.providers[index].signing_in = true;
+        w.providers[index].authorize_url = Some("https://auth.openai.com/oauth/x".to_string());
+
+        let screen = rendered(&w);
+        assert!(screen.contains("Waiting for your browser"), "{screen}");
         assert!(
-            !signed_in.contains("lev auth login codex"),
-            "the reminder outlived the sign-in:\n{signed_in}"
+            screen.contains("https://auth.openai.com/oauth/x"),
+            "{screen}"
+        );
+    }
+
+    /// The buttons are the only rows on this card, so the one the cursor
+    /// starts on is the action somebody opening this screen actually wants.
+    #[test]
+    fn the_first_row_of_a_sign_in_card_is_the_sign_in_button() {
+        let (_dir, w, index) = codex_card();
+        assert!(!w.detail_has_credential_row(index));
+        assert_eq!(w.cursor, 0);
+        assert_eq!(
+            w.detail_action_at(index, 0),
+            Some(crate::commands::setup::state::DetailAction::SignIn)
+        );
+        let screen = rendered(&w);
+        assert!(
+            screen.contains("› [ Sign in with your browser ]"),
+            "the focus marker belongs on the sign-in button:\n{screen}"
         );
     }
 

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -1462,6 +1462,10 @@ mod tests {
             .expect("the codex row is offered");
         for row in &mut w.providers {
             row.selected = false;
+            // Cleared rather than trusted: `Wizard::new` reads the grant store
+            // under a `$LEVIATH_HOME` another test may have pointed at its own
+            // temp home, and this card is about the not-signed-in state.
+            row.signed_in = None;
         }
         w.providers[index].selected = true;
         w.enter(Step::ProviderDetail);

--- a/crates/leviath-cli/src/commands/setup/signin.rs
+++ b/crates/leviath-cli/src/commands/setup/signin.rs
@@ -1,0 +1,254 @@
+//! Taking a browser sign-in from inside the wizard.
+//!
+//! A provider whose credential is an OAuth grant has nothing for the wizard to
+//! ask for. The first version of the Codex row said so and stopped there,
+//! telling the user to quit and run `lev auth login codex` - which meant the
+//! one provider that needs no typing was the only one setup could not finish.
+//!
+//! So the sign-in happens here instead, and `lev auth login` goes back to
+//! being what it is actually for: signing in again on a machine with no
+//! wizard, or after a session has been revoked.
+//!
+//! ## The seam
+//!
+//! [`ProviderAuthorizer`] exists for the same reason [`ProviderVerifier`] does,
+//! with one addition: this one opens a browser. `lev dash` once had a unit test
+//! launch a real one, and a test that reached this without a seam would open a
+//! browser *and* wait five minutes for a callback nobody was going to make.
+//! Nothing in the library builds the live implementation; the binary wires it
+//! in, exactly as it does the verifier.
+//!
+//! [`ProviderVerifier`]: super::verify::ProviderVerifier
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use super::state::{SigninAction, SigninEvent, SigninRequest};
+use crate::commands::auth::codex::{self as codex_login, LoginEnv};
+
+/// Takes and forgets browser sign-ins.
+pub trait ProviderAuthorizer {
+    /// Sign `provider_id` in, reporting the authorize URL through `announce`
+    /// as soon as there is one. Returns the identity line to show.
+    ///
+    /// `announce` fires before the browser is asked to open, so a session with
+    /// no browser still has something to copy.
+    fn sign_in(
+        &self,
+        provider_id: &str,
+        announce: codex_login::Announce,
+    ) -> impl std::future::Future<Output = anyhow::Result<String>> + Send;
+
+    /// Forget `provider_id`'s stored grant.
+    fn sign_out(
+        &self,
+        provider_id: &str,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send;
+}
+
+/// Production [`ProviderAuthorizer`]: really opens a browser and really writes
+/// a grant.
+///
+/// Wired in only by the binary.
+pub struct LiveAuthorizer {
+    /// Opens the browser.
+    pub opener: leviath_mcp::BrowserOpener,
+    /// Where the grant is written. `None` when there is no home directory to
+    /// write one into, which is the one case this cannot do anything about.
+    pub store_path: Option<PathBuf>,
+    /// The OS credential store `[security]` asked for, or why it could not be
+    /// opened.
+    ///
+    /// Held unresolved rather than as an `Option`, so a keychain that cannot
+    /// be reached is reported when the user presses sign in instead of being
+    /// swallowed at start-up and writing the grant to a file they asked not to
+    /// use.
+    pub credential_store: Result<Option<Arc<dyn leviath_core::CredentialStore>>, String>,
+    /// The outbound client the token exchange goes out on.
+    ///
+    /// From `leviath_net::client`, not the provider builder, for the reason
+    /// `AuthEnv::real` gives: this is an OAuth exchange with an issuer rather
+    /// than an inference call, so it takes the shared HTTP defaults and cannot
+    /// fail to be built.
+    pub client: reqwest::Client,
+    /// The OAuth issuer, and the loopback ports its client id is registered
+    /// against. Overridden only by tests, which point them at a local mock and
+    /// port zero so a whole sign-in runs without a browser or a fixed port.
+    pub issuer: String,
+    /// See [`Self::issuer`].
+    pub ports: Vec<u16>,
+}
+
+impl LiveAuthorizer {
+    /// The authorizer for this machine: its home, and the credential backend
+    /// `[security]` asked for.
+    ///
+    /// Assembled here rather than in the binary so the composition root stays
+    /// one call, and because the config it reads is the same one the wizard is
+    /// about to edit: a grant has to land wherever `credential_store` says,
+    /// not wherever the default would have put it.
+    #[must_use]
+    pub fn real(opener: leviath_mcp::BrowserOpener, config_path: &std::path::Path) -> Self {
+        let kind = crate::config::Config::load_from_path_public(config_path)
+            .unwrap_or_default()
+            .security
+            .credential_store;
+        Self {
+            opener,
+            store_path: leviath_providers::codex::ProviderAuthStore::default_path(),
+            credential_store: crate::credentials::store_for(kind).map(|store| store.map(Arc::from)),
+            client: leviath_net::client(leviath_net::ClientTimeouts::default()),
+            issuer: leviath_providers::codex::ISSUER.to_string(),
+            ports: leviath_providers::codex::CALLBACK_PORTS.to_vec(),
+        }
+    }
+
+    /// The store path, or the error explaining why there is not one.
+    fn store_path(&self) -> anyhow::Result<PathBuf> {
+        self.store_path.clone().ok_or_else(|| {
+            anyhow::anyhow!(
+                "no home directory to store the sign-in in; set LEVIATH_HOME and try again"
+            )
+        })
+    }
+
+    /// The credential store, or the reason it is unavailable.
+    fn credential_store(&self) -> anyhow::Result<Option<Arc<dyn leviath_core::CredentialStore>>> {
+        self.credential_store
+            .clone()
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// Everything the flow needs, or the first reason it cannot run.
+    ///
+    /// Assembled before the flow starts so a missing home or an unreachable
+    /// keychain is reported without a browser having opened onto a sign-in
+    /// there is nowhere to store.
+    fn login_env(&self, announce: codex_login::Announce) -> anyhow::Result<LoginEnv> {
+        let mut env = LoginEnv::new(
+            self.opener.clone(),
+            self.store_path()?,
+            self.credential_store()?,
+            self.client.clone(),
+            announce,
+        );
+        env.issuer = self.issuer.clone();
+        env.ports = self.ports.clone();
+        Ok(env)
+    }
+}
+
+impl ProviderAuthorizer for LiveAuthorizer {
+    async fn sign_in(
+        &self,
+        provider_id: &str,
+        announce: codex_login::Announce,
+    ) -> anyhow::Result<String> {
+        unsupported(provider_id)?;
+        let grant = codex_login::login(&self.login_env(announce)?).await?;
+        Ok(describe(&grant))
+    }
+
+    async fn sign_out(&self, provider_id: &str) -> anyhow::Result<()> {
+        unsupported(provider_id)?;
+        codex_login::logout(&self.store_path()?, self.credential_store()?.as_deref())?;
+        Ok(())
+    }
+}
+
+/// Refuse a provider this does not know how to sign in.
+///
+/// Codex is the only one today. A second would be a match here rather than a
+/// second implementation of the trait, since the wizard's side of it is the
+/// same either way.
+fn unsupported(provider_id: &str) -> anyhow::Result<()> {
+    if provider_id == leviath_providers::codex::PROVIDER_NAME {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!(
+        "'{provider_id}' does not sign in with a browser"
+    ))
+}
+
+/// The identity line a signed-in grant shows as.
+pub(crate) fn describe(grant: &leviath_providers::ProviderGrant) -> String {
+    let claims = grant.claims();
+    let who = grant
+        .email
+        .clone()
+        .or(claims.email)
+        .unwrap_or_else(|| "signed in".to_string());
+    match grant.plan_type.clone().or(claims.plan_type) {
+        Some(plan) => format!("{who} ({plan} plan)"),
+        None => who,
+    }
+}
+
+/// Serve sign-in requests until the wizard closes.
+///
+/// One at a time, and deliberately: a sign-in owns a fixed loopback port that
+/// the second one could not bind, and two browser windows asking the same
+/// question is not a thing to offer anybody.
+pub async fn signin_loop<A: ProviderAuthorizer>(
+    authorizer: A,
+    mut requests: mpsc::UnboundedReceiver<SigninRequest>,
+    events: mpsc::UnboundedSender<SigninEvent>,
+) {
+    while let Some(request) = requests.recv().await {
+        let provider_id = request.provider_id.clone();
+        let event = match request.action {
+            SigninAction::In => {
+                let announce = announcer(&events, &provider_id);
+                match authorizer.sign_in(&provider_id, announce).await {
+                    Ok(who) => SigninEvent::SignedIn { provider_id, who },
+                    Err(e) => failed(provider_id, &e),
+                }
+            }
+            SigninAction::Out => match authorizer.sign_out(&provider_id).await {
+                Ok(()) => SigninEvent::SignedOut { provider_id },
+                Err(e) => failed(provider_id, &e),
+            },
+        };
+        // A closed receiver means the wizard exited; nothing left to report to.
+        if events.send(event).is_err() {
+            return;
+        }
+    }
+}
+
+/// The callback that forwards an authorize URL to the wizard.
+fn announcer(
+    events: &mpsc::UnboundedSender<SigninEvent>,
+    provider_id: &str,
+) -> codex_login::Announce {
+    let events = events.clone();
+    let provider_id = provider_id.to_string();
+    Arc::new(move |url: &str| {
+        let _ = events.send(SigninEvent::Opened {
+            provider_id: provider_id.clone(),
+            url: url.to_string(),
+        });
+    })
+}
+
+/// One failure, reported as the card's message.
+///
+/// The whole chain, because the useful half is usually the cause: "could not
+/// listen on port 1455 or 1457" is what the user has to act on, and the
+/// outer sentence alone would not say it.
+fn failed(provider_id: String, error: &anyhow::Error) -> SigninEvent {
+    let message = error
+        .chain()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(": ");
+    SigninEvent::Failed {
+        provider_id,
+        message,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/leviath-cli/src/commands/setup/signin/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/signin/tests.rs
@@ -1,0 +1,401 @@
+//! The sign-in lane, driven with a canned authorizer so nothing opens a
+//! browser or binds a port.
+
+use super::*;
+use leviath_providers::ProviderGrant;
+
+/// An authorizer that answers from a script.
+struct Canned {
+    /// What a sign-in returns: the identity, or the message to fail with.
+    sign_in: Result<String, String>,
+    /// What a sign-out returns.
+    sign_out: Result<(), String>,
+    /// The URL to announce before answering, when there is one.
+    url: Option<String>,
+}
+
+impl Canned {
+    fn signing_in_as(who: &str) -> Self {
+        Self {
+            sign_in: Ok(who.to_string()),
+            sign_out: Ok(()),
+            url: Some("https://auth.example/authorize?x=1".to_string()),
+        }
+    }
+}
+
+impl ProviderAuthorizer for Canned {
+    async fn sign_in(
+        &self,
+        _provider_id: &str,
+        announce: codex_login::Announce,
+    ) -> anyhow::Result<String> {
+        if let Some(url) = &self.url {
+            announce(url);
+        }
+        self.sign_in
+            .clone()
+            .map_err(|e| anyhow::anyhow!(e).context("could not sign in"))
+    }
+
+    async fn sign_out(&self, _provider_id: &str) -> anyhow::Result<()> {
+        self.sign_out.clone().map_err(|e| anyhow::anyhow!(e))
+    }
+}
+
+/// Run one request through the lane and collect everything it reported.
+async fn drive(authorizer: Canned, action: SigninAction) -> Vec<SigninEvent> {
+    let (request_tx, request_rx) = mpsc::unbounded_channel();
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+    request_tx
+        .send(SigninRequest {
+            provider_id: "codex".to_string(),
+            action,
+        })
+        .unwrap();
+    // Dropping the sender ends the loop once the one request is served.
+    drop(request_tx);
+    signin_loop(authorizer, request_rx, event_tx).await;
+    let mut events = Vec::new();
+    while let Ok(event) = event_rx.try_recv() {
+        events.push(event);
+    }
+    events
+}
+
+/// The URL comes back before the answer does, which is the whole reason the
+/// lane reports more than once per request.
+#[tokio::test]
+async fn a_sign_in_announces_its_url_and_then_who_it_signed_in() {
+    let events = drive(Canned::signing_in_as("a@b.c (plus plan)"), SigninAction::In).await;
+    assert_eq!(events.len(), 2, "{events:?}");
+    match &events[0] {
+        SigninEvent::Opened { provider_id, url } => {
+            assert_eq!(provider_id, "codex");
+            assert!(url.starts_with("https://auth.example/"), "{url}");
+        }
+        other => panic!("expected the URL first, got {other:?}"),
+    }
+    match &events[1] {
+        SigninEvent::SignedIn { who, .. } => assert_eq!(who, "a@b.c (plus plan)"),
+        other => panic!("expected a signed-in event, got {other:?}"),
+    }
+}
+
+/// A sign-out has no URL to announce, so it reports once.
+#[tokio::test]
+async fn a_sign_out_reports_only_that_it_finished() {
+    let events = drive(Canned::signing_in_as("nobody"), SigninAction::Out).await;
+    assert_eq!(events.len(), 1, "{events:?}");
+    assert!(
+        matches!(events[0], SigninEvent::SignedOut { .. }),
+        "{events:?}"
+    );
+}
+
+/// The cause is kept, because the cause is the half that says what to do.
+#[tokio::test]
+async fn a_failed_sign_in_reports_the_whole_chain() {
+    let events = drive(
+        Canned {
+            sign_in: Err("could not listen on port 1455".to_string()),
+            sign_out: Ok(()),
+            url: None,
+        },
+        SigninAction::In,
+    )
+    .await;
+    match &events[..] {
+        [SigninEvent::Failed { message, .. }] => {
+            assert!(message.contains("could not sign in"), "{message}");
+            assert!(message.contains("port 1455"), "{message}");
+        }
+        other => panic!("expected one failure, got {other:?}"),
+    }
+}
+
+/// A failed sign-out is reported the same way.
+#[tokio::test]
+async fn a_failed_sign_out_is_reported_too() {
+    let events = drive(
+        Canned {
+            sign_in: Ok(String::new()),
+            sign_out: Err("the keychain refused".to_string()),
+            url: None,
+        },
+        SigninAction::Out,
+    )
+    .await;
+    match &events[..] {
+        [SigninEvent::Failed { message, .. }] => {
+            assert!(message.contains("keychain"), "{message}");
+        }
+        other => panic!("expected one failure, got {other:?}"),
+    }
+}
+
+/// A wizard that has already closed leaves the lane nothing to report to, and
+/// it stops rather than looping on a dead channel.
+#[tokio::test]
+async fn the_lane_stops_when_the_wizard_is_gone() {
+    let (request_tx, request_rx) = mpsc::unbounded_channel();
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    for _ in 0..2 {
+        request_tx
+            .send(SigninRequest {
+                provider_id: "codex".to_string(),
+                action: SigninAction::Out,
+            })
+            .unwrap();
+    }
+    drop(request_tx);
+    drop(event_rx);
+    // Returns rather than hanging or panicking on the closed reply channel.
+    signin_loop(Canned::signing_in_as("x"), request_rx, event_tx).await;
+}
+
+/// Every event knows which row it belongs to, including the two that carry
+/// nothing else.
+#[test]
+fn every_event_names_its_provider() {
+    let events = [
+        SigninEvent::Opened {
+            provider_id: "a".to_string(),
+            url: String::new(),
+        },
+        SigninEvent::SignedIn {
+            provider_id: "b".to_string(),
+            who: String::new(),
+        },
+        SigninEvent::SignedOut {
+            provider_id: "c".to_string(),
+        },
+        SigninEvent::Failed {
+            provider_id: "d".to_string(),
+            message: String::new(),
+        },
+    ];
+    let named: Vec<&str> = events.iter().map(SigninEvent::provider_id).collect();
+    assert_eq!(named, ["a", "b", "c", "d"]);
+}
+
+/// The identity line prefers the stored fields, falls back to the token's
+/// claims, and still says something for a grant that carries neither.
+#[test]
+fn the_identity_line_falls_back_all_the_way_to_signed_in() {
+    let bare = ProviderGrant {
+        access_token: "at".to_string(),
+        refresh_token: "rt".to_string(),
+        ..Default::default()
+    };
+    assert_eq!(describe(&bare), "signed in");
+
+    let with_email = ProviderGrant {
+        email: Some("someone@example.com".to_string()),
+        ..bare.clone()
+    };
+    assert_eq!(describe(&with_email), "someone@example.com");
+
+    let with_plan = ProviderGrant {
+        plan_type: Some("plus".to_string()),
+        ..with_email
+    };
+    assert_eq!(describe(&with_plan), "someone@example.com (plus plan)");
+}
+
+/// Only Codex signs in with a browser, and anything else is told so rather
+/// than being handed to a flow written for one provider.
+#[tokio::test]
+async fn a_provider_that_does_not_sign_in_is_refused() {
+    let authorizer = LiveAuthorizer {
+        opener: Arc::new(|_: &str| true),
+        store_path: None,
+        credential_store: Ok(None),
+        client: reqwest::Client::new(),
+        issuer: "http://127.0.0.1:1".to_string(),
+        ports: vec![0],
+    };
+    let announce: codex_login::Announce = Arc::new(|_: &str| {});
+    let error = authorizer
+        .sign_in("anthropic", announce)
+        .await
+        .expect_err("anthropic has no browser sign-in");
+    assert!(error.to_string().contains("anthropic"), "{error}");
+    let error = authorizer
+        .sign_out("anthropic")
+        .await
+        .expect_err("nor a browser sign-out");
+    assert!(error.to_string().contains("anthropic"), "{error}");
+}
+
+/// With no home there is nowhere to put a grant, and that is said rather than
+/// guessed at.
+#[tokio::test]
+async fn no_home_is_reported_before_a_browser_opens() {
+    let authorizer = LiveAuthorizer {
+        opener: Arc::new(|_: &str| panic!("no browser may open")),
+        store_path: None,
+        credential_store: Ok(None),
+        client: reqwest::Client::new(),
+        issuer: "http://127.0.0.1:1".to_string(),
+        ports: vec![0],
+    };
+    let announce: codex_login::Announce = Arc::new(|_: &str| {});
+    let error = authorizer
+        .sign_in("codex", announce)
+        .await
+        .expect_err("nowhere to write");
+    assert!(error.to_string().contains("LEVIATH_HOME"), "{error}");
+    let error = authorizer
+        .sign_out("codex")
+        .await
+        .expect_err("nowhere to read");
+    assert!(error.to_string().contains("LEVIATH_HOME"), "{error}");
+}
+
+/// A credential store that could not be opened stops the sign-in instead of
+/// quietly writing the grant to a file the user asked not to use.
+#[tokio::test]
+async fn an_unreachable_keychain_stops_the_sign_in() {
+    let authorizer = LiveAuthorizer {
+        opener: Arc::new(|_: &str| panic!("no browser may open")),
+        store_path: Some(PathBuf::from("/nowhere/provider-auth.json")),
+        credential_store: Err("no keychain on this machine".to_string()),
+        client: reqwest::Client::new(),
+        issuer: "http://127.0.0.1:1".to_string(),
+        ports: vec![0],
+    };
+    let announce: codex_login::Announce = Arc::new(|_: &str| {});
+    let error = authorizer
+        .sign_in("codex", announce)
+        .await
+        .expect_err("the keychain is the store");
+    assert!(error.to_string().contains("no keychain"), "{error}");
+    let error = authorizer
+        .sign_out("codex")
+        .await
+        .expect_err("and the sign-out reads it too");
+    assert!(error.to_string().contains("no keychain"), "{error}");
+}
+
+/// The live authorizer, end to end: a local issuer, a stub browser that plays
+/// the redirect, and a temp file for the grant.
+///
+/// This is the path the wizard actually takes, so it is worth driving rather
+/// than only its refusals. Port zero because the two registered ports are the
+/// production value and a test that bound them would fight whatever the
+/// developer has signed in.
+#[tokio::test]
+async fn a_whole_sign_in_through_the_live_authorizer_reports_the_account() {
+    use crate::commands::auth::codex::tests::{browser_that_redirects, id_token};
+
+    let body = serde_json::json!({
+        "access_token": "at-1",
+        "refresh_token": "rt-1",
+        "id_token": id_token(),
+        "expires_in": 3600,
+    });
+    let issuer = leviath_testkit::spawn_mock_server(200, "OK", body.to_string().into_bytes()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let store_path = dir.path().join("provider-auth.json");
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let authorizer = LiveAuthorizer {
+        opener: browser_that_redirects(Arc::clone(&seen)),
+        store_path: Some(store_path.clone()),
+        credential_store: Ok(None),
+        client: reqwest::Client::new(),
+        issuer,
+        ports: vec![0],
+    };
+
+    let announced = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let sink = Arc::clone(&announced);
+    let announce: codex_login::Announce = Arc::new(move |url: &str| {
+        sink.lock().expect("sink").push(url.to_string());
+    });
+
+    let who = authorizer
+        .sign_in("codex", announce)
+        .await
+        .expect("the whole round trip");
+
+    assert_eq!(who, "someone@example.com (plus plan)");
+    assert_eq!(
+        announced.lock().expect("sink").len(),
+        1,
+        "the URL is announced once, before the browser is asked"
+    );
+    // And the grant really landed, so the sign-out below has something to
+    // remove rather than reporting success over an empty store.
+    let stored = leviath_providers::codex::ProviderAuthStore::load(&store_path)
+        .expect("the store reads back");
+    assert!(stored.get("codex").is_some());
+
+    authorizer.sign_out("codex").await.expect("signs out");
+    let stored = leviath_providers::codex::ProviderAuthStore::load(&store_path)
+        .expect("the store still reads back");
+    assert!(
+        stored.get("codex").is_none(),
+        "the grant outlived the sign-out"
+    );
+}
+
+/// A sign-in that gets as far as the issuer and is refused there reports that,
+/// rather than the wizard sitting on "waiting for your browser" for ever.
+#[tokio::test]
+async fn an_issuer_that_refuses_the_exchange_fails_the_sign_in() {
+    use crate::commands::auth::codex::tests::browser_that_redirects;
+
+    let dir = tempfile::tempdir().unwrap();
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let authorizer = LiveAuthorizer {
+        opener: browser_that_redirects(Arc::clone(&seen)),
+        store_path: Some(dir.path().join("provider-auth.json")),
+        credential_store: Ok(None),
+        client: reqwest::Client::new(),
+        // Nothing listens on port 1, so the code exchange cannot succeed.
+        issuer: "http://127.0.0.1:1".to_string(),
+        ports: vec![0],
+    };
+    let announce: codex_login::Announce = Arc::new(|_: &str| {});
+
+    let error = authorizer
+        .sign_in("codex", announce)
+        .await
+        .expect_err("the issuer never answered");
+    assert!(!error.to_string().is_empty());
+}
+
+/// A grant file that will not parse stops the sign-out rather than reporting
+/// that there was nothing to remove.
+#[tokio::test]
+async fn a_corrupt_grant_file_fails_the_sign_out() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("provider-auth.json");
+    std::fs::write(&path, "{ not json").unwrap();
+    let authorizer = LiveAuthorizer {
+        opener: Arc::new(|_: &str| panic!("no browser may open")),
+        store_path: Some(path),
+        credential_store: Ok(None),
+        client: reqwest::Client::new(),
+        issuer: "http://127.0.0.1:1".to_string(),
+        ports: vec![0],
+    };
+    assert!(authorizer.sign_out("codex").await.is_err());
+}
+
+/// The real authorizer resolves this machine rather than being handed paths.
+#[test]
+fn the_real_authorizer_points_at_this_machine() {
+    let dir = tempfile::tempdir().unwrap();
+    let authorizer =
+        LiveAuthorizer::real(Arc::new(|_: &str| true), &dir.path().join("config.toml"));
+    assert!(
+        authorizer.store_path.is_some(),
+        "a home resolves in a test run"
+    );
+    // A config that does not exist is the default one, whose backend is the
+    // file store: resolving it must not fail.
+    assert!(authorizer.credential_store.is_ok());
+    assert_eq!(authorizer.ports, leviath_providers::codex::CALLBACK_PORTS);
+}

--- a/crates/leviath-cli/src/commands/setup/state/lanes.rs
+++ b/crates/leviath-cli/src/commands/setup/state/lanes.rs
@@ -1,0 +1,187 @@
+//! The two background lanes, and how their answers land on a provider row.
+//!
+//! Both exist for the same reason: the wizard draws on a tick, and anything
+//! that waits on somebody else must not wait on that thread. A credential
+//! check is a round trip; a browser sign-in is a person. Neither belongs in
+//! the draw loop, so each is asked over a channel and drained per tick.
+//!
+//! They are separate lanes rather than one, because a sign-in can hold its
+//! channel open for minutes and would stall every check queued behind it.
+
+use std::collections::HashMap;
+
+use super::{Credential, Outcome, SigninAction, SigninEvent, SigninRequest, Step, VerifyRequest};
+use super::{Wizard, catalog};
+
+impl Wizard {
+    /// Ask the background verifier about the provider at `index`.
+    ///
+    /// A provider with nothing to check is left alone rather than queued: a
+    /// blank API key would fail with a message about the key rather than saying
+    /// the obvious, that none was given.
+    pub(crate) fn request_verification(&mut self, index: usize) {
+        if self.is_endpoint_preset(index) {
+            self.verify_endpoints_under(index);
+            return;
+        }
+        let Some(row) = self.providers.get_mut(index) else {
+            return;
+        };
+        if !row.has_credential() {
+            row.outcome = Outcome::Skipped;
+            return;
+        }
+        let id = row.provider.id.to_string();
+        let key = if row.value.is_empty() {
+            self.env_only
+                .get(row.provider.env_var.unwrap_or_default())
+                .cloned()
+        } else {
+            Some(row.value.clone())
+        };
+        let base_url = (row.provider.credential == Credential::BaseUrl).then(|| {
+            if row.value.is_empty() {
+                catalog::DEFAULT_OLLAMA_URL.to_string()
+            } else {
+                row.value.clone()
+            }
+        });
+        let signin = row.provider.credential == Credential::Signin;
+        row.checking = true;
+
+        // A sign-in provider is built from a grant on disk rather than from
+        // anything on this screen, and the registry is deliberately unwilling
+        // to guess where that grant lives. Built the same way a run builds it,
+        // so the wizard cannot report a sign-in working that a run would not
+        // find.
+        let options = if signin {
+            crate::commands::run::session::codex_options(&self.base)
+        } else {
+            HashMap::new()
+        };
+        let creds = leviath_runtime::provider_creds::ProviderCreds {
+            name: id.clone(),
+            api_key: base_url.is_none().then_some(key).flatten(),
+            base_url,
+            model_capabilities: HashMap::new(),
+            request_timeout_secs: Some(20),
+            rate_limit: None,
+            options,
+        };
+        // A closed receiver means the background task is gone; the row simply
+        // stays "checking" and nothing else breaks.
+        let _ = self.verify_tx.send(VerifyRequest {
+            provider_id: id,
+            creds,
+        });
+    }
+
+    /// Ask about every selected provider at once.
+    pub(crate) fn verify_all(&mut self) {
+        for index in self.selected_providers() {
+            self.request_verification(index);
+        }
+    }
+
+    /// Take whatever the background verifier has answered.
+    pub(crate) fn drain_verifications(&mut self) {
+        let mut landed = false;
+        while let Ok(reply) = self.reply_rx.try_recv() {
+            // Entries first: an entry is named after its preset by default
+            // (`llama-cpp`), and the preset's own row never asks for a check
+            // under its id, so a reply carrying that name is the entry's.
+            if self.settle_endpoint_reply(&reply) {
+                landed = true;
+            } else if let Some(row) = self
+                .providers
+                .iter_mut()
+                .find(|r| r.provider.id == reply.provider_id)
+            {
+                row.checking = false;
+                row.outcome = reply.outcome;
+                landed = true;
+            }
+        }
+        // A reply carries the model list, and the picker was built from
+        // whatever had arrived when the screen opened. Without this, moving on
+        // from a credential and straight into Defaults shows an empty picker
+        // for the provider that was verified half a second ago. Rebuilding
+        // keeps the current selection, so nothing the user chose is lost.
+        if landed && self.step == Step::Defaults {
+            self.rebuild_defaults();
+        }
+    }
+
+    // ── Signing in ──────────────────────────────────────────────────────────
+
+    /// Send the provider at `index` to the sign-in lane.
+    ///
+    /// The row goes into its waiting state here rather than when the lane
+    /// picks the request up, so the screen changes on the key press instead of
+    /// a tick or two later. Selecting the provider is implied: someone who
+    /// signs in has said what they want more clearly than a checkbox does.
+    pub(crate) fn request_signin(&mut self, index: usize, action: SigninAction) {
+        let Some(row) = self.providers.get_mut(index) else {
+            return;
+        };
+        let id = row.provider.id.to_string();
+        if action == SigninAction::In {
+            row.signing_in = true;
+            row.authorize_url = None;
+            row.selected = true;
+            self.dirty = true;
+        }
+        // The old check described the old account. Leaving it up through a
+        // sign-out would show a green tick beside "Not signed in".
+        row.outcome = Outcome::Skipped;
+        self.message = Some(
+            match action {
+                SigninAction::In => "Opening your browser…",
+                SigninAction::Out => "Signing out…",
+            }
+            .to_string(),
+        );
+        // A closed receiver means the lane is gone; the row stays as it is and
+        // nothing else breaks.
+        let _ = self.signin_tx.send(SigninRequest {
+            provider_id: id,
+            action,
+        });
+    }
+
+    /// Take whatever the sign-in lane has reported.
+    pub(crate) fn drain_signins(&mut self) {
+        while let Ok(event) = self.signin_reply_rx.try_recv() {
+            let Some(row) = self
+                .providers
+                .iter_mut()
+                .find(|r| r.provider.id == event.provider_id())
+            else {
+                continue;
+            };
+            match event {
+                SigninEvent::Opened { url, .. } => {
+                    row.authorize_url = Some(url);
+                }
+                SigninEvent::SignedIn { who, .. } => {
+                    row.signing_in = false;
+                    row.authorize_url = None;
+                    row.signed_in = Some(who);
+                    self.message = Some("Signed in. Check it to confirm it works.".to_string());
+                }
+                SigninEvent::SignedOut { .. } => {
+                    row.signing_in = false;
+                    row.authorize_url = None;
+                    row.signed_in = None;
+                    self.message = Some("Signed out. The provider is still enabled.".to_string());
+                }
+                SigninEvent::Failed { message, .. } => {
+                    row.signing_in = false;
+                    row.authorize_url = None;
+                    row.outcome = Outcome::Failed { message };
+                    self.message = None;
+                }
+            }
+        }
+    }
+}

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -2848,6 +2848,10 @@ pub(super) mod tests {
             .expect("the codex row is offered");
 
         let mut row = wizard.providers[index].clone();
+        // Set explicitly rather than assumed: `Wizard::new` reads the grant
+        // store under a process-wide `$LEVIATH_HOME`, so what this row arrives
+        // holding depends on what else is running.
+        row.signed_in = None;
         assert!(!row.has_credential());
         row.signed_in = Some("someone@example.com (plus plan)".to_string());
         assert!(row.has_credential());
@@ -2868,7 +2872,14 @@ pub(super) mod tests {
         assert_eq!(wizard.row_count(), 0);
     }
 
-    /// The codex row at its index, on a wizard whose only selection it is.
+    /// The codex row at its index, on a wizard whose only selection it is and
+    /// which is signed in to nothing.
+    ///
+    /// `signed_in` is cleared rather than trusted. `Wizard::new` reads the
+    /// grant store under `$LEVIATH_HOME`, `temp_env` sets that for the whole
+    /// process, and another test writing a grant into its own temp home is
+    /// visible here while it runs. Depending on that made this fail on
+    /// whichever platform lost the race - Windows, as it happened.
     fn wizard_showing_codex(agents_dir: &std::path::Path) -> (Wizard, usize) {
         let mut wizard = test_wizard(agents_dir);
         let index = wizard
@@ -2878,6 +2889,7 @@ pub(super) mod tests {
             .expect("the codex row is offered");
         for row in &mut wizard.providers {
             row.selected = false;
+            row.signed_in = None;
         }
         wizard.providers[index].selected = true;
         wizard.step = Step::ProviderDetail;
@@ -3095,8 +3107,20 @@ pub(super) mod tests {
                 who: "nobody".to_string(),
             })
             .unwrap();
+        let before: Vec<Option<String>> = wizard
+            .providers
+            .iter()
+            .map(|r| r.signed_in.clone())
+            .collect();
+
         wizard.drain_signins();
-        assert!(wizard.providers.iter().all(|r| r.signed_in.is_none()));
+
+        let after: Vec<Option<String>> = wizard
+            .providers
+            .iter()
+            .map(|r| r.signed_in.clone())
+            .collect();
+        assert_eq!(before, after, "an event landed on a row it was not for");
     }
 
     /// A sign-in provider is checked through the grant on disk, so the

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -22,6 +22,7 @@ use crate::config::Config;
 // existing `state::Wizard` path keeps working.
 mod endpoints;
 pub(crate) use endpoints::*;
+mod lanes;
 mod limits;
 use limits::*;
 mod types;
@@ -85,6 +86,13 @@ pub struct Wizard {
     reply_tx: mpsc::UnboundedSender<VerifyReply>,
     /// Where finished checks arrive, drained once per tick.
     pub reply_rx: mpsc::UnboundedReceiver<VerifyReply>,
+    /// Where a browser sign-in is sent. Its own lane, for the reason
+    /// [`SigninRequest`] gives.
+    pub signin_tx: mpsc::UnboundedSender<SigninRequest>,
+    signin_rx: Option<mpsc::UnboundedReceiver<SigninRequest>>,
+    signin_reply_tx: mpsc::UnboundedSender<SigninEvent>,
+    /// Where the sign-in lane reports, drained on the same tick as the checks.
+    pub signin_reply_rx: mpsc::UnboundedReceiver<SigninEvent>,
     /// Tick counter, for the spinner.
     pub ticks: u64,
     /// First visible row of the current step, so a screen taller than the
@@ -121,22 +129,22 @@ fn env_credentials(lookup: &dyn Fn(&str) -> Option<String>) -> HashMap<&'static 
         .collect()
 }
 
-/// Who is signed in to `provider`, as a line to show, or `None`.
+/// Who is signed in to `provider`, as a line to show, or `None` when nobody
+/// is.
 ///
-/// Read once when the wizard is built. A grant taken while the wizard is open
-/// is not picked up, which is the honest reflection of the flow: signing in is
-/// a separate command, and the wizard is showing what was true when it opened.
+/// Read when the wizard is built; a sign-in taken from inside the wizard
+/// updates the row from what the lane reports rather than by re-reading this.
+///
+/// A grant whose token carries no email still counts as signed in. It is the
+/// grant that decides whether the provider can answer, and reporting "not
+/// signed in" because a claim was missing would offer a second sign-in that
+/// replaces a working one.
 fn signed_in_as(path: Option<&std::path::Path>, provider: &str) -> Option<String> {
     let grant = leviath_providers::codex::ProviderAuthStore::load(path?)
         .ok()?
         .get(provider)
         .cloned()?;
-    let claims = grant.claims();
-    let who = grant.email.or(claims.email)?;
-    Some(match grant.plan_type.or(claims.plan_type) {
-        Some(plan) => format!("{who} ({plan} plan)"),
-        None => who,
-    })
+    Some(super::signin::describe(&grant))
 }
 
 impl Wizard {
@@ -180,6 +188,8 @@ impl Wizard {
                     outcome: Outcome::Skipped,
                     checking: false,
                     signed_in,
+                    signing_in: false,
+                    authorize_url: None,
                     provider,
                 }
             })
@@ -230,6 +240,8 @@ impl Wizard {
 
         let (verify_tx, verify_rx) = mpsc::unbounded_channel();
         let (reply_tx, reply_rx) = mpsc::unbounded_channel();
+        let (signin_tx, signin_rx) = mpsc::unbounded_channel();
+        let (signin_reply_tx, signin_reply_rx) = mpsc::unbounded_channel();
 
         let endpoints = Self::endpoints_from_config(&base);
         let mut wizard = Self {
@@ -258,6 +270,10 @@ impl Wizard {
             verify_rx: Some(verify_rx),
             reply_tx,
             reply_rx,
+            signin_tx,
+            signin_rx: Some(signin_rx),
+            signin_reply_tx,
+            signin_reply_rx,
             ticks: 0,
             scroll: 0,
             show_advanced: false,
@@ -278,6 +294,19 @@ impl Wizard {
         mpsc::UnboundedSender<VerifyReply>,
     )> {
         self.verify_rx.take().map(|rx| (rx, self.reply_tx.clone()))
+    }
+
+    /// Hand the background sign-in lane its channel ends. Returns `None` if
+    /// already taken.
+    pub fn take_signin_ends(
+        &mut self,
+    ) -> Option<(
+        mpsc::UnboundedReceiver<SigninRequest>,
+        mpsc::UnboundedSender<SigninEvent>,
+    )> {
+        self.signin_rx
+            .take()
+            .map(|rx| (rx, self.signin_reply_tx.clone()))
     }
 
     // ── Rows and navigation ─────────────────────────────────────────────────
@@ -328,12 +357,62 @@ impl Wizard {
         if self.is_endpoint_preset(index) {
             return Vec::new();
         }
+        let row = &self.providers[index];
+        if row.provider.credential == Credential::Signin {
+            return Self::signin_actions(row);
+        }
         let mut actions = Vec::new();
-        if self.providers[index].provider.signup_url.is_some() {
+        if row.provider.signup_url.is_some() {
             actions.push(DetailAction::OpenSignup);
         }
         actions.push(DetailAction::Verify);
         actions
+    }
+
+    /// The buttons on a browser sign-in's screen, in the order they are
+    /// offered.
+    ///
+    /// Nothing is typed here, so these are the whole screen and the first of
+    /// them is what the cursor lands on. That decides the order: the thing
+    /// somebody opening this card came to do goes first, which is the sign-in
+    /// while there is none and the check once there is. Sign out and the plans
+    /// page are both further down because neither is why anyone is here.
+    ///
+    /// Sign out is offered only when there is something to forget, and the
+    /// check only when there is something to check: an unsigned-in row would
+    /// answer "no credential" to a question the line above it already
+    /// answered.
+    fn signin_actions(row: &ProviderRow) -> Vec<DetailAction> {
+        let mut actions = Vec::new();
+        if row.signed_in.is_some() {
+            actions.push(DetailAction::Verify);
+        }
+        actions.push(DetailAction::SignIn);
+        if row.signed_in.is_some() {
+            actions.push(DetailAction::SignOut);
+        }
+        // Where to get a subscription, for somebody who does not have one yet.
+        actions.extend(row.provider.signup_url.map(|_| DetailAction::OpenSignup));
+        actions
+    }
+
+    /// Whether the credential screen's first row is the credential itself.
+    ///
+    /// It is for everything typed or defaulted. A browser sign-in has nothing
+    /// to type, so its status is a line rather than a row and the buttons
+    /// start at the top: without this, Enter on a sign-in provider opened a
+    /// text editor over a credential that does not exist.
+    pub(crate) fn detail_has_credential_row(&self, index: usize) -> bool {
+        self.providers[index].provider.credential != Credential::Signin
+    }
+
+    /// Which action the cursor is on, accounting for whether a credential row
+    /// sits above them.
+    pub(crate) fn detail_action_at(&self, index: usize, cursor: usize) -> Option<DetailAction> {
+        let offset = usize::from(self.detail_has_credential_row(index));
+        self.detail_actions()
+            .get(cursor.checked_sub(offset)?)
+            .copied()
     }
 
     /// How many selectable rows the current step has.
@@ -343,7 +422,9 @@ impl Wizard {
             Step::Providers => self.providers.len(),
             Step::ProviderDetail => match self.detail_row() {
                 Some(index) if self.is_endpoint_preset(index) => self.endpoint_row_count(index),
-                Some(_) => 1 + self.detail_actions().len(),
+                Some(index) => {
+                    usize::from(self.detail_has_credential_row(index)) + self.detail_actions().len()
+                }
                 None => 0,
             },
             Step::Defaults => self.defaults.len(),
@@ -532,95 +613,6 @@ impl Wizard {
             return true;
         }
         false
-    }
-
-    // ── Verification ────────────────────────────────────────────────────────
-
-    /// Ask the background verifier about the provider at `index`.
-    ///
-    /// A provider with nothing to check is left alone rather than queued: a
-    /// blank API key would fail with a message about the key rather than saying
-    /// the obvious, that none was given.
-    pub(crate) fn request_verification(&mut self, index: usize) {
-        if self.is_endpoint_preset(index) {
-            self.verify_endpoints_under(index);
-            return;
-        }
-        let Some(row) = self.providers.get_mut(index) else {
-            return;
-        };
-        if !row.has_credential() {
-            row.outcome = Outcome::Skipped;
-            return;
-        }
-        let id = row.provider.id.to_string();
-        let key = if row.value.is_empty() {
-            self.env_only
-                .get(row.provider.env_var.unwrap_or_default())
-                .cloned()
-        } else {
-            Some(row.value.clone())
-        };
-        let base_url = (row.provider.credential == Credential::BaseUrl).then(|| {
-            if row.value.is_empty() {
-                catalog::DEFAULT_OLLAMA_URL.to_string()
-            } else {
-                row.value.clone()
-            }
-        });
-        row.checking = true;
-
-        let creds = leviath_runtime::provider_creds::ProviderCreds {
-            name: id.clone(),
-            api_key: base_url.is_none().then_some(key).flatten(),
-            base_url,
-            model_capabilities: HashMap::new(),
-            request_timeout_secs: Some(20),
-            rate_limit: None,
-            options: HashMap::new(),
-        };
-        // A closed receiver means the background task is gone; the row simply
-        // stays "checking" and nothing else breaks.
-        let _ = self.verify_tx.send(VerifyRequest {
-            provider_id: id,
-            creds,
-        });
-    }
-
-    /// Ask about every selected provider at once.
-    pub(crate) fn verify_all(&mut self) {
-        for index in self.selected_providers() {
-            self.request_verification(index);
-        }
-    }
-
-    /// Take whatever the background verifier has answered.
-    pub(crate) fn drain_verifications(&mut self) {
-        let mut landed = false;
-        while let Ok(reply) = self.reply_rx.try_recv() {
-            // Entries first: an entry is named after its preset by default
-            // (`llama-cpp`), and the preset's own row never asks for a check
-            // under its id, so a reply carrying that name is the entry's.
-            if self.settle_endpoint_reply(&reply) {
-                landed = true;
-            } else if let Some(row) = self
-                .providers
-                .iter_mut()
-                .find(|r| r.provider.id == reply.provider_id)
-            {
-                row.checking = false;
-                row.outcome = reply.outcome;
-                landed = true;
-            }
-        }
-        // A reply carries the model list, and the picker was built from
-        // whatever had arrived when the screen opened. Without this, moving on
-        // from a credential and straight into Defaults shows an empty picker
-        // for the provider that was verified half a second ago. Rebuilding
-        // keeps the current selection, so nothing the user chose is lost.
-        if landed && self.step == Step::Defaults {
-            self.rebuild_defaults();
-        }
     }
 
     /// What choosing one of these values actually decides.
@@ -2819,7 +2811,10 @@ pub(super) mod tests {
                 Some("someone@example.com")
             );
 
-            // A grant with no account at all is not something to report.
+            // A grant with no account at all still counts as signed in. The
+            // grant is what lets the provider answer, and reporting "not
+            // signed in" over a missing claim would offer to replace a
+            // working sign-in.
             let mut store = leviath_providers::codex::ProviderAuthStore::default();
             store.set(
                 "codex",
@@ -2830,7 +2825,10 @@ pub(super) mod tests {
                 },
             );
             store.save(&path).unwrap();
-            assert_eq!(signed_in_as(Some(&path), "codex"), None);
+            assert_eq!(
+                signed_in_as(Some(&path), "codex").as_deref(),
+                Some("signed in")
+            );
 
             // And a provider nobody has signed in to.
             assert_eq!(signed_in_as(Some(&path), "someone-else"), None);
@@ -2853,5 +2851,278 @@ pub(super) mod tests {
         assert!(!row.has_credential());
         row.signed_in = Some("someone@example.com (plus plan)".to_string());
         assert!(row.has_credential());
+    }
+
+    /// With nothing selected the credential screen has no provider to show,
+    /// so it offers no buttons rather than the first row's.
+    #[test]
+    fn a_credential_screen_with_no_provider_offers_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = test_wizard(dir.path());
+        for row in &mut wizard.providers {
+            row.selected = false;
+        }
+        wizard.step = Step::ProviderDetail;
+
+        assert!(wizard.detail_actions().is_empty());
+        assert_eq!(wizard.row_count(), 0);
+    }
+
+    /// The codex row at its index, on a wizard whose only selection it is.
+    fn wizard_showing_codex(agents_dir: &std::path::Path) -> (Wizard, usize) {
+        let mut wizard = test_wizard(agents_dir);
+        let index = wizard
+            .providers
+            .iter()
+            .position(|r| r.provider.id == "codex")
+            .expect("the codex row is offered");
+        for row in &mut wizard.providers {
+            row.selected = false;
+        }
+        wizard.providers[index].selected = true;
+        wizard.step = Step::ProviderDetail;
+        (wizard, index)
+    }
+
+    /// The buttons on offer follow the sign-in, because two of the three do
+    /// nothing without one.
+    #[test]
+    fn a_sign_in_row_offers_more_once_it_is_signed_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut wizard, index) = wizard_showing_codex(dir.path());
+
+        assert_eq!(
+            wizard.detail_actions(),
+            vec![DetailAction::SignIn, DetailAction::OpenSignup]
+        );
+        // No credential row, so the buttons are the whole screen, and the
+        // first is the one this screen exists for.
+        assert!(!wizard.detail_has_credential_row(index));
+        assert_eq!(wizard.row_count(), 2);
+        assert_eq!(
+            wizard.detail_action_at(index, 0),
+            Some(DetailAction::SignIn)
+        );
+
+        wizard.providers[index].signed_in = Some("a@b.c".to_string());
+        assert_eq!(
+            wizard.detail_actions(),
+            vec![
+                DetailAction::Verify,
+                DetailAction::SignIn,
+                DetailAction::SignOut,
+                DetailAction::OpenSignup,
+            ],
+            "once signed in, checking it is what somebody came here to do"
+        );
+        assert_eq!(wizard.row_count(), 4);
+    }
+
+    /// A typed provider still has its credential above the buttons, so the
+    /// offset is not a blanket change.
+    #[test]
+    fn a_typed_row_still_starts_with_its_credential() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = test_wizard(dir.path());
+        let index = wizard
+            .providers
+            .iter()
+            .position(|r| r.provider.id == "anthropic")
+            .expect("the anthropic row is offered");
+        for row in &mut wizard.providers {
+            row.selected = false;
+        }
+        wizard.providers[index].selected = true;
+        wizard.step = Step::ProviderDetail;
+
+        assert!(wizard.detail_has_credential_row(index));
+        assert_eq!(wizard.detail_action_at(index, 0), None, "row 0 is the key");
+        assert_eq!(
+            wizard.detail_action_at(index, 1),
+            Some(DetailAction::OpenSignup)
+        );
+        assert_eq!(wizard.row_count(), 3);
+    }
+
+    /// Asking to sign in puts the row into its waiting state at the key press
+    /// rather than a tick later, selects the provider, and sends the request.
+    #[test]
+    fn requesting_a_sign_in_shows_it_waiting_and_sends_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut wizard, index) = wizard_showing_codex(dir.path());
+        wizard.providers[index].selected = false;
+        wizard.providers[index].outcome = Outcome::Reachable {
+            models: vec!["gpt-5.6-sol".to_string()],
+        };
+        let (mut requests, _events) = wizard.take_signin_ends().expect("first take");
+
+        wizard.request_signin(index, SigninAction::In);
+
+        assert!(wizard.providers[index].signing_in);
+        assert!(
+            wizard.providers[index].selected,
+            "signing in says what a checkbox says, only louder"
+        );
+        assert!(wizard.dirty);
+        assert_eq!(
+            wizard.providers[index].outcome,
+            Outcome::Skipped,
+            "the old check described the account being replaced"
+        );
+        let request = requests.try_recv().expect("the lane was asked");
+        assert_eq!(request.provider_id, "codex");
+        assert_eq!(request.action, SigninAction::In);
+    }
+
+    /// A sign-out asks without claiming the browser is open.
+    #[test]
+    fn requesting_a_sign_out_does_not_show_a_browser_waiting() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut wizard, index) = wizard_showing_codex(dir.path());
+        let (mut requests, _events) = wizard.take_signin_ends().expect("first take");
+
+        wizard.request_signin(index, SigninAction::Out);
+
+        assert!(!wizard.providers[index].signing_in);
+        assert_eq!(
+            requests.try_recv().expect("the lane was asked").action,
+            SigninAction::Out
+        );
+    }
+
+    /// An index no row has is a no-op rather than a panic.
+    #[test]
+    fn an_out_of_range_sign_in_request_is_a_no_op() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut wizard, _) = wizard_showing_codex(dir.path());
+        let (mut requests, _events) = wizard.take_signin_ends().expect("first take");
+        wizard.request_signin(999, SigninAction::In);
+        assert!(requests.try_recv().is_err());
+    }
+
+    /// The lane's ends can only be taken once, like the verifier's.
+    #[test]
+    fn the_sign_in_channel_ends_can_only_be_taken_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut wizard, _) = wizard_showing_codex(dir.path());
+        assert!(wizard.take_signin_ends().is_some());
+        assert!(wizard.take_signin_ends().is_none());
+    }
+
+    /// What the lane reports lands on the row: the URL while it waits, then
+    /// the identity, and the waiting state clears either way.
+    #[test]
+    fn a_finished_sign_in_settles_the_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut wizard, index) = wizard_showing_codex(dir.path());
+        let (_requests, events) = wizard.take_signin_ends().expect("first take");
+        wizard.providers[index].signing_in = true;
+
+        events
+            .send(SigninEvent::Opened {
+                provider_id: "codex".to_string(),
+                url: "https://auth.example/go".to_string(),
+            })
+            .unwrap();
+        wizard.drain_signins();
+        assert_eq!(
+            wizard.providers[index].authorize_url.as_deref(),
+            Some("https://auth.example/go")
+        );
+        assert!(wizard.providers[index].signing_in, "still waiting");
+
+        events
+            .send(SigninEvent::SignedIn {
+                provider_id: "codex".to_string(),
+                who: "a@b.c (plus plan)".to_string(),
+            })
+            .unwrap();
+        wizard.drain_signins();
+        assert!(!wizard.providers[index].signing_in);
+        assert_eq!(wizard.providers[index].authorize_url, None);
+        assert_eq!(
+            wizard.providers[index].signed_in.as_deref(),
+            Some("a@b.c (plus plan)")
+        );
+    }
+
+    /// A sign-out clears the identity, and a failure lands where a failed
+    /// check would so the card has one place to look.
+    #[test]
+    fn a_sign_out_and_a_failure_both_settle_the_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut wizard, index) = wizard_showing_codex(dir.path());
+        let (_requests, events) = wizard.take_signin_ends().expect("first take");
+        wizard.providers[index].signed_in = Some("a@b.c".to_string());
+        wizard.providers[index].signing_in = true;
+
+        events
+            .send(SigninEvent::SignedOut {
+                provider_id: "codex".to_string(),
+            })
+            .unwrap();
+        wizard.drain_signins();
+        assert_eq!(wizard.providers[index].signed_in, None);
+        assert!(!wizard.providers[index].signing_in);
+
+        wizard.providers[index].signing_in = true;
+        events
+            .send(SigninEvent::Failed {
+                provider_id: "codex".to_string(),
+                message: "could not listen on port 1455".to_string(),
+            })
+            .unwrap();
+        wizard.drain_signins();
+        assert!(!wizard.providers[index].signing_in);
+        assert_eq!(
+            wizard.providers[index].outcome,
+            Outcome::Failed {
+                message: "could not listen on port 1455".to_string()
+            }
+        );
+    }
+
+    /// An event for a row that is not on this wizard is dropped rather than
+    /// landing on whichever row happens to be first.
+    #[test]
+    fn an_event_for_an_unknown_provider_is_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut wizard, _) = wizard_showing_codex(dir.path());
+        let (_requests, events) = wizard.take_signin_ends().expect("first take");
+        events
+            .send(SigninEvent::SignedIn {
+                provider_id: "not-a-provider".to_string(),
+                who: "nobody".to_string(),
+            })
+            .unwrap();
+        wizard.drain_signins();
+        assert!(wizard.providers.iter().all(|r| r.signed_in.is_none()));
+    }
+
+    /// A sign-in provider is checked through the grant on disk, so the
+    /// request has to carry where that grant is - the registry refuses to
+    /// guess, and a check with no path would report the provider missing.
+    #[test]
+    fn checking_a_sign_in_provider_says_where_its_grant_lives() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut wizard, index) = wizard_showing_codex(dir.path());
+        wizard.providers[index].signed_in = Some("a@b.c".to_string());
+        let (mut requests, _replies) = wizard.take_verify_ends().expect("first take");
+
+        wizard.request_verification(index);
+
+        let request = requests.try_recv().expect("the verifier was asked");
+        assert_eq!(request.creds.name, "codex");
+        assert!(
+            request.creds.api_key.is_none(),
+            "a sign-in provider has no key to send"
+        );
+        // Bound rather than formatted inline: a call that only runs when the
+        // assertion fails is a region no passing test reaches.
+        let named: Vec<&String> = request.creds.options.keys().collect();
+        assert!(
+            request.creds.options.contains_key("auth_store_path"),
+            "{named:?}"
+        );
     }
 }

--- a/crates/leviath-cli/src/commands/setup/state/types.rs
+++ b/crates/leviath-cli/src/commands/setup/state/types.rs
@@ -82,8 +82,20 @@ pub struct ProviderRow {
     pub checking: bool,
 
     /// For a [`Credential::Signin`] row, who is signed in, as a line to show.
-    /// `None` means nobody is. Read once when the wizard is built.
+    /// `None` means nobody is. Read when the wizard is built, and again from
+    /// whatever a finished sign-in reports.
     pub signed_in: Option<String>,
+    /// A sign-in is in flight: the browser is open and the user is somewhere
+    /// in it. Minutes, not the second a credential check takes, which is why
+    /// this is its own flag rather than reusing `checking`.
+    pub signing_in: bool,
+    /// The authorize URL of the sign-in in flight.
+    ///
+    /// Shown rather than only opened. The opener silently does nothing over
+    /// SSH and in a bare console, and without the URL on screen the wizard
+    /// would sit on "waiting for your browser" with no browser and no way for
+    /// the user to find out why.
+    pub authorize_url: Option<String>,
 }
 
 impl ProviderRow {
@@ -146,6 +158,10 @@ pub(crate) use crate::tui::widgets::picker::{Picker, PickerOption};
 pub(crate) enum DetailAction {
     /// Open the provider's signup or key page in a browser.
     OpenSignup,
+    /// Take a browser sign-in for a [`Credential::Signin`] provider.
+    SignIn,
+    /// Forget the stored sign-in.
+    SignOut,
     /// Check the credential against the provider.
     Verify,
 }
@@ -153,9 +169,28 @@ pub(crate) enum DetailAction {
 impl DetailAction {
     /// The button's text, which names the provider so the row says what it
     /// will do rather than what it is called.
-    pub(crate) fn label(self, provider: &str) -> String {
+    ///
+    /// Takes the row rather than the display name because two of these read
+    /// differently depending on what the provider wants. A sign-in provider
+    /// has no key page to open, and its sign-in button is an offer the first
+    /// time and a warning after that: doing it again replaces the account
+    /// every run is currently billed to.
+    pub(crate) fn label(self, row: &ProviderRow) -> String {
+        let provider = row.provider.display;
         match self {
+            // Unnamed, unlike the key-page button. This provider's display
+            // name is a sentence ("OpenAI Codex (ChatGPT subscription)"), it
+            // is already the heading two lines above, and a button that
+            // repeats it reads as a different provider's.
+            Self::OpenSignup if row.provider.credential == Credential::Signin => {
+                "Open the subscription plans page".to_string()
+            }
             Self::OpenSignup => format!("Open the {provider} key page"),
+            Self::SignIn if row.signed_in.is_some() => {
+                "Sign in again, as a different account".to_string()
+            }
+            Self::SignIn => "Sign in with your browser".to_string(),
+            Self::SignOut => "Sign out".to_string(),
             Self::Verify => "Check this credential".to_string(),
         }
     }
@@ -242,6 +277,76 @@ pub struct VerifyReply {
     pub provider_id: String,
     /// What the check concluded.
     pub outcome: Outcome,
+}
+
+/// Asked of the background sign-in lane.
+///
+/// A lane of its own rather than another kind of [`VerifyRequest`], because
+/// the two wait for entirely different things. A credential check is a round
+/// trip and the verifier runs them one after another; a sign-in waits for a
+/// person to find their password, and putting it in that queue would stall
+/// every check behind it for as long as the browser stayed open.
+#[derive(Debug, Clone)]
+pub struct SigninRequest {
+    /// Which provider to act on, matching the row that asked.
+    pub provider_id: String,
+    /// Whether to take a sign-in or forget the one that is stored.
+    pub action: SigninAction,
+}
+
+/// What a [`SigninRequest`] asks for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SigninAction {
+    /// Open the browser and store what comes back.
+    In,
+    /// Forget the stored grant. Leaves `config.toml` alone: signing out is
+    /// not the same as turning the provider off.
+    Out,
+}
+
+/// Reported by the background sign-in lane, possibly more than once per
+/// request: the URL comes back as soon as it exists, long before the person
+/// has finished with it.
+#[derive(Debug, Clone)]
+pub enum SigninEvent {
+    /// The authorize URL, ready to be opened or copied.
+    Opened {
+        /// Which provider's sign-in this belongs to.
+        provider_id: String,
+        /// Where to go.
+        url: String,
+    },
+    /// A sign-in finished and this is who it was for.
+    SignedIn {
+        /// Which provider signed in.
+        provider_id: String,
+        /// The identity line to show, already formatted.
+        who: String,
+    },
+    /// A sign-out finished.
+    SignedOut {
+        /// Which provider signed out.
+        provider_id: String,
+    },
+    /// Neither finished, and this is why.
+    Failed {
+        /// Which provider was being acted on.
+        provider_id: String,
+        /// What went wrong, shown on the card.
+        message: String,
+    },
+}
+
+impl SigninEvent {
+    /// Which row this belongs to.
+    pub(crate) fn provider_id(&self) -> &str {
+        match self {
+            Self::Opened { provider_id, .. }
+            | Self::SignedIn { provider_id, .. }
+            | Self::SignedOut { provider_id }
+            | Self::Failed { provider_id, .. } => provider_id,
+        }
+    }
 }
 
 /// Where the text being typed goes when it is committed.

--- a/crates/leviath-cli/src/commands/setup/verify.rs
+++ b/crates/leviath-cli/src/commands/setup/verify.rs
@@ -14,6 +14,13 @@
 //! proves the credential and returns the model list the wizard's default-model
 //! picker needs. Two answers for the price of one round trip.
 //!
+//! The call made is
+//! [`check_credential`](leviath_providers::Provider::check_credential), which
+//! is that same listing for all of those and something else for a provider
+//! whose catalogue is a compiled-in table. Codex is the one that has to
+//! differ: its list is a table, so listing it proves nothing, and it answers
+//! the check from an authenticated route instead.
+//!
 //! ## The seam
 //!
 //! [`ProviderVerifier`] exists so no test ever reaches the network. Tests use a
@@ -133,7 +140,7 @@ pub(crate) async fn verify_via_registry_with(
             message: format!("no provider named '{}'", creds.name),
         };
     };
-    match provider.list_models().await {
+    match provider.check_credential().await {
         Ok(models) => Outcome::Reachable {
             models: models.into_iter().map(|m| m.id).collect(),
         },

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -784,6 +784,7 @@ fn open_controlling_tty() -> io::Result<File> {
 /// never instantiates it, so no unit test can reach the network through it.
 async fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
     use commands::setup::{SetupEnv, import, verification_loop};
+    use leviath_cli::commands::setup::signin::{LiveAuthorizer, signin_loop};
     use leviath_cli::commands::setup::verify::{LiveVerifier, SkipVerifier};
 
     let home = leviath_cli::config::leviath_home_dir().unwrap_or_default();
@@ -826,6 +827,10 @@ async fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
         } else {
             tokio::spawn(verification_loop(LiveVerifier, requests, replies));
         }
+    }
+    if let Some((requests, events)) = wizard.take_signin_ends() {
+        let authorizer = LiveAuthorizer::real(env.opener.clone(), &env.config_path);
+        tokio::spawn(signin_loop(authorizer, requests, events));
     }
     let mut setup = CrosstermSetup {
         viewport: Viewport::Fullscreen,

--- a/crates/leviath-providers/src/codex/provider.rs
+++ b/crates/leviath-providers/src/codex/provider.rs
@@ -292,7 +292,17 @@ impl CodexProvider {
             .send()
             .await
             .map_err(|e| ProviderError::transport("reading the subscription quota", &e))?;
+        let status = response.status().as_u16();
         let body = response.text().await.unwrap_or_default();
+        // Read before the body is parsed, because a rejected request answers
+        // with a perfectly well-formed error document and parsing it first
+        // turns "your session was revoked" into "not in a known shape".
+        if status == 401 || status == 403 {
+            return Err(ProviderError::Unavailable {
+                reason: UnavailableReason::AuthFailed,
+                detail: format!("the quota route answered HTTP {status}"),
+            });
+        }
         usage::parse(&body).ok_or_else(|| {
             ProviderError::InvalidResponse(
                 "the quota response was not in a known shape".to_string(),
@@ -405,6 +415,27 @@ impl Provider for CodexProvider {
                     .named(Some((*display).to_string()))
             })
             .collect())
+    }
+
+    /// Ask the subscription about itself.
+    ///
+    /// [`Provider::list_models`] here reads a table compiled into this build,
+    /// so it answers the same list whether the user signed in this morning or
+    /// never signed in at all. The quota route is the cheapest call that the
+    /// account has to agree to: it is authenticated, it costs no model tokens,
+    /// and it comes back with the plan tier, which is also what decides which
+    /// of those models the account may actually use.
+    ///
+    /// Refreshing happens on the way in, because [`Self::quota`] asks for
+    /// credentials and that is where a lapsed access token is rotated. So a
+    /// check is also the thing that keeps a rarely-used sign-in alive.
+    async fn check_credential(&self) -> Result<Vec<ModelInfo>> {
+        let plan = self.quota().await?.plan_type.or_else(|| self.plan());
+        // Learned for real this time, so `served_catalog` can start answering
+        // and a later `list_models` shows this account's models rather than
+        // every account's.
+        *leviath_core::sync::lock(&self.served) = Some(catalog::served(plan.as_deref()));
+        self.list_models().await
     }
 
     fn serves_model(&self, model_key: &str) -> Option<String> {

--- a/crates/leviath-providers/src/codex/provider/tests.rs
+++ b/crates/leviath-providers/src/codex/provider/tests.rs
@@ -775,6 +775,90 @@ async fn a_quota_body_in_an_unknown_shape_is_reported() {
     assert!(err.to_string().contains("known shape"), "got {err}");
 }
 
+/// A refused session answers the quota route with a well-formed error
+/// document, so parsing it first would report the *shape* rather than the
+/// rejection. Status is read before the body for exactly that reason.
+#[tokio::test]
+async fn a_refused_session_is_an_auth_failure_not_an_unknown_shape() {
+    for status in [401, 403] {
+        let body = br#"{"detail":"Your authentication token is not from a valid issuer."}"#;
+        let url = spawn_mock_server(status, "Unauthorized", body.to_vec()).await;
+        let err = provider("http://x", Static::new("t"))
+            .with_usage_url(Some(url))
+            .quota()
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ProviderError::Unavailable {
+                    reason: UnavailableReason::AuthFailed,
+                    ..
+                }
+            ),
+            "got {err} for HTTP {status}"
+        );
+    }
+}
+
+/// The wizard's check has to reach the network. `list_models` here is a
+/// compiled table, so a check answered from it would report a working
+/// subscription for a session that was revoked yesterday.
+#[tokio::test]
+async fn checking_the_credential_asks_the_account_rather_than_the_table() {
+    // No listener, so the check cannot possibly be answered locally.
+    let err = provider("http://x", Static::new("t"))
+        .with_usage_url(Some("http://127.0.0.1:1".to_string()))
+        .check_credential()
+        .await
+        .unwrap_err();
+    assert!(err.failure_kind().is_some(), "got {err:?}");
+
+    // And the table still answers when nobody asked for a check.
+    let listed = provider("http://x", Static::new("t"))
+        .list_models()
+        .await
+        .expect("the table needs no network");
+    assert!(!listed.is_empty());
+}
+
+/// A successful check learns the plan from the route, which is what lets
+/// `served_catalog` start answering and keeps a pro-only model off a plus
+/// account.
+#[tokio::test]
+async fn a_successful_check_learns_the_plan_it_was_told() {
+    let body = br#"{"plan_type":"plus","rate_limit":{}}"#.to_vec();
+    let url = spawn_mock_server(200, "OK", body).await;
+    // The grant claims nothing, so the plan can only have come from the route.
+    let p = provider("http://x", Static::with_plan("t", None)).with_usage_url(Some(url));
+    assert_eq!(p.served_catalog(), None, "nothing learned yet");
+
+    let models = p.check_credential().await.expect("the route answered");
+
+    let served = p.served_catalog().expect("the plan is known now");
+    assert_eq!(models.len(), served.len());
+    assert!(
+        !served.iter().any(|id| id == "gpt-5.3-codex-spark"),
+        "a pro-only model reached a plus account: {served:?}"
+    );
+}
+
+/// A route that answers without naming the plan falls back to the grant's own
+/// claim rather than forgetting the tier and offering every model.
+#[tokio::test]
+async fn a_check_falls_back_to_the_plan_in_the_grant() {
+    let url = spawn_mock_server(200, "OK", br#"{"rate_limit":{}}"#.to_vec()).await;
+    let p = provider("http://x", Static::with_plan("t", Some("plus"))).with_usage_url(Some(url));
+
+    p.check_credential().await.expect("the route answered");
+
+    let served = p.served_catalog().expect("the grant knew the plan");
+    assert!(
+        !served.iter().any(|id| id == "gpt-5.3-codex-spark"),
+        "the tier was forgotten: {served:?}"
+    );
+}
+
 #[test]
 fn an_empty_usage_url_leaves_the_default_alone() {
     let p = provider("http://x", Static::new("t")).with_usage_url(Some("  ".to_string()));

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -6,7 +6,6 @@ pub use crate::capabilities::{LimitsSource, ModelCapabilities, ModelCapabilityOv
 pub use crate::failure::FailureKind;
 use async_trait::async_trait;
 use futures_core::Stream;
-use leviath_net::read_caps::{BodyReadError, JSON_BODY_CAP, read_body_capped, read_text_capped};
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
 use thiserror::Error;
@@ -936,6 +935,24 @@ pub trait Provider: Send + Sync {
         false
     }
 
+    /// Prove the stored credential works *right now*, and report the models it
+    /// reaches.
+    ///
+    /// This is what `lev setup`'s check calls, and the distinction from
+    /// [`Self::list_models`] is whether the answer required the provider to
+    /// agree. For every key-based provider they are the same call: the model
+    /// list comes from an authenticated endpoint, so a listing that succeeded
+    /// is a credential that works, and the default here is exactly that.
+    ///
+    /// A provider whose catalogue is a table compiled into this build has to
+    /// override it. `list_models` there is a local read that succeeds with a
+    /// revoked credential, an expired session, or no credential at all, and a
+    /// check answering "12 models" on any of those is worse than no check:
+    /// it is the wizard telling the user they are set up when they are not.
+    async fn check_credential(&self) -> Result<Vec<ModelInfo>> {
+        self.list_models().await
+    }
+
     /// [`Self::serves_model`] answered from the compiled-in capability table.
     ///
     /// Split out so an override can fall back to it: a gateway answers from its
@@ -976,225 +993,13 @@ pub trait Provider: Send + Sync {
 }
 
 // ─── Shared provider helpers ─────────────────────────────────────────────────
+//
+// In `provider/helpers.rs`, and re-exported so every caller's path is
+// unchanged. See that file for why they are not in this one.
+mod helpers;
 
-/// Map an OpenAI-style `finish_reason` string to a `FinishReason`.
-///
-/// Used by both the OpenAI and OpenRouter providers which share the same
-/// Chat Completions API response schema.
-pub(crate) fn parse_openai_finish_reason(reason: &str) -> FinishReason {
-    match reason {
-        "stop" => FinishReason::Complete,
-        "tool_calls" => FinishReason::ToolCall,
-        "length" => FinishReason::TokenLimit,
-        other => {
-            tracing::debug!(
-                reason = other,
-                "unrecognised finish_reason from the provider"
-            );
-            FinishReason::Unknown
-        }
-    }
-}
-
-/// Turn the argument text of a tool call into the value the runtime executes.
-///
-/// Empty text is a call with no arguments, and becomes `{}` so a tool that
-/// takes none is still called. Text that is not JSON is **kept as text**
-/// rather than replaced by `{}`: the usual reason it is not JSON is that the
-/// reply hit its output cap mid-argument, and executing the tool with nothing
-/// hid that from the model. It re-sent the same oversized call and was cut
-/// off the same way, five times in a row, before the stage gave up. A string
-/// where an object should be fails schema validation, and the runtime reads
-/// the string shape as "this call was cut off" and says so back to the model.
-pub(crate) fn parse_tool_arguments(raw: &str) -> serde_json::Value {
-    let raw = raw.trim();
-    if raw.is_empty() {
-        return serde_json::Value::Object(serde_json::Map::new());
-    }
-    serde_json::from_str(raw).unwrap_or_else(|_| serde_json::Value::String(raw.to_string()))
-}
-
-/// Model names remembered for the life of the process.
-///
-/// What a provider learns about a model by being refused (no temperature,
-/// no tools over a reasoning effort) or by warning about it once is worth
-/// keeping across requests, and clones of the provider share the same set.
-#[derive(Debug, Clone, Default)]
-pub(crate) struct ModelMemo(std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>);
-
-impl ModelMemo {
-    /// Whether `model` has been recorded.
-    pub(crate) fn contains(&self, model: &str) -> bool {
-        leviath_core::sync::lock(&self.0).contains(model)
-    }
-
-    /// Record `model`; `true` the first time, `false` if it was already there.
-    pub(crate) fn insert(&self, model: &str) -> bool {
-        leviath_core::sync::lock(&self.0).insert(model.to_string())
-    }
-
-    /// How many models are recorded.
-    #[cfg(test)]
-    pub(crate) fn len(&self) -> usize {
-        leviath_core::sync::lock(&self.0).len()
-    }
-
-    /// Whether nothing has been recorded.
-    #[cfg(test)]
-    pub(crate) fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
-/// How long a response's `Retry-After` header asks the caller to wait.
-///
-/// Only the delta-seconds form is read. The header's other form is an HTTP
-/// date, which every provider API in use here answers with seconds instead, and
-/// reading it would mean trusting the server's clock against ours; an
-/// unparseable value is treated as no hint at all, which falls back to the
-/// caller's own backoff.
-pub(crate) fn retry_after_secs(headers: &reqwest::header::HeaderMap) -> Option<u64> {
-    headers
-        .get("retry-after")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.trim().parse::<u64>().ok())
-}
-
-/// Check an HTTP response for errors and return it on success.
-///
-/// - On 429 (rate limit): notifies the optional rate limiter and returns `RateLimitExceeded`.
-/// - On a provider-fatal failure (see [`UnavailableReason::classify`]): returns `Unavailable`.
-/// - On any other non-2xx: reads the body and returns `ApiError`.
-/// - On 2xx: returns `Ok(response)` so the caller can read the body.
-///
-/// Pass the full `reqwest::Response`; it is returned back on success.
-pub(crate) async fn check_http_response(
-    response: reqwest::Response,
-    limiter: Option<&crate::rate_limit::RateLimiter>,
-) -> Result<reqwest::Response> {
-    let status = response.status();
-    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-        // Extract retry-after *before* consuming the response body.
-        let retry_after = retry_after_secs(response.headers());
-        if let Some(l) = limiter {
-            l.handle_rate_limit(retry_after).await;
-        }
-        // The hint rides along on the error: the client-side limiter paces the
-        // *next* request, while the dispatch layer's retry loop is what decides
-        // how long this one waits before trying again.
-        return Err(ProviderError::RateLimitExceeded {
-            retry_after_secs: retry_after,
-        });
-    }
-    if !status.is_success() {
-        // Capped like a good body: an error page is a body too, and a gateway
-        // that answers a 502 with its whole access log is still a peer.
-        let error_body = read_text_capped(response, JSON_BODY_CAP)
-            .await
-            .unwrap_or_else(|e| e.to_string());
-        // The kind rides in front of the status so it survives every layer that
-        // only passes strings - including a Rhai script, which sees the message
-        // and nothing else. A bare status left "their endpoint is down" and
-        // "your base_url has a typo" reading identically.
-        let kind = FailureKind::from_status(status.as_u16());
-        let detail = format!(
-            "[{}] HTTP {}: {} - {}",
-            kind.label(),
-            status,
-            error_body,
-            kind.remedy()
-        );
-        // An out-of-credits or bad-key response is worth telling apart: the
-        // runtime fails over on it and counts it against the provider's
-        // circuit breaker, where a plain `ApiError` would just kill the run.
-        return Err(
-            match UnavailableReason::classify(status.as_u16(), &error_body) {
-                Some(reason) => ProviderError::Unavailable { reason, detail },
-                None => ProviderError::ApiError(detail),
-            },
-        );
-    }
-    Ok(response)
-}
-
-/// Read a response body to completion and parse it as JSON.
-///
-/// The two halves fail for entirely different reasons and must not share an
-/// error variant. Bytes that never arrived - a reset connection, a socket that
-/// died while the machine was asleep, a truncated body - are a *transport*
-/// failure: [`ProviderError::RequestFailed`], which is transient, gets retried,
-/// counts against the provider's circuit breaker and is eligible for failover.
-/// Bytes that arrived and did not fit the schema are the provider's own fault:
-/// [`ProviderError::InvalidResponse`], which is permanent, because sending the
-/// same request again produces the same unusable answer.
-///
-/// `reqwest`'s own `Response::json` collapses both into one `Decode` error whose
-/// message is the famously unhelpful "error decoding response body". Routing
-/// that through `InvalidResponse` made every network blip permanent: a run with
-/// dozens of iterations of completed work died outright rather than retrying,
-/// because a dead socket was being reported as malformed JSON. The streaming
-/// path already drew this line correctly (see `openai_compat::stream_chat`);
-/// this is the buffered path drawing the same one.
-pub(crate) async fn decode_json<T: serde::de::DeserializeOwned>(
-    response: reqwest::Response,
-) -> Result<T> {
-    decode_json_capped(response, JSON_BODY_CAP).await
-}
-
-/// [`decode_json`] with the body cap as a parameter, so a test can hit the
-/// cap with a few kilobytes rather than 64 MiB.
-///
-/// A body past the cap is [`ProviderError::InvalidResponse`]: the same
-/// request would draw the same oversized answer, so retrying it only spends
-/// the attempts, and the message names the cap and the peer.
-pub(crate) async fn decode_json_capped<T: serde::de::DeserializeOwned>(
-    response: reqwest::Response,
-    cap: usize,
-) -> Result<T> {
-    let bytes = read_body_capped(response, cap)
-        .await
-        .map_err(ProviderError::from)?;
-    serde_json::from_slice(&bytes).map_err(|e| ProviderError::InvalidResponse(e.to_string()))
-}
-
-impl From<BodyReadError> for ProviderError {
-    /// Bytes that never arrived are a transport failure (retried, counted
-    /// against the breaker); a body past the cap is the provider's own fault
-    /// and permanent, since the same request draws the same oversized answer.
-    fn from(e: BodyReadError) -> Self {
-        match e {
-            BodyReadError::Transport(e) => {
-                ProviderError::transport("reading the response body", &e)
-            }
-            too_large @ BodyReadError::TooLarge { .. } => {
-                ProviderError::InvalidResponse(too_large.to_string())
-            }
-        }
-    }
-}
-
-// Helper module for single-item streams
-mod stream_once {
-    use futures_core::Stream;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-
-    pub struct Once<T> {
-        item: Option<T>,
-    }
-
-    impl<T: Unpin> Stream for Once<T> {
-        type Item = T;
-
-        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-            Poll::Ready(self.item.take())
-        }
-    }
-
-    pub fn once<T>(item: T) -> Once<T> {
-        Once { item: Some(item) }
-    }
-}
+use helpers::stream_once;
+pub(crate) use helpers::*;
 
 #[cfg(test)]
 mod tests {
@@ -2233,6 +2038,29 @@ mod tests {
         let provider = MinimalProvider;
         let models = provider.list_models().await.unwrap();
         assert!(models.is_empty());
+    }
+
+    /// The default credential check *is* the listing, which is the right
+    /// answer for every provider whose listing is an authenticated call. Only
+    /// one whose catalogue is a compiled table has to override it.
+    #[tokio::test]
+    async fn the_default_credential_check_is_the_listing() {
+        let provider = MinimalProvider;
+        let checked: Vec<String> = provider
+            .check_credential()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.id)
+            .collect();
+        let listed: Vec<String> = provider
+            .list_models()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.id)
+            .collect();
+        assert_eq!(checked, listed);
     }
 
     /// A provider that has not implemented `served_catalog` says "cannot say",

--- a/crates/leviath-providers/src/provider/helpers.rs
+++ b/crates/leviath-providers/src/provider/helpers.rs
@@ -1,0 +1,234 @@
+//! The pieces every provider reaches for, kept out of the trait's own file.
+//!
+//! Nothing here is part of the [`Provider`](super::Provider) contract. They
+//! are the shared implementation details several providers happen to need: the
+//! Chat Completions vocabulary that OpenAI and OpenRouter both speak, the
+//! once-per-process memo a provider builds by being refused, the capped body
+//! reader, and a one-item stream.
+//!
+//! Split out when `provider.rs` reached the production-line limit, which was
+//! the right moment: the trait, its request and response types, and the errors
+//! it can raise are one thing to read, and this is the other.
+
+use super::{FinishReason, ProviderError, Result, UnavailableReason};
+use crate::failure::FailureKind;
+use leviath_net::read_caps::{BodyReadError, JSON_BODY_CAP, read_body_capped, read_text_capped};
+
+/// Map an OpenAI-style `finish_reason` string to a `FinishReason`.
+///
+/// Used by both the OpenAI and OpenRouter providers which share the same
+/// Chat Completions API response schema.
+pub(crate) fn parse_openai_finish_reason(reason: &str) -> FinishReason {
+    match reason {
+        "stop" => FinishReason::Complete,
+        "tool_calls" => FinishReason::ToolCall,
+        "length" => FinishReason::TokenLimit,
+        other => {
+            tracing::debug!(
+                reason = other,
+                "unrecognised finish_reason from the provider"
+            );
+            FinishReason::Unknown
+        }
+    }
+}
+
+/// Turn the argument text of a tool call into the value the runtime executes.
+///
+/// Empty text is a call with no arguments, and becomes `{}` so a tool that
+/// takes none is still called. Text that is not JSON is **kept as text**
+/// rather than replaced by `{}`: the usual reason it is not JSON is that the
+/// reply hit its output cap mid-argument, and executing the tool with nothing
+/// hid that from the model. It re-sent the same oversized call and was cut
+/// off the same way, five times in a row, before the stage gave up. A string
+/// where an object should be fails schema validation, and the runtime reads
+/// the string shape as "this call was cut off" and says so back to the model.
+pub(crate) fn parse_tool_arguments(raw: &str) -> serde_json::Value {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return serde_json::Value::Object(serde_json::Map::new());
+    }
+    serde_json::from_str(raw).unwrap_or_else(|_| serde_json::Value::String(raw.to_string()))
+}
+
+/// Model names remembered for the life of the process.
+///
+/// What a provider learns about a model by being refused (no temperature,
+/// no tools over a reasoning effort) or by warning about it once is worth
+/// keeping across requests, and clones of the provider share the same set.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ModelMemo(std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>);
+
+impl ModelMemo {
+    /// Whether `model` has been recorded.
+    pub(crate) fn contains(&self, model: &str) -> bool {
+        leviath_core::sync::lock(&self.0).contains(model)
+    }
+
+    /// Record `model`; `true` the first time, `false` if it was already there.
+    pub(crate) fn insert(&self, model: &str) -> bool {
+        leviath_core::sync::lock(&self.0).insert(model.to_string())
+    }
+
+    /// How many models are recorded.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        leviath_core::sync::lock(&self.0).len()
+    }
+
+    /// Whether nothing has been recorded.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// How long a response's `Retry-After` header asks the caller to wait.
+///
+/// Only the delta-seconds form is read. The header's other form is an HTTP
+/// date, which every provider API in use here answers with seconds instead, and
+/// reading it would mean trusting the server's clock against ours; an
+/// unparseable value is treated as no hint at all, which falls back to the
+/// caller's own backoff.
+pub(crate) fn retry_after_secs(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<u64>().ok())
+}
+
+/// Check an HTTP response for errors and return it on success.
+///
+/// - On 429 (rate limit): notifies the optional rate limiter and returns `RateLimitExceeded`.
+/// - On a provider-fatal failure (see [`UnavailableReason::classify`]): returns `Unavailable`.
+/// - On any other non-2xx: reads the body and returns `ApiError`.
+/// - On 2xx: returns `Ok(response)` so the caller can read the body.
+///
+/// Pass the full `reqwest::Response`; it is returned back on success.
+pub(crate) async fn check_http_response(
+    response: reqwest::Response,
+    limiter: Option<&crate::rate_limit::RateLimiter>,
+) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        // Extract retry-after *before* consuming the response body.
+        let retry_after = retry_after_secs(response.headers());
+        if let Some(l) = limiter {
+            l.handle_rate_limit(retry_after).await;
+        }
+        // The hint rides along on the error: the client-side limiter paces the
+        // *next* request, while the dispatch layer's retry loop is what decides
+        // how long this one waits before trying again.
+        return Err(ProviderError::RateLimitExceeded {
+            retry_after_secs: retry_after,
+        });
+    }
+    if !status.is_success() {
+        // Capped like a good body: an error page is a body too, and a gateway
+        // that answers a 502 with its whole access log is still a peer.
+        let error_body = read_text_capped(response, JSON_BODY_CAP)
+            .await
+            .unwrap_or_else(|e| e.to_string());
+        // The kind rides in front of the status so it survives every layer that
+        // only passes strings - including a Rhai script, which sees the message
+        // and nothing else. A bare status left "their endpoint is down" and
+        // "your base_url has a typo" reading identically.
+        let kind = FailureKind::from_status(status.as_u16());
+        let detail = format!(
+            "[{}] HTTP {}: {} - {}",
+            kind.label(),
+            status,
+            error_body,
+            kind.remedy()
+        );
+        // An out-of-credits or bad-key response is worth telling apart: the
+        // runtime fails over on it and counts it against the provider's
+        // circuit breaker, where a plain `ApiError` would just kill the run.
+        return Err(
+            match UnavailableReason::classify(status.as_u16(), &error_body) {
+                Some(reason) => ProviderError::Unavailable { reason, detail },
+                None => ProviderError::ApiError(detail),
+            },
+        );
+    }
+    Ok(response)
+}
+
+/// Read a response body to completion and parse it as JSON.
+///
+/// The two halves fail for entirely different reasons and must not share an
+/// error variant. Bytes that never arrived - a reset connection, a socket that
+/// died while the machine was asleep, a truncated body - are a *transport*
+/// failure: [`ProviderError::RequestFailed`], which is transient, gets retried,
+/// counts against the provider's circuit breaker and is eligible for failover.
+/// Bytes that arrived and did not fit the schema are the provider's own fault:
+/// [`ProviderError::InvalidResponse`], which is permanent, because sending the
+/// same request again produces the same unusable answer.
+///
+/// `reqwest`'s own `Response::json` collapses both into one `Decode` error whose
+/// message is the famously unhelpful "error decoding response body". Routing
+/// that through `InvalidResponse` made every network blip permanent: a run with
+/// dozens of iterations of completed work died outright rather than retrying,
+/// because a dead socket was being reported as malformed JSON. The streaming
+/// path already drew this line correctly (see `openai_compat::stream_chat`);
+/// this is the buffered path drawing the same one.
+pub(crate) async fn decode_json<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T> {
+    decode_json_capped(response, JSON_BODY_CAP).await
+}
+
+/// [`decode_json`] with the body cap as a parameter, so a test can hit the
+/// cap with a few kilobytes rather than 64 MiB.
+///
+/// A body past the cap is [`ProviderError::InvalidResponse`]: the same
+/// request would draw the same oversized answer, so retrying it only spends
+/// the attempts, and the message names the cap and the peer.
+pub(crate) async fn decode_json_capped<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+    cap: usize,
+) -> Result<T> {
+    let bytes = read_body_capped(response, cap)
+        .await
+        .map_err(ProviderError::from)?;
+    serde_json::from_slice(&bytes).map_err(|e| ProviderError::InvalidResponse(e.to_string()))
+}
+
+impl From<BodyReadError> for ProviderError {
+    /// Bytes that never arrived are a transport failure (retried, counted
+    /// against the breaker); a body past the cap is the provider's own fault
+    /// and permanent, since the same request draws the same oversized answer.
+    fn from(e: BodyReadError) -> Self {
+        match e {
+            BodyReadError::Transport(e) => {
+                ProviderError::transport("reading the response body", &e)
+            }
+            too_large @ BodyReadError::TooLarge { .. } => {
+                ProviderError::InvalidResponse(too_large.to_string())
+            }
+        }
+    }
+}
+
+// Helper module for single-item streams
+pub(super) mod stream_once {
+    use futures_core::Stream;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    pub struct Once<T> {
+        item: Option<T>,
+    }
+
+    impl<T: Unpin> Stream for Once<T> {
+        type Item = T;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(self.item.take())
+        }
+    }
+
+    pub fn once<T>(item: T) -> Once<T> {
+        Once { item: Some(item) }
+    }
+}

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -822,7 +822,7 @@ Transport is inferred from whether you pass `--url` or `--command`.
 | Command | Flags | Purpose |
 |---|---|---|
 | `lev auth status` | | Which credential backend is in use and what it holds |
-| `lev auth login <provider>` | | Sign in with a browser (`codex`); stores the grant outside `config.toml` |
+| `lev auth login <provider>` | | Sign in with a browser (`codex`); stores the grant outside `config.toml`. `lev setup` does this on its own screen, so this is for headless machines and revoked sessions |
 | `lev auth logout <provider>` | | Forget a browser sign-in, leaving the provider enabled |
 | `lev auth migrate` | `--to-file`, `--dry-run` | Move secrets between `config.toml` and the OS keychain |
 

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -405,11 +405,21 @@ rewritten by the CLI and has no business holding a refresh token. With
 `[security] credential_store = "keychain"` the grant moves to the OS store like
 every other secret, and `lev auth migrate` moves it with them.
 
+You sign in from `lev setup`, on the provider's own screen. The commands below
+are for the times there is no wizard to run: a headless machine, a script, or a
+session someone revoked from the ChatGPT settings page.
+
 ```bash
-lev auth login codex     # sign in
 lev auth status          # which account, and on what plan
+lev auth login codex     # sign in again
 lev auth logout codex    # forget it (leaves the provider enabled)
 ```
+
+**The access token renews itself.** Leviath refreshes it a couple of minutes
+before it lapses, on whichever call needs it next, and writes the rotated token
+back before using it. Signing in again is for a session that was revoked or one
+left unused long enough for the refresh token itself to expire, not for
+ordinary use.
 
 ## Rate limits
 
@@ -441,13 +451,17 @@ inference to it instead of an API balance. Sign in once with a browser and no
 API key is involved at all.
 
 ```bash
-lev auth login codex     # opens your browser, stores the grant outside config.toml
-lev setup                # select "OpenAI Codex" to turn it on
+lev setup                # select "OpenAI Codex", then "Sign in with your browser"
 ```
 
-`lev setup` offers it as an ordinary provider row. The sign-in itself is the
-separate command above, because a browser round trip does not belong inside the
-wizard's screen.
+The whole thing happens on that screen. There is no key to paste, so instead of
+a field the card shows who is signed in, a button that opens your browser, and
+the same **Check this credential** button every other provider has. The check
+asks your subscription about itself rather than reading a table, so a green
+answer means the account really did agree.
+
+If your browser does not open (an SSH session, say), the card prints the URL to
+copy.
 
 This is a different provider from `openai`, not a mode of it. You can hold both
 credentials; a blueprint reaches this one as `codex/gpt-5.6-sol`.

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -33,7 +33,8 @@ anthropic_cache_ttl = "5m"
 claude_code_binary = "/usr/local/bin/claude"
 claude_code_effort = "medium"
 # Bill inference to a ChatGPT subscription instead of an API balance.
-# Sign in with `lev auth login codex`; the grant is stored outside this file.
+# Sign in from `lev setup` (or `lev auth login codex` on a headless machine);
+# the grant is stored outside this file and its token renews itself.
 codex_enabled = false
 codex_originator = "leviath"
 codex_reasoning_effort = "medium"

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -87,7 +87,7 @@
           ]
         },
         "codex_enabled": {
-          "description": "Offer the Codex transport, which bills inference to a ChatGPT subscription. Sign in with `lev auth login codex`.",
+          "description": "Offer the Codex transport, which bills inference to a ChatGPT subscription. Sign in from `lev setup`, or with `lev auth login codex` on a headless machine.",
           "type": "boolean",
           "default": false
         },


### PR DESCRIPTION
Codex was the one provider `lev setup` could not finish. Its credential is a browser grant, so there was nothing to type, and the card said "Not signed in yet" and told you to quit and run `lev auth login codex`.

## The screen

No API key field. Pressing the credential row used to open a text editor over a credential that does not exist; there is no credential row now, so the card is a status line and the buttons are the whole screen.

```
  Not signed in yet.
  Signing in opens your browser and stores the grant outside config.toml. Nothing to type here.

  not checked yet

› [ Sign in with your browser ]
  [ Open the subscription plans page ]
```

Once signed in the card names the account and offers `[ Check this credential ]`, `[ Sign in again, as a different account ]` and `[ Sign out ]`. The focused button is whichever one somebody opening the card came to press: the sign-in while there is none, the check once there is.

While the browser is open the card says so and prints the authorize URL. The opener silently does nothing over SSH, and without the URL on screen the wizard would sit on "waiting for your browser" with no browser and no way to find out why.

## The check had to become real first

`lev setup`'s check called `list_models`, which for every key-based provider is an authenticated call: a listing that succeeded is a credential that works. Codex breaks that, because its catalogue is a table compiled into the build. Its check reported "5 models" for a revoked session, an expired one, and for never having signed in at all.

So the check is its own trait method, `check_credential`, defaulting to exactly the listing every other provider already made. Codex overrides it with the quota route: authenticated, costs no model tokens, and it answers with the plan tier, which is also what decides which of those models the account may use.

Two things fall out of that. A successful check teaches `served_catalog` the tier, so a pro-only model stops being offered to a plus account. And it refreshes a lapsed token on the way in, so checking a rarely-used sign-in is also what keeps it alive.

The quota route now reads its status before parsing the body. A refused session answers with a well-formed error document, so parsing first turned "your session was revoked" into "not in a known shape".

## Auto-renewal

Already worked, and now says so. The access token is refreshed a couple of minutes before it lapses, on whichever call needs it next, and written back before it is used. `lev auth login codex` stays for a headless machine, a script, or a session revoked from the ChatGPT settings page.

## Shape

The sign-in runs on a lane of its own beside the verifier's, not the same one: a check is a round trip and the verifier runs them one after another, while a sign-in waits for a person to find their password, and putting it in that queue would stall every check behind it.

`ProviderAuthorizer` is the seam, for the reason `ProviderVerifier` is one plus a sharper one: this opens a browser, and `lev dash` once had a unit test launch a real one. Nothing in the library builds the live implementation. The whole round trip is still driven in tests, against a local issuer with the stub browser the login flow already had, so the production path is exercised rather than only its refusals.

The wizard's check builds its credentials the way a run does, through a shared `codex_options`. It reads a grant from disk, and a wizard pointing somewhere else would have been checking a sign-in no run would ever find.

## Verification

All 13 packages at 100% region coverage, clippy clean, structure and docs gates pass, full suite green.

The regression test for the check was run against the unfixed code first: it returns all five models with no network at all, which is exactly the false "you are set up" the check exists to prevent.

Two files crossed the 1200-line production limit and were split at seams that were already drawn: the shared-helper block below the `Provider` trait moved to `provider/helpers.rs`, and the wizard's two background lanes moved to `state/lanes.rs`. Both are re-exported, so no caller's path changes.

`main.rs` gains two lines wiring the live authorizer, the same way it already wires the live verifier, so this needs the `allow-main-rs-change` label.
