### PR TITLE
Sign in to Codex over the HTTP API, so the Lair can offer it visually

### DIFF
--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -25,10 +25,12 @@ fn cache_ttl_key(ttl: leviath_providers::anthropic::CacheTtl) -> &'static str {
     }
 }
 
-/// Build the list of [`ProviderCreds`] a [`Config`] implies. `ollama` is always
-/// present (it needs no key); the API-key providers are included only when their
-/// key is configured, and `claude-code` only when explicitly enabled. This is the
-/// sole point that reads provider settings out of `Config`.
+/// Build the list of [`ProviderCreds`] a [`Config`] implies.
+///
+/// Every provider here is opt-in: an API-key one when its key is configured,
+/// `claude-code` and `codex` when they are enabled, and `ollama` when it was
+/// chosen or given an address. This is the sole point that reads provider
+/// settings out of `Config`.
 pub(crate) fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> {
     let caps = &config.model_capabilities;
     let timeout = config.request_timeout_secs;
@@ -90,22 +92,30 @@ pub(crate) fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> 
         }
     }
 
-    // Ollama is always available (no key); carry any configured base URL.
-    creds.push(ProviderCreds {
-        name: "ollama".to_string(),
-        api_key: None,
-        base_url: Some(
-            config
-                .ollama_base_url
-                .as_deref()
-                .unwrap_or("http://localhost:11434")
-                .to_string(),
-        ),
-        model_capabilities: caps.clone(),
-        request_timeout_secs: timeout,
-        rate_limit: None,
-        options: std::collections::HashMap::new(),
-    });
+    // Ollama needs no key and answers on a well-known local port, so this
+    // used to register it on every machine whether or not anybody had asked.
+    // That made a bare model name in a blueprint resolvable against whatever
+    // happened to be running locally - a surprising place for a run to end
+    // up, and not one the user chose. Opt-in now, by the switch `lev setup`
+    // writes or by naming an address, which is what an install that
+    // configured it before the switch existed already has.
+    if config.providers.ollama_enabled || config.ollama_base_url.is_some() {
+        creds.push(ProviderCreds {
+            name: "ollama".to_string(),
+            api_key: None,
+            base_url: Some(
+                config
+                    .ollama_base_url
+                    .as_deref()
+                    .unwrap_or("http://localhost:11434")
+                    .to_string(),
+            ),
+            model_capabilities: caps.clone(),
+            request_timeout_secs: timeout,
+            rate_limit: None,
+            options: std::collections::HashMap::new(),
+        });
+    }
 
     // Every `[model_providers.<name>]` entry that is an endpoint rather than a
     // script. Registered natively, under its own name, so it needs no `.rhai`
@@ -477,8 +487,9 @@ mod tests {
             &|_| true,
         )
         .expect("an HTTPS client builds in tests");
-        // Ollama needs no key and is always on.
-        assert!(registry.has("ollama"));
+        // Opt-in like everything else, so a default config registers it not
+        // at all.
+        assert!(!registry.has("ollama"));
         // Claude Code needs no key either, but is opt-in - a default config
         // must not reach the user's Claude subscription (or send their account
         // email to it) without them having said yes.
@@ -1030,7 +1041,7 @@ mod tests {
     // ─── resolve_task: multiline file content ───────────────────────────
 
     #[test]
-    fn build_provider_registry_defaults_have_ollama_only() {
+    fn build_provider_registry_defaults_have_nothing() {
         let config = Config::default();
         let registry = build_provider_registry_from_config_probing(
             &config,
@@ -1038,10 +1049,41 @@ mod tests {
             &|_| true,
         )
         .expect("an HTTPS client builds in tests");
-        // Ollama is present regardless of key configuration; claude-code is not,
-        // until the user opts in.
-        assert!(registry.has("ollama"));
+        // Every provider is opt-in, Ollama included. It needs no key and
+        // answers on a well-known local port, which used to be reason enough
+        // to register it everywhere - and made a bare model name resolvable
+        // against whatever happened to be running on the machine.
+        assert!(!registry.has("ollama"));
         assert!(!registry.has("claude-code"));
+    }
+
+    /// Chosen in `lev setup`, or given an address by hand: either counts.
+    ///
+    /// The second is what an install that configured Ollama before the switch
+    /// existed already has, so it keeps working without being re-run.
+    #[test]
+    fn ollama_registers_once_it_is_chosen_or_addressed() {
+        for config in [
+            Config {
+                providers: crate::config::ProviderConfig {
+                    ollama_enabled: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Config {
+                ollama_base_url: Some("http://elsewhere:11434".to_string()),
+                ..Default::default()
+            },
+        ] {
+            let registry = build_provider_registry_from_config_probing(
+                &config,
+                &leviath_providers::provider::build_http_client,
+                &|_| true,
+            )
+            .expect("an HTTPS client builds in tests");
+            assert!(registry.has("ollama"));
+        }
     }
 
     #[test]
@@ -1143,8 +1185,8 @@ mod tests {
         .expect("an HTTPS client builds in tests");
         // Verify anthropic provider was registered
         assert!(registry.has("anthropic"));
-        // Verify ollama always registered
-        assert!(registry.has("ollama"));
+        // And nothing else: this config chose one provider.
+        assert!(!registry.has("ollama"));
     }
 
     // ─── launch_editor: candidates exhausted when no editors available ────

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -835,6 +835,7 @@ mod tests {
             event_tx: tx,
             control: no_daemon(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }
@@ -866,6 +867,7 @@ mod tests {
             event_tx: tx,
             control: no_daemon(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Arc::new(ServeLimits {
                 allow_local_network: false,
                 workdir_root: Some(root.path().to_path_buf()),
@@ -1132,6 +1134,7 @@ mod tests {
             event_tx: tx,
             control,
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }
@@ -2996,6 +2999,7 @@ system_prompt = "Plan the work"
             event_tx: tx,
             control,
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         let app = Router::new()
@@ -3054,6 +3058,7 @@ system_prompt = "Plan the work"
             event_tx: tx,
             control,
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         let app = Router::new()

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -598,6 +598,7 @@ system_prompt = "do it"
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Arc::new(crate::commands::serve::types::ServeLimits::default()),
         };
         let app = Router::new()
@@ -832,6 +833,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -62,6 +62,10 @@ fn redact(
         has_google_key: c.providers.google_api_key.is_some(),
         has_openrouter_key: c.openrouter_api_key.is_some(),
         ollama_base_url: c.ollama_base_url.clone(),
+        codex_enabled: c.providers.codex_enabled,
+        codex_reasoning_effort: c.providers.codex_reasoning_effort.clone(),
+        codex_verbosity: c.providers.codex_verbosity.clone(),
+        codex_replay_reasoning: c.providers.codex_replay_reasoning,
         gateways: gateways_of(c),
         agent_paths: c.agent_paths.clone(),
         mcp_server_count: c.mcp_servers.len(),
@@ -69,6 +73,37 @@ fn redact(
         capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
         limits: ApiLimits::current(requests),
     }
+}
+
+/// The reasoning efforts the Codex route accepts.
+const CODEX_EFFORTS: &[&str] = &["none", "minimal", "low", "medium", "high", "xhigh"];
+
+/// The text verbosities it accepts.
+const CODEX_VERBOSITIES: &[&str] = &["low", "medium", "high"];
+
+/// Refuse a value outside `allowed`, naming what was expected.
+///
+/// The provider drops a setting it does not recognise, so an unchecked typo
+/// is saved, reported back by `GET /api/config`, and silently does nothing -
+/// the same class of quiet no-op a mistyped `gate` key is in a blueprint.
+fn validated(
+    value: Option<String>,
+    allowed: &[&str],
+    what: &str,
+) -> Result<Option<String>, ApiError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if allowed.contains(&value.as_str()) {
+        return Ok(Some(value));
+    }
+    Err(err(
+        StatusCode::BAD_REQUEST,
+        format!(
+            "unknown Codex {what} '{value}'; use one of {}",
+            allowed.join(", ")
+        ),
+    ))
 }
 
 /// `GET /api/config`. Reads the file rather than a start-up copy, so an edit
@@ -137,6 +172,21 @@ pub(super) async fn put_config(
     if let Some(v) = req.ollama_base_url {
         config.ollama_base_url = Some(v);
     }
+    // Checked before anything is written, like the gateway kind below: the
+    // provider silently ignores a value it does not know, so a console that
+    // sent a typo would see it saved and never take effect.
+    let effort = validated(
+        req.codex_reasoning_effort,
+        CODEX_EFFORTS,
+        "reasoning effort",
+    )?;
+    let verbosity = validated(req.codex_verbosity, CODEX_VERBOSITIES, "verbosity")?;
+    config.providers.codex_enabled = req.codex_enabled.unwrap_or(config.providers.codex_enabled);
+    config.providers.codex_replay_reasoning = req
+        .codex_replay_reasoning
+        .unwrap_or(config.providers.codex_replay_reasoning);
+    config.providers.codex_reasoning_effort = effort.or(config.providers.codex_reasoning_effort);
+    config.providers.codex_verbosity = verbosity.or(config.providers.codex_verbosity);
     // Field by field, like everything above: a gateway names only what it is
     // changing, so a console can edit a base URL without knowing the key or
     // sending it back through the browser.
@@ -520,6 +570,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }
@@ -533,6 +584,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }
@@ -566,6 +618,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }
@@ -767,6 +820,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         let app = Router::new()
@@ -808,6 +862,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }
@@ -937,6 +992,10 @@ mod tests {
             has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: None,
+            codex_enabled: false,
+            codex_reasoning_effort: None,
+            codex_verbosity: None,
+            codex_replay_reasoning: true,
             gateways: Vec::new(),
             agent_paths: vec![],
             mcp_server_count: 2,
@@ -964,6 +1023,10 @@ mod tests {
             has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: Some("http://localhost:11434".to_string()),
+            codex_enabled: false,
+            codex_reasoning_effort: None,
+            codex_verbosity: None,
+            codex_replay_reasoning: true,
             gateways: Vec::new(),
             agent_paths: vec![],
             mcp_server_count: 0,
@@ -989,6 +1052,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         (state, paths_for(path))
@@ -1014,6 +1078,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         (state, paths_for(path))
@@ -1122,6 +1187,93 @@ mod tests {
             .body(Body::from(body.to_string()))
             .unwrap();
         app.oneshot(req).await.unwrap()
+    }
+
+    /// The Codex switch and its two tuning knobs are writable, so a console
+    /// can offer the provider without the user editing `config.toml` by hand.
+    #[tokio::test]
+    async fn put_config_writes_the_codex_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+
+        let body = serde_json::json!({
+            "codex_enabled": true,
+            "codex_reasoning_effort": "high",
+            "codex_verbosity": "low",
+            "codex_replay_reasoning": false,
+        })
+        .to_string();
+        let resp = put_config_request(state_with_config_path(path.clone()), &body).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let rc: RedactedConfig = serde_json::from_slice(&bytes).unwrap();
+        assert!(rc.codex_enabled);
+        assert_eq!(rc.codex_reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(rc.codex_verbosity.as_deref(), Some("low"));
+        assert!(!rc.codex_replay_reasoning);
+
+        let saved = Config::load_from_path_public(&path).unwrap();
+        assert!(saved.providers.codex_enabled);
+        assert_eq!(
+            saved.providers.codex_reasoning_effort.as_deref(),
+            Some("high")
+        );
+        assert_eq!(saved.providers.codex_verbosity.as_deref(), Some("low"));
+        assert!(!saved.providers.codex_replay_reasoning);
+    }
+
+    /// An absent field leaves the setting alone, the partial-update rule every
+    /// field here follows. Without it a console editing the effort would turn
+    /// the provider off by not mentioning it.
+    #[tokio::test]
+    async fn a_put_that_mentions_no_codex_field_changes_none_of_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut config = Config::default();
+        config.providers.codex_enabled = true;
+        config.providers.codex_verbosity = Some("high".to_string());
+        config.save_to_path_public(&path).unwrap();
+
+        let body = serde_json::json!({ "default_provider": "codex" }).to_string();
+        let resp = put_config_request(state_with_config_path(path.clone()), &body).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        let saved = Config::load_from_path_public(&path).unwrap();
+        assert!(saved.providers.codex_enabled, "the switch was turned off");
+        assert_eq!(saved.providers.codex_verbosity.as_deref(), Some("high"));
+    }
+
+    /// A value the provider would ignore is refused rather than saved. The
+    /// route drops an effort it does not recognise, so an unchecked typo is
+    /// written, read back by `GET /api/config`, and quietly does nothing.
+    #[tokio::test]
+    async fn a_codex_setting_the_provider_would_ignore_is_refused() {
+        for (field, value) in [
+            ("codex_reasoning_effort", "hard"),
+            ("codex_verbosity", "verbose"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("config.toml");
+            Config::default().save_to_path_public(&path).unwrap();
+
+            let body = serde_json::json!({ field: value, "codex_enabled": true }).to_string();
+            let resp = put_config_request(state_with_config_path(path.clone()), &body).await;
+            assert_eq!(
+                resp.status(),
+                axum::http::StatusCode::BAD_REQUEST,
+                "{field} = {value}"
+            );
+
+            let saved = Config::load_from_path_public(&path).unwrap();
+            assert!(
+                !saved.providers.codex_enabled,
+                "the check runs before anything is written, so {field} left the file alone"
+            );
+        }
     }
 
     #[tokio::test]
@@ -1834,6 +1986,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         let Json(models) = super::models_with(&state, &|_t| {

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -1060,7 +1060,12 @@ mod tests {
 
     fn paths_for(config: std::path::PathBuf) -> AdminPaths {
         let store = config.with_file_name("mcp-auth.json");
-        AdminPaths { config, store }
+        let grants = config.with_file_name("provider-auth.json");
+        AdminPaths {
+            config,
+            store,
+            grants,
+        }
     }
 
     /// [`state_with_config_path`], but its config source *watches* that file

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -48,6 +48,17 @@ pub(super) struct RedactedConfig {
     pub(super) has_google_key: bool,
     pub(super) has_openrouter_key: bool,
     pub(super) ollama_base_url: Option<String>,
+    /// Whether the Codex transport is on. Whether it is *signed in* is a
+    /// separate question with a separate route: see `GET /api/providers`.
+    pub(super) codex_enabled: bool,
+    /// Its reasoning effort, when the config pins one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) codex_reasoning_effort: Option<String>,
+    /// Its text verbosity, when the config pins one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) codex_verbosity: Option<String>,
+    /// Whether reasoning is replayed between turns.
+    pub(super) codex_replay_reasoning: bool,
     /// Every custom gateway `[model_providers]` declares, name-sorted.
     ///
     /// The four fields above can only describe the providers that existed when
@@ -297,6 +308,15 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // approval request. Announced because an older daemon drops the field
     // without a word: a console that offered the box against one would send
     // the person's redirect nowhere.
+    // `GET /api/providers` and the three admin routes under it: the browser
+    // sign-in for a provider that has no API key. Announced because a console
+    // that cannot tell whether they exist has to offer a Codex row that either
+    // 404s on sign-in or, worse, writes `codex_enabled` and leaves the user
+    // enabled but not signed in - which is a provider every run fails against.
+    // The read half is always mounted; the three writes need `--allow-admin`,
+    // and a client finds that out the way it does for the MCP admin routes,
+    // by calling one and reading the status.
+    "providers.signin",
     "interaction.feedback",
     // `config_error` and `config_mtime` on `GET /api/config`, and the
     // `config_health` websocket frame. Announced because the absence of
@@ -386,6 +406,24 @@ pub(super) struct WriteConfigReq {
     pub(super) google_key: Option<String>,
     pub(super) openrouter_key: Option<String>,
     pub(super) ollama_base_url: Option<String>,
+    /// Turn the Codex transport on or off.
+    ///
+    /// The one provider here with no key to send: its credential is a browser
+    /// sign-in, taken through `POST /api/providers/codex/login`. Writing this
+    /// alone leaves a provider that is enabled and cannot answer, which is why
+    /// `GET /api/providers` reports the two separately.
+    pub(super) codex_enabled: Option<bool>,
+    /// How hard Codex thinks: `none`, `minimal`, `low`, `medium`, `high` or
+    /// `xhigh`. Validated before anything is written.
+    pub(super) codex_reasoning_effort: Option<String>,
+    /// How much it writes: `low`, `medium` or `high`.
+    pub(super) codex_verbosity: Option<String>,
+    /// Whether a turn's opaque reasoning token is replayed on the next one.
+    ///
+    /// On by default and worth leaving on; it is here so it can be turned off
+    /// from a console the day the route stops accepting a replayed blob,
+    /// without editing `config.toml` by hand on the serving machine.
+    pub(super) codex_replay_reasoning: Option<bool>,
     /// Gateways to add or update, by name. Absent means "change none", the
     /// same partial-update rule every field above follows: a gateway this list
     /// does not mention is left exactly as it was.

--- a/crates/leviath-cli/src/commands/serve/doctor.rs
+++ b/crates/leviath-cli/src/commands/serve/doctor.rs
@@ -137,6 +137,7 @@ mod tests {
                 )),
             ),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }

--- a/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
@@ -177,6 +177,7 @@ async fn stand_up(runs_dir: &std::path::Path) -> Seam {
         event_tx,
         control: control.clone(),
         mcp: super::mcp::McpAdmin::default(),
+        providers: super::providers::ProviderAdmin::default(),
         limits: Default::default(),
     };
     let relay = tokio::spawn(super::polling::event_loop(

--- a/crates/leviath-cli/src/commands/serve/fs.rs
+++ b/crates/leviath-cli/src/commands/serve/fs.rs
@@ -288,6 +288,7 @@ mod tests {
             event_tx: tx,
             control: no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Arc::new(ServeLimits {
                 workdir_root,
                 ..Default::default()

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -132,6 +132,7 @@ mod tests {
             event_tx: tx,
             control,
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         Router::new()

--- a/crates/leviath-cli/src/commands/serve/mcp.rs
+++ b/crates/leviath-cli/src/commands/serve/mcp.rs
@@ -75,8 +75,9 @@ pub(crate) struct McpAdmin {
     pub clock: fn() -> u64,
 }
 
-/// Real Unix time in seconds.
-fn system_now() -> u64 {
+/// Real Unix time in seconds. Shared with the provider routes, which
+/// track sign-in timestamps the same way.
+pub(super) fn system_now() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -412,6 +413,7 @@ mod tests {
                 opener: Arc::new(opener),
                 clock: fixed_clock,
             },
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }
@@ -822,6 +824,7 @@ for line in sys.stdin:
                 opener: Arc::new(never_opens),
                 clock: fixed_clock,
             },
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }
@@ -888,6 +891,7 @@ for line in sys.stdin:
                 opener: Arc::new(never_opens),
                 clock: fixed_clock,
             },
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         let app = scoped(

--- a/crates/leviath-cli/src/commands/serve/mcp.rs
+++ b/crates/leviath-cli/src/commands/serve/mcp.rs
@@ -28,6 +28,8 @@ pub(crate) struct AdminPaths {
     pub config: std::path::PathBuf,
     /// OAuth token store.
     pub store: std::path::PathBuf,
+    /// Provider sign-in grants, for the `/api/providers` routes.
+    pub grants: std::path::PathBuf,
 }
 
 /// The operator's file locations for this process.
@@ -44,6 +46,7 @@ pub(crate) fn admin_paths() -> AdminPaths {
     AdminPaths {
         config: Config::config_path(),
         store: AuthStore::default_path().unwrap_or_default(),
+        grants: leviath_providers::codex::ProviderAuthStore::default_path().unwrap_or_default(),
     }
 }
 
@@ -433,6 +436,7 @@ mod tests {
         AdminPaths {
             config: dir.join("config.toml"),
             store: dir.join("mcp-auth.json"),
+            grants: dir.join("provider-auth.json"),
         }
     }
 
@@ -837,6 +841,10 @@ for line in sys.stdin:
             AdminPaths {
                 config: dir.path().join("cfg-dir"),
                 store: dir.path().join("store-dir"),
+                grants: dir
+                    .path()
+                    .join("store-dir")
+                    .with_file_name("provider-auth.json"),
             },
         );
         for (method, uri) in [
@@ -863,6 +871,10 @@ for line in sys.stdin:
             AdminPaths {
                 config: dir.path().join("cfg-dir"),
                 store: dir.path().join("store-dir"),
+                grants: dir
+                    .path()
+                    .join("store-dir")
+                    .with_file_name("provider-auth.json"),
             },
         );
         let (status_code, _) = send(
@@ -899,6 +911,10 @@ for line in sys.stdin:
             AdminPaths {
                 config: file.join("config.toml"),
                 store: dir.path().join("s.json"),
+                grants: dir
+                    .path()
+                    .join("s.json")
+                    .with_file_name("provider-auth.json"),
             },
         );
         let (status_code, _) = send(

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -1219,6 +1219,7 @@ mod tests {
             // about one run in three, on an assertion about *routing*.
             config: std::env::temp_dir().join("leviath-serve-router-tests-no-such-config.toml"),
             store: std::env::temp_dir().join("leviath-serve-router-tests-no-such-store.json"),
+            grants: std::env::temp_dir().join("leviath-serve-router-tests-no-such-grants.json"),
         }
     }
 

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -16,6 +16,7 @@ mod fs;
 mod interactions;
 mod mcp;
 mod polling;
+mod providers;
 mod request_limits;
 mod runs;
 mod scripts;
@@ -145,6 +146,7 @@ fn api_router() -> Router<AppState> {
         // MCP servers - read-only surface. Everything that connects to one or
         // opens a browser is mounted by `execute_with_shutdown`, behind
         // `--allow-admin`.
+        .route("/api/providers", get(providers::list_providers))
         .route("/api/mcp/servers", get(mcp::list_servers))
         .route("/api/mcp/servers/{name}/status", get(mcp::status))
         // Doctor - the offline half of the checks `lev doctor` runs, returned
@@ -372,6 +374,7 @@ async fn execute_with_shutdown(
         event_tx: event_tx.clone(),
         control,
         mcp: mcp::McpAdmin::default(),
+        providers: providers::ProviderAdmin::default(),
         limits: Arc::new(ServeLimits {
             workdir_root: args.workdir_root.clone(),
             no_remote_yolo: args.no_remote_yolo,
@@ -466,6 +469,16 @@ async fn execute_with_shutdown(
             // anyone holding the bearer token.
             .route("/api/mcp/servers/{name}/login", post(mcp::login))
             .route("/api/mcp/servers/{name}/test", post(mcp::test_server))
+            // The provider sign-in opens the operator's browser and binds a
+            // fixed loopback port on this host, and the sign-out deletes a
+            // credential. Same category of act as the MCP login above, gated
+            // the same way. The read half stays open, so a console without
+            // admin can still show what is signed in and offer nothing else.
+            .route("/api/providers/{name}/login", post(providers::login))
+            .route("/api/providers/{name}/logout", post(providers::logout))
+            // The check makes a real authenticated call to the provider, the
+            // same category as `/api/models/probe` beside it.
+            .route("/api/providers/{name}/check", post(providers::check))
             // The live doctor makes two billed provider calls and spawns a run
             // through the daemon. The read half above stops before either.
             .route("/api/doctor/live", post(doctor::run_doctor_live))
@@ -810,6 +823,7 @@ mod tests {
         ("fs", include_str!("fs.rs")),
         ("interactions", include_str!("interactions.rs")),
         ("mcp", include_str!("mcp.rs")),
+        ("providers", include_str!("providers.rs")),
         ("runs", include_str!("runs.rs")),
         ("scripts", include_str!("scripts.rs")),
         ("tools", include_str!("tools.rs")),
@@ -838,6 +852,7 @@ mod tests {
         ("INTERNAL_SERVER_ERROR", 500),
         ("BAD_GATEWAY", 502),
         ("SERVICE_UNAVAILABLE", 503),
+        ("GATEWAY_TIMEOUT", 504),
     ];
 
     /// Every `StatusCode::` constant named in the body of `function` in
@@ -1181,6 +1196,7 @@ mod tests {
             event_tx: tx,
             control: no_daemon_control(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -525,6 +525,7 @@ mod tests {
                 event_tx: tx,
                 control,
                 mcp: crate::commands::serve::mcp::McpAdmin::default(),
+                providers: crate::commands::serve::providers::ProviderAdmin::default(),
                 limits: Default::default(),
             },
             rx,

--- a/crates/leviath-cli/src/commands/serve/providers.rs
+++ b/crates/leviath-cli/src/commands/serve/providers.rs
@@ -148,12 +148,10 @@ fn describe(
     id: &str,
     display: &str,
     config: &crate::config::Config,
-    store_path: Option<&std::path::Path>,
+    store: Option<&leviath_providers::codex::ProviderAuthStore>,
     in_flight: &HashMap<String, Progress>,
 ) -> ProviderInfo {
-    let grant = store_path
-        .and_then(|path| leviath_providers::codex::ProviderAuthStore::load(path).ok())
-        .and_then(|store| store.get(id).cloned());
+    let grant = store.and_then(|store| store.get(id).cloned());
     let claims = grant.as_ref().map(leviath_providers::ProviderGrant::claims);
     ProviderInfo {
         id: id.to_string(),
@@ -180,31 +178,48 @@ fn describe(
 /// `GET /api/providers` - every browser-sign-in provider and its state.
 pub(super) async fn list_providers(State(state): State<AppState>) -> impl IntoResponse {
     let config = state.current_config();
-    let store_path = state.providers.authorizer.store_path.clone();
+    // Read once, not once per row: this is a file, and the answer is the same
+    // for every provider in it.
+    let store = state
+        .providers
+        .authorizer
+        .store_path
+        .as_deref()
+        .and_then(|path| leviath_providers::codex::ProviderAuthStore::load(path).ok());
     let in_flight = leviath_core::sync::lock(&state.providers.in_flight).clone();
     let providers: Vec<ProviderInfo> = signin_providers()
         .into_iter()
-        .map(|(id, display)| describe(id, display, &config, store_path.as_deref(), &in_flight))
+        .map(|(id, display)| describe(id, display, &config, store.as_ref(), &in_flight))
         .collect();
     Json(serde_json::json!({ "providers": providers })).into_response()
 }
 
-/// The refusal for a name this does not sign in, or `None` when it does.
+/// The catalog's own id for `name`, or the refusal for a name nothing signs
+/// in with.
 ///
-/// An `Option<Response>` rather than a `Result<(), Response>`: an axum
-/// response is a large value, and a `Result` whose `Err` is the big half is
-/// the shape clippy asks about. The answer reads the same at the call sites.
-fn unknown(name: &str) -> Option<axum::response::Response> {
-    if signin_providers().iter().any(|(id, _)| *id == name) {
-        return None;
-    }
-    Some(
-        err(
-            StatusCode::NOT_FOUND,
-            format!("no browser sign-in provider named '{name}'"),
-        )
-        .into_response(),
-    )
+/// Returns the `&'static str` from the table rather than the caller's string,
+/// and every handler works from that. The two are equal by the time this
+/// returns, so it is not a correctness fix - it is that nothing derived from
+/// the request URL then reaches a credential store path, a registry entry or
+/// a filesystem read, and neither a reader nor a scanner has to prove that by
+/// following the string.
+///
+/// The refusal is boxed because an axum response is a large value and this
+/// returns a small one beside it.
+fn resolve(name: &str) -> Result<&'static str, Box<axum::response::Response>> {
+    signin_providers()
+        .iter()
+        .find(|(id, _)| *id == name)
+        .map(|(id, _)| *id)
+        .ok_or_else(|| {
+            Box::new(
+                err(
+                    StatusCode::NOT_FOUND,
+                    format!("no browser sign-in provider named '{name}'"),
+                )
+                .into_response(),
+            )
+        })
 }
 
 /// `POST /api/providers/{name}/login` - start the browser sign-in.
@@ -215,13 +230,14 @@ pub(super) async fn login(
     State(state): State<AppState>,
     AxumPath(name): AxumPath<String>,
 ) -> impl IntoResponse {
-    if let Some(response) = unknown(&name) {
-        return response;
-    }
+    let name = match resolve(&name) {
+        Ok(id) => id,
+        Err(response) => return *response,
+    };
     // One at a time: the flow owns a fixed loopback port that a second could
     // not bind, and two browser windows asking the same question help nobody.
     if let Some(Progress::Waiting { authorize_url, .. }) =
-        leviath_core::sync::lock(&state.providers.in_flight).get(&name)
+        leviath_core::sync::lock(&state.providers.in_flight).get(name)
     {
         return (
             StatusCode::CONFLICT,
@@ -254,15 +270,14 @@ pub(super) async fn login(
     let authorizer = Arc::clone(&state.providers.authorizer);
     let tracker = Arc::clone(&state.providers.in_flight);
     let now = state.providers.now;
-    let id = name.clone();
     tokio::spawn(async move {
-        let outcome = authorizer.sign_in(&id, announce).await;
+        let outcome = authorizer.sign_in(name, announce).await;
         let mut in_flight = leviath_core::sync::lock(&tracker);
         match outcome {
             // Nothing is recorded on success: the grant store is now the
             // answer, and a second copy of "signed in" is how the two drift.
             Ok(_) => {
-                in_flight.remove(&id);
+                in_flight.remove(name);
             }
             Err(e) => {
                 let message = e
@@ -275,7 +290,7 @@ pub(super) async fn login(
                 let _ = leviath_core::sync::lock(&slot)
                     .take()
                     .map(|tx| tx.send(Err(message.clone())));
-                in_flight.insert(id.clone(), Progress::Failed { message, at: now() });
+                in_flight.insert(name.to_string(), Progress::Failed { message, at: now() });
             }
         }
     });
@@ -296,7 +311,7 @@ pub(super) async fn login(
     {
         Ok(url) => {
             leviath_core::sync::lock(&state.providers.in_flight).insert(
-                name.clone(),
+                name.to_string(),
                 Progress::Waiting {
                     authorize_url: url.clone(),
                     started_at: (state.providers.now)(),
@@ -325,12 +340,13 @@ pub(super) async fn logout(
     State(state): State<AppState>,
     AxumPath(name): AxumPath<String>,
 ) -> impl IntoResponse {
-    if let Some(response) = unknown(&name) {
-        return response;
-    }
-    match state.providers.authorizer.sign_out(&name).await {
+    let name = match resolve(&name) {
+        Ok(id) => id,
+        Err(response) => return *response,
+    };
+    match state.providers.authorizer.sign_out(name).await {
         Ok(()) => {
-            leviath_core::sync::lock(&state.providers.in_flight).remove(&name);
+            leviath_core::sync::lock(&state.providers.in_flight).remove(name);
             Json(serde_json::json!({ "status": "signed_out", "provider": name })).into_response()
         }
         Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -346,9 +362,10 @@ pub(super) async fn check(
     State(state): State<AppState>,
     AxumPath(name): AxumPath<String>,
 ) -> impl IntoResponse {
-    if let Some(response) = unknown(&name) {
-        return response;
-    }
+    let name = match resolve(&name) {
+        Ok(id) => id,
+        Err(response) => return *response,
+    };
     let config = state.current_config();
     let mut options = crate::commands::run::session::codex_options(&config);
     // The authorizer's path, not the default one it usually resolves to: the
@@ -370,7 +387,8 @@ pub(super) async fn check(
             .map(|url| ("usage_url".to_string(), url)),
     );
     let creds = leviath_runtime::provider_creds::ProviderCreds {
-        name: name.clone(),
+        // The table's id, not the caller's string: see `resolve`.
+        name: name.to_string(),
         api_key: None,
         base_url: None,
         model_capabilities: HashMap::new(),

--- a/crates/leviath-cli/src/commands/serve/providers.rs
+++ b/crates/leviath-cli/src/commands/serve/providers.rs
@@ -44,11 +44,25 @@ use crate::commands::setup::signin::{LiveAuthorizer, ProviderAuthorizer};
 /// Shaped like [`McpAdmin`](super::mcp::McpAdmin) and for the same reason: the
 /// live authorizer opens a browser and binds a fixed port, so a test supplies
 /// its own rather than being careful.
+///
+/// **No file location lives here**, for the reason [`AdminPaths`] gives:
+/// anything reachable from a handler's parameters is request data as far as a
+/// scanner is concerned, and a file location that is request data is a
+/// path-injection finding. The grant store comes from
+/// [`admin_paths`](super::mcp::admin_paths) inside each handler instead. It
+/// did live here, and CodeQL was right to say so.
+///
+/// [`AdminPaths`]: super::mcp::AdminPaths
 #[derive(Clone)]
 pub(crate) struct ProviderAdmin {
-    /// Takes and forgets the sign-ins. Shared with `lev setup`, so the wizard
-    /// and the API cannot disagree about where a grant goes.
-    pub(crate) authorizer: Arc<LiveAuthorizer>,
+    /// Opens the browser during a sign-in.
+    pub(crate) opener: leviath_mcp::BrowserOpener,
+    /// The OAuth issuer, and the loopback ports its client id is registered
+    /// against. Overridden only by tests, which point them at a local mock and
+    /// port zero so a whole sign-in runs without a browser or a fixed port.
+    pub(crate) issuer: String,
+    /// See [`Self::issuer`].
+    pub(crate) ports: Vec<u16>,
     /// What each provider's sign-in is doing, for the poll to read.
     pub(crate) in_flight: Arc<Mutex<HashMap<String, Progress>>>,
     /// Current Unix time; a fn so a long-lived server stays current.
@@ -65,14 +79,30 @@ pub(crate) struct ProviderAdmin {
 impl Default for ProviderAdmin {
     fn default() -> Self {
         Self {
-            authorizer: Arc::new(LiveAuthorizer::real(
-                Arc::new(leviath_sys::open_url),
-                &super::mcp::admin_paths().config,
-            )),
+            opener: Arc::new(leviath_sys::open_url),
+            issuer: leviath_providers::codex::ISSUER.to_string(),
+            ports: leviath_providers::codex::CALLBACK_PORTS.to_vec(),
             in_flight: Arc::new(Mutex::new(HashMap::new())),
             now: super::mcp::system_now,
             usage_url: None,
         }
+    }
+}
+
+impl ProviderAdmin {
+    /// The authorizer for this request.
+    ///
+    /// Built per call rather than held, so the grant store and the credential
+    /// backend are both read from where they are *now*: a `[security]
+    /// credential_store` change used to need a restart of `lev serve` to take
+    /// effect, because the backend was resolved once at start-up.
+    fn authorizer(&self) -> LiveAuthorizer {
+        let paths = super::mcp::admin_paths();
+        let mut authorizer = LiveAuthorizer::real(self.opener.clone(), &paths.config);
+        authorizer.store_path = Some(paths.grants);
+        authorizer.issuer = self.issuer.clone();
+        authorizer.ports = self.ports.clone();
+        authorizer
     }
 }
 
@@ -179,13 +209,10 @@ fn describe(
 pub(super) async fn list_providers(State(state): State<AppState>) -> impl IntoResponse {
     let config = state.current_config();
     // Read once, not once per row: this is a file, and the answer is the same
-    // for every provider in it.
-    let store = state
-        .providers
-        .authorizer
-        .store_path
-        .as_deref()
-        .and_then(|path| leviath_providers::codex::ProviderAuthStore::load(path).ok());
+    // for every provider in it. The location comes from `admin_paths` rather
+    // than from `state`; see `ProviderAdmin`.
+    let store =
+        leviath_providers::codex::ProviderAuthStore::load(&super::mcp::admin_paths().grants).ok();
     let in_flight = leviath_core::sync::lock(&state.providers.in_flight).clone();
     let providers: Vec<ProviderInfo> = signin_providers()
         .into_iter()
@@ -267,7 +294,10 @@ pub(super) async fn login(
             .map(|tx| tx.send(Ok(url.to_string())));
     });
 
-    let authorizer = Arc::clone(&state.providers.authorizer);
+    // Resolved here, in the request, and moved into the task below: a
+    // `tokio::spawn` does not inherit the task-local the tests scope, so
+    // resolving it in there would reach the real home.
+    let authorizer = state.providers.authorizer();
     let tracker = Arc::clone(&state.providers.in_flight);
     let now = state.providers.now;
     tokio::spawn(async move {
@@ -344,7 +374,7 @@ pub(super) async fn logout(
         Ok(id) => id,
         Err(response) => return *response,
     };
-    match state.providers.authorizer.sign_out(name).await {
+    match state.providers.authorizer().sign_out(name).await {
         Ok(()) => {
             leviath_core::sync::lock(&state.providers.in_flight).remove(name);
             Json(serde_json::json!({ "status": "signed_out", "provider": name })).into_response()
@@ -371,13 +401,9 @@ pub(super) async fn check(
     // The authorizer's path, not the default one it usually resolves to: the
     // sign-in wrote there, and a check that read somewhere else would report
     // a provider with no grant a moment after storing one.
-    options.extend(
-        state
-            .providers
-            .authorizer
-            .store_path
-            .as_ref()
-            .map(|path| ("auth_store_path".to_string(), path.display().to_string())),
+    options.insert(
+        "auth_store_path".to_string(),
+        super::mcp::admin_paths().grants.display().to_string(),
     );
     options.extend(
         state

--- a/crates/leviath-cli/src/commands/serve/providers.rs
+++ b/crates/leviath-cli/src/commands/serve/providers.rs
@@ -1,0 +1,398 @@
+//! `/api/providers`: the providers that sign in with a browser, and the
+//! sign-in itself.
+//!
+//! `PUT /api/config` can already turn Codex on. It cannot sign anybody in, and
+//! a provider that is enabled but not signed in is a provider every run fails
+//! against - so a console that could only write the flag could get a user
+//! exactly as far as broken. That is what these routes are for.
+//!
+//! ## Why login does not block
+//!
+//! The MCP login route holds its request open for the whole OAuth flow, up to
+//! its five-minute callback timeout. That is fine for a CLI and wrong for a
+//! browser UI: the tab has nothing to draw while it waits, no way to show the
+//! URL for a machine whose browser did not open, and no way to give up without
+//! losing the flow.
+//!
+//! So `POST .../login` returns as soon as there is an authorize URL - which is
+//! immediately, since it exists the moment the loopback listener binds - and
+//! the flow carries on behind it. The caller polls `GET /api/providers`, which
+//! reports `waiting`, then `signed_in` or the failure. One extra request buys
+//! a UI that can render the whole thing.
+//!
+//! ## Where the browser has to be
+//!
+//! On the machine running `lev serve`. The redirect goes to `localhost:1455`
+//! there and nowhere else, because that is what the public client id is
+//! registered against. A console driving a remote daemon can still start the
+//! flow and show the URL, but somebody has to open it on the daemon's host.
+//! `authorize_url` is in the response for exactly that case.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+
+use super::types::{AppState, err};
+use crate::commands::setup::signin::{LiveAuthorizer, ProviderAuthorizer};
+
+/// The seams and the shared state the provider routes need.
+///
+/// Shaped like [`McpAdmin`](super::mcp::McpAdmin) and for the same reason: the
+/// live authorizer opens a browser and binds a fixed port, so a test supplies
+/// its own rather than being careful.
+#[derive(Clone)]
+pub(crate) struct ProviderAdmin {
+    /// Takes and forgets the sign-ins. Shared with `lev setup`, so the wizard
+    /// and the API cannot disagree about where a grant goes.
+    pub(crate) authorizer: Arc<LiveAuthorizer>,
+    /// What each provider's sign-in is doing, for the poll to read.
+    pub(crate) in_flight: Arc<Mutex<HashMap<String, Progress>>>,
+    /// Current Unix time; a fn so a long-lived server stays current.
+    pub(crate) now: fn() -> u64,
+    /// Where the credential check reads the subscription's quota, when it is
+    /// not the provider's own route.
+    ///
+    /// `None` in production. It exists so a test can answer the check without
+    /// reaching OpenAI, and it is the same field anybody proxying that route
+    /// would need.
+    pub(crate) usage_url: Option<String>,
+}
+
+impl Default for ProviderAdmin {
+    fn default() -> Self {
+        Self {
+            authorizer: Arc::new(LiveAuthorizer::real(
+                Arc::new(leviath_sys::open_url),
+                &super::mcp::admin_paths().config,
+            )),
+            in_flight: Arc::new(Mutex::new(HashMap::new())),
+            now: super::mcp::system_now,
+            usage_url: None,
+        }
+    }
+}
+
+/// Where one provider's sign-in has got to.
+///
+/// Only the unfinished states live here. A finished one is the grant store's
+/// to report, and keeping a second copy of "signed in" is how the two come to
+/// disagree.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub(crate) enum Progress {
+    /// The browser was asked to open this, and the callback has not arrived.
+    Waiting {
+        /// The page to open, for a host whose browser did not.
+        authorize_url: String,
+        /// When it started, in unix seconds.
+        started_at: u64,
+    },
+    /// It did not finish, and this is why.
+    Failed {
+        /// What went wrong, ready to show.
+        message: String,
+        /// When it failed, in unix seconds.
+        at: u64,
+    },
+}
+
+/// One browser-sign-in provider, as the API reports it.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ProviderInfo {
+    /// The registry name a blueprint would use: `codex/gpt-5.6-sol`.
+    pub(crate) id: String,
+    /// The name to show.
+    pub(crate) display: String,
+    /// Whether `config.toml` has it turned on. Separate from `signed_in`:
+    /// the two are set by different routes and either can be true alone.
+    pub(crate) enabled: bool,
+    /// Whether a grant is stored.
+    pub(crate) signed_in: bool,
+    /// The account, when the grant names one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) account: Option<String>,
+    /// The subscription tier, when the grant names one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) plan: Option<String>,
+    /// When the *access* token lapses, in unix seconds.
+    ///
+    /// Not a deadline for the user: it is refreshed automatically well before
+    /// this, and it is here so a console can show that the session is live
+    /// rather than implying anybody has to act on it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) expires_at: Option<u64>,
+    /// A sign-in in flight, or the last one that failed. Absent when there is
+    /// neither.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) signin: Option<serde_json::Value>,
+}
+
+/// The providers that sign in with a browser.
+///
+/// One entry today. A list rather than a `codex` key so a second one is a
+/// table entry rather than a new route and a console change.
+fn signin_providers() -> Vec<(&'static str, &'static str)> {
+    crate::commands::setup::catalog::providers()
+        .into_iter()
+        .filter(|p| p.credential == crate::commands::setup::catalog::Credential::Signin)
+        .map(|p| (p.id, p.display))
+        .collect()
+}
+
+/// Describe one provider from the config, the grant store and the tracker.
+fn describe(
+    id: &str,
+    display: &str,
+    config: &crate::config::Config,
+    store_path: Option<&std::path::Path>,
+    in_flight: &HashMap<String, Progress>,
+) -> ProviderInfo {
+    let grant = store_path
+        .and_then(|path| leviath_providers::codex::ProviderAuthStore::load(path).ok())
+        .and_then(|store| store.get(id).cloned());
+    let claims = grant.as_ref().map(leviath_providers::ProviderGrant::claims);
+    ProviderInfo {
+        id: id.to_string(),
+        display: display.to_string(),
+        enabled: config.providers.codex_enabled,
+        signed_in: grant.is_some(),
+        account: grant
+            .as_ref()
+            .and_then(|g| g.email.clone())
+            .or_else(|| claims.as_ref().and_then(|c| c.email.clone())),
+        plan: grant
+            .as_ref()
+            .and_then(|g| g.plan_type.clone())
+            .or_else(|| claims.as_ref().and_then(|c| c.plan_type.clone())),
+        expires_at: grant
+            .as_ref()
+            .and_then(|g| leviath_providers::codex::claims::expiry(&g.access_token)),
+        signin: in_flight
+            .get(id)
+            .map(|p| serde_json::to_value(p).unwrap_or(serde_json::Value::Null)),
+    }
+}
+
+/// `GET /api/providers` - every browser-sign-in provider and its state.
+pub(super) async fn list_providers(State(state): State<AppState>) -> impl IntoResponse {
+    let config = state.current_config();
+    let store_path = state.providers.authorizer.store_path.clone();
+    let in_flight = leviath_core::sync::lock(&state.providers.in_flight).clone();
+    let providers: Vec<ProviderInfo> = signin_providers()
+        .into_iter()
+        .map(|(id, display)| describe(id, display, &config, store_path.as_deref(), &in_flight))
+        .collect();
+    Json(serde_json::json!({ "providers": providers })).into_response()
+}
+
+/// The refusal for a name this does not sign in, or `None` when it does.
+///
+/// An `Option<Response>` rather than a `Result<(), Response>`: an axum
+/// response is a large value, and a `Result` whose `Err` is the big half is
+/// the shape clippy asks about. The answer reads the same at the call sites.
+fn unknown(name: &str) -> Option<axum::response::Response> {
+    if signin_providers().iter().any(|(id, _)| *id == name) {
+        return None;
+    }
+    Some(
+        err(
+            StatusCode::NOT_FOUND,
+            format!("no browser sign-in provider named '{name}'"),
+        )
+        .into_response(),
+    )
+}
+
+/// `POST /api/providers/{name}/login` - start the browser sign-in.
+///
+/// Returns `202` with the authorize URL as soon as there is one; the flow
+/// continues behind the response and `GET /api/providers` reports how it went.
+pub(super) async fn login(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+) -> impl IntoResponse {
+    if let Some(response) = unknown(&name) {
+        return response;
+    }
+    // One at a time: the flow owns a fixed loopback port that a second could
+    // not bind, and two browser windows asking the same question help nobody.
+    if let Some(Progress::Waiting { authorize_url, .. }) =
+        leviath_core::sync::lock(&state.providers.in_flight).get(&name)
+    {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": format!("a sign-in to '{name}' is already waiting"),
+                "authorize_url": authorize_url,
+            })),
+        )
+            .into_response();
+    }
+
+    // One channel for both answers: the URL when the flow gets that far, and
+    // the reason when it does not. A second channel, or reading the failure
+    // back out of the tracker, would leave the handler racing the task that
+    // recorded it.
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel::<Result<String, String>>();
+    // A `Fn`, not a `FnOnce`, so the sender lives in a slot it can be taken
+    // out of. Whichever of the two fires first wins, and `login` announces at
+    // most once.
+    let slot = Arc::new(Mutex::new(Some(started_tx)));
+    let announce_slot = Arc::clone(&slot);
+    let announce: crate::commands::auth::codex::Announce = Arc::new(move |url: &str| {
+        // `Option::map` rather than `if let`: an `if let` with no else leaves
+        // a region only a second announce could reach, and there is not one.
+        let _ = leviath_core::sync::lock(&announce_slot)
+            .take()
+            .map(|tx| tx.send(Ok(url.to_string())));
+    });
+
+    let authorizer = Arc::clone(&state.providers.authorizer);
+    let tracker = Arc::clone(&state.providers.in_flight);
+    let now = state.providers.now;
+    let id = name.clone();
+    tokio::spawn(async move {
+        let outcome = authorizer.sign_in(&id, announce).await;
+        let mut in_flight = leviath_core::sync::lock(&tracker);
+        match outcome {
+            // Nothing is recorded on success: the grant store is now the
+            // answer, and a second copy of "signed in" is how the two drift.
+            Ok(_) => {
+                in_flight.remove(&id);
+            }
+            Err(e) => {
+                let message = e
+                    .chain()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(": ");
+                // The handler is still waiting if this failed before there was
+                // a URL to announce, and this is what it reads.
+                let _ = leviath_core::sync::lock(&slot)
+                    .take()
+                    .map(|tx| tx.send(Err(message.clone())));
+                in_flight.insert(id.clone(), Progress::Failed { message, at: now() });
+            }
+        }
+    });
+
+    // Awaited without a deadline, deliberately. Everything between the spawn
+    // above and one of the two answers is a PKCE generate, a loopback bind and
+    // a string format: the URL exists within microseconds or the bind failed
+    // and the reason is already on its way. A timeout here would be guarding
+    // a stall that cannot happen, and the arm reporting it would be code no
+    // test could ever reach.
+    //
+    // `unwrap_or` with a value rather than a closure covers the one case left:
+    // a task that ended without answering either way, which is a panic in the
+    // flow. The channel closes, and the caller is told rather than held.
+    match started_rx
+        .await
+        .unwrap_or(Err("the sign-in ended before it began".to_string()))
+    {
+        Ok(url) => {
+            leviath_core::sync::lock(&state.providers.in_flight).insert(
+                name.clone(),
+                Progress::Waiting {
+                    authorize_url: url.clone(),
+                    started_at: (state.providers.now)(),
+                },
+            );
+            (
+                StatusCode::ACCEPTED,
+                Json(serde_json::json!({
+                    "status": "waiting",
+                    "provider": name,
+                    "authorize_url": url,
+                })),
+            )
+                .into_response()
+        }
+        Err(message) => err(StatusCode::BAD_GATEWAY, message).into_response(),
+    }
+}
+
+/// `POST /api/providers/{name}/logout` - forget the stored grant.
+///
+/// `config.toml` is deliberately untouched, the same as `lev auth logout`:
+/// signing out is not the same as turning the provider off, and doing both
+/// would surprise anyone who meant to sign in again.
+pub(super) async fn logout(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+) -> impl IntoResponse {
+    if let Some(response) = unknown(&name) {
+        return response;
+    }
+    match state.providers.authorizer.sign_out(&name).await {
+        Ok(()) => {
+            leviath_core::sync::lock(&state.providers.in_flight).remove(&name);
+            Json(serde_json::json!({ "status": "signed_out", "provider": name })).into_response()
+        }
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+/// `POST /api/providers/{name}/check` - prove the stored sign-in works.
+///
+/// The same check `lev setup` runs, through the same code: it asks the account
+/// rather than reading a compiled table, so a green answer here means the
+/// subscription really did agree.
+pub(super) async fn check(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+) -> impl IntoResponse {
+    if let Some(response) = unknown(&name) {
+        return response;
+    }
+    let config = state.current_config();
+    let mut options = crate::commands::run::session::codex_options(&config);
+    // The authorizer's path, not the default one it usually resolves to: the
+    // sign-in wrote there, and a check that read somewhere else would report
+    // a provider with no grant a moment after storing one.
+    options.extend(
+        state
+            .providers
+            .authorizer
+            .store_path
+            .as_ref()
+            .map(|path| ("auth_store_path".to_string(), path.display().to_string())),
+    );
+    options.extend(
+        state
+            .providers
+            .usage_url
+            .clone()
+            .map(|url| ("usage_url".to_string(), url)),
+    );
+    let creds = leviath_runtime::provider_creds::ProviderCreds {
+        name: name.clone(),
+        api_key: None,
+        base_url: None,
+        model_capabilities: HashMap::new(),
+        request_timeout_secs: Some(20),
+        rate_limit: None,
+        options,
+    };
+    // Read through the outcome's own helpers rather than matched variant by
+    // variant: `verify_via_registry` never skips - only the wizard's
+    // `--no-verify` backend does, and that one is not wired here - so a
+    // `Skipped` arm would be a branch nothing could reach.
+    let outcome = crate::commands::setup::verify::verify_via_registry(&creds).await;
+    if outcome.is_failure() {
+        return err(StatusCode::BAD_GATEWAY, outcome.summary()).into_response();
+    }
+    Json(serde_json::json!({
+        "status": "ok",
+        "provider": name,
+        "models": outcome.models(),
+    }))
+    .into_response()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/leviath-cli/src/commands/serve/providers/tests.rs
+++ b/crates/leviath-cli/src/commands/serve/providers/tests.rs
@@ -24,23 +24,30 @@ fn fixed_now() -> u64 {
     1_700_000_000
 }
 
-/// An authorizer pointed at `issuer`, writing into `dir`, with `opener`
-/// playing the browser.
-fn authorizer(
-    dir: &std::path::Path,
-    issuer: String,
-    opener: leviath_mcp::BrowserOpener,
-) -> LiveAuthorizer {
-    LiveAuthorizer {
+/// An admin pointed at `issuer`, with `opener` playing the browser.
+///
+/// No path here: the grant store comes from `admin_paths`, which `app_at`
+/// scopes onto the router. See `ProviderAdmin`.
+fn admin(issuer: String, opener: leviath_mcp::BrowserOpener) -> ProviderAdmin {
+    ProviderAdmin {
         opener,
-        store_path: Some(dir.join("provider-auth.json")),
-        credential_store: Ok(None),
-        client: reqwest::Client::new(),
         issuer,
         // The registered ports are the production value; a test that bound
         // them would fight whatever the developer has signed in.
         ports: vec![0],
+        in_flight: Arc::new(Mutex::new(HashMap::new())),
+        now: fixed_now,
+        usage_url: None,
     }
+}
+
+/// An admin that never reaches an issuer and never opens anything, for the
+/// routes that do neither.
+fn quiet_admin() -> ProviderAdmin {
+    admin(
+        "http://127.0.0.1:1".to_string(),
+        Arc::new(|_: &str| panic!("no browser may open")),
+    )
 }
 
 /// App state carrying `admin`, with the rest stubbed.
@@ -58,22 +65,21 @@ fn state_with(admin: ProviderAdmin, config: Config) -> AppState {
     }
 }
 
-fn admin_over(authorizer: LiveAuthorizer) -> ProviderAdmin {
-    ProviderAdmin {
-        authorizer: Arc::new(authorizer),
-        in_flight: Arc::new(Mutex::new(HashMap::new())),
-        now: fixed_now,
-        usage_url: None,
-    }
-}
-
-fn router(state: AppState) -> Router {
-    Router::new()
-        .route("/api/providers", get(list_providers))
-        .route("/api/providers/{name}/login", post(login))
-        .route("/api/providers/{name}/logout", post(logout))
-        .route("/api/providers/{name}/check", post(check))
-        .with_state(state)
+/// A router over `state` whose handlers read the files under `dir`.
+fn app_at(dir: &std::path::Path, state: AppState) -> Router {
+    crate::commands::serve::mcp::scoped(
+        Router::new()
+            .route("/api/providers", get(list_providers))
+            .route("/api/providers/{name}/login", post(login))
+            .route("/api/providers/{name}/logout", post(logout))
+            .route("/api/providers/{name}/check", post(check))
+            .with_state(state),
+        crate::commands::serve::mcp::AdminPaths {
+            config: dir.join("config.toml"),
+            store: dir.join("mcp-auth.json"),
+            grants: dir.join("provider-auth.json"),
+        },
+    )
 }
 
 async fn send(app: &Router, method: &str, uri: &str) -> (StatusCode, serde_json::Value) {
@@ -130,14 +136,13 @@ async fn the_listing_reports_enabled_and_signed_in_separately() {
     let dir = tempfile::tempdir().unwrap();
     let mut config = Config::default();
     config.providers.codex_enabled = true;
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            "http://127.0.0.1:1".to_string(),
-            Arc::new(|_: &str| true),
-        )),
-        config,
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin("http://127.0.0.1:1".to_string(), Arc::new(|_: &str| true)),
+            config,
+        ),
+    );
 
     let (status, body) = send(&app, "GET", "/api/providers").await;
     assert_eq!(status, StatusCode::OK);
@@ -163,14 +168,13 @@ async fn the_listing_reports_enabled_and_signed_in_separately() {
 async fn the_listing_never_carries_a_token() {
     let dir = tempfile::tempdir().unwrap();
     store_grant(dir.path());
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            "http://127.0.0.1:1".to_string(),
-            Arc::new(|_: &str| true),
-        )),
-        Config::default(),
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin("http://127.0.0.1:1".to_string(), Arc::new(|_: &str| true)),
+            Config::default(),
+        ),
+    );
 
     let (_, body) = send(&app, "GET", "/api/providers").await;
     let text = body.to_string();
@@ -188,14 +192,16 @@ async fn the_listing_never_carries_a_token() {
 async fn a_login_returns_a_url_at_once_and_the_listing_settles() {
     let dir = tempfile::tempdir().unwrap();
     let seen = Arc::new(Mutex::new(Vec::new()));
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            mock_issuer().await,
-            browser_that_redirects(Arc::clone(&seen)),
-        )),
-        Config::default(),
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin(
+                mock_issuer().await,
+                browser_that_redirects(Arc::clone(&seen)),
+            ),
+            Config::default(),
+        ),
+    );
 
     let (status, body) = send(&app, "POST", "/api/providers/codex/login").await;
     assert_eq!(status, StatusCode::ACCEPTED);
@@ -228,15 +234,17 @@ async fn a_login_returns_a_url_at_once_and_the_listing_settles() {
 async fn a_failed_login_is_reported_and_then_visible_on_the_listing() {
     let dir = tempfile::tempdir().unwrap();
     let seen = Arc::new(Mutex::new(Vec::new()));
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            // Nothing listens on port 1, so the code exchange fails.
-            "http://127.0.0.1:1".to_string(),
-            browser_that_redirects(Arc::clone(&seen)),
-        )),
-        Config::default(),
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin(
+                // Nothing listens on port 1, so the code exchange fails.
+                "http://127.0.0.1:1".to_string(),
+                browser_that_redirects(Arc::clone(&seen)),
+            ),
+            Config::default(),
+        ),
+    );
 
     let (status, _) = send(&app, "POST", "/api/providers/codex/login").await;
     assert_eq!(status, StatusCode::ACCEPTED, "it started before it failed");
@@ -266,14 +274,13 @@ async fn a_failed_login_is_reported_and_then_visible_on_the_listing() {
 async fn a_second_login_is_refused_with_the_url_of_the_first() {
     let dir = tempfile::tempdir().unwrap();
     // A browser that never redirects, so the first flow stays waiting.
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            "http://127.0.0.1:1".to_string(),
-            Arc::new(|_: &str| false),
-        )),
-        Config::default(),
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin("http://127.0.0.1:1".to_string(), Arc::new(|_: &str| false)),
+            Config::default(),
+        ),
+    );
 
     let (status, first) = send(&app, "POST", "/api/providers/codex/login").await;
     assert_eq!(status, StatusCode::ACCEPTED);
@@ -288,14 +295,16 @@ async fn a_second_login_is_refused_with_the_url_of_the_first() {
 #[tokio::test]
 async fn an_unknown_provider_is_a_404_everywhere() {
     let dir = tempfile::tempdir().unwrap();
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            "http://127.0.0.1:1".to_string(),
-            Arc::new(|_: &str| panic!("no browser may open")),
-        )),
-        Config::default(),
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin(
+                "http://127.0.0.1:1".to_string(),
+                Arc::new(|_: &str| panic!("no browser may open")),
+            ),
+            Config::default(),
+        ),
+    );
 
     for route in [
         "/api/providers/anthropic/login",
@@ -314,14 +323,16 @@ async fn signing_out_forgets_the_grant_and_not_the_setting() {
     store_grant(dir.path());
     let mut config = Config::default();
     config.providers.codex_enabled = true;
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            "http://127.0.0.1:1".to_string(),
-            Arc::new(|_: &str| panic!("no browser may open")),
-        )),
-        config,
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin(
+                "http://127.0.0.1:1".to_string(),
+                Arc::new(|_: &str| panic!("no browser may open")),
+            ),
+            config,
+        ),
+    );
 
     let (status, body) = send(&app, "POST", "/api/providers/codex/logout").await;
     assert_eq!(status, StatusCode::OK);
@@ -341,38 +352,38 @@ async fn signing_out_forgets_the_grant_and_not_the_setting() {
 async fn a_sign_out_that_cannot_read_the_store_is_an_error() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("provider-auth.json"), "{ not json").unwrap();
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            "http://127.0.0.1:1".to_string(),
-            Arc::new(|_: &str| panic!("no browser may open")),
-        )),
-        Config::default(),
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin(
+                "http://127.0.0.1:1".to_string(),
+                Arc::new(|_: &str| panic!("no browser may open")),
+            ),
+            Config::default(),
+        ),
+    );
 
     let (status, _) = send(&app, "POST", "/api/providers/codex/logout").await;
     assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
 }
 
-/// A login whose flow ends before it has a URL - no home to write into -
-/// reports the reason rather than the timeout.
+/// A login whose flow ends before it has a URL reports the reason, rather
+/// than leaving the caller waiting on a URL that is never coming.
+///
+/// Driven with no ports to try, which is the shape of the real failure: the
+/// two registered ones are taken, usually by a `codex login` of the user's
+/// own.
 #[tokio::test]
 async fn a_login_that_never_starts_reports_why() {
-    let mut authorizer = authorizer(
-        std::path::Path::new("/unused"),
-        "http://127.0.0.1:1".to_string(),
-        Arc::new(|_: &str| panic!("no browser may open")),
-    );
-    authorizer.store_path = None;
-    let app = router(state_with(admin_over(authorizer), Config::default()));
+    let dir = tempfile::tempdir().unwrap();
+    let mut admin = quiet_admin();
+    admin.ports = Vec::new();
+    let app = app_at(dir.path(), state_with(admin, Config::default()));
 
     let (status, body) = send(&app, "POST", "/api/providers/codex/login").await;
     assert_eq!(status, StatusCode::BAD_GATEWAY);
     assert!(
-        body["error"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("LEVIATH_HOME"),
+        !body["error"].as_str().unwrap_or_default().is_empty(),
         "{body}"
     );
 }
@@ -382,14 +393,13 @@ async fn a_login_that_never_starts_reports_why() {
 #[tokio::test]
 async fn a_waiting_sign_in_records_when_it_started() {
     let dir = tempfile::tempdir().unwrap();
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            "http://127.0.0.1:1".to_string(),
-            Arc::new(|_: &str| false),
-        )),
-        Config::default(),
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin("http://127.0.0.1:1".to_string(), Arc::new(|_: &str| false)),
+            Config::default(),
+        ),
+    );
 
     send(&app, "POST", "/api/providers/codex/login").await;
     let (_, body) = send(&app, "GET", "/api/providers").await;
@@ -415,14 +425,13 @@ async fn the_account_falls_back_to_the_id_token() {
     );
     store.save(&dir.path().join("provider-auth.json")).unwrap();
 
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            "http://127.0.0.1:1".to_string(),
-            Arc::new(|_: &str| true),
-        )),
-        Config::default(),
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin("http://127.0.0.1:1".to_string(), Arc::new(|_: &str| true)),
+            Config::default(),
+        ),
+    );
 
     let (_, body) = send(&app, "GET", "/api/providers").await;
     assert_eq!(body["providers"][0]["account"], "someone@example.com");
@@ -434,14 +443,16 @@ async fn the_account_falls_back_to_the_id_token() {
 #[tokio::test]
 async fn checking_without_a_sign_in_is_refused() {
     let dir = tempfile::tempdir().unwrap();
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            "http://127.0.0.1:1".to_string(),
-            Arc::new(|_: &str| panic!("no browser may open")),
-        )),
-        Config::default(),
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin(
+                "http://127.0.0.1:1".to_string(),
+                Arc::new(|_: &str| panic!("no browser may open")),
+            ),
+            Config::default(),
+        ),
+    );
 
     let (status, body) = send(&app, "POST", "/api/providers/codex/check").await;
     assert_eq!(status, StatusCode::BAD_GATEWAY);
@@ -456,24 +467,34 @@ async fn checking_without_a_sign_in_is_refused() {
 #[tokio::test]
 async fn checking_an_unknown_provider_is_a_404() {
     let dir = tempfile::tempdir().unwrap();
-    let app = router(state_with(
-        admin_over(authorizer(
-            dir.path(),
-            "http://127.0.0.1:1".to_string(),
-            Arc::new(|_: &str| panic!("no browser may open")),
-        )),
-        Config::default(),
-    ));
+    let app = app_at(
+        dir.path(),
+        state_with(
+            admin(
+                "http://127.0.0.1:1".to_string(),
+                Arc::new(|_: &str| panic!("no browser may open")),
+            ),
+            Config::default(),
+        ),
+    );
 
     let (status, _) = send(&app, "POST", "/api/providers/openai/check").await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
-/// The default admin resolves this machine rather than being handed paths.
+/// The default admin points at the real issuer and the two registered ports,
+/// and its authorizer takes its store from `admin_paths` rather than from a
+/// field somebody could set.
 #[test]
 fn the_default_admin_points_at_this_machine() {
     let admin = ProviderAdmin::default();
-    assert!(admin.authorizer.store_path.is_some(), "a home resolves");
+    assert_eq!(admin.issuer, leviath_providers::codex::ISSUER);
+    assert_eq!(admin.ports, leviath_providers::codex::CALLBACK_PORTS);
+    let authorizer = admin.authorizer();
+    assert_eq!(
+        authorizer.store_path,
+        Some(crate::commands::serve::mcp::admin_paths().grants)
+    );
     assert!(
         leviath_core::sync::lock(&admin.in_flight).is_empty(),
         "nothing is in flight before anything is asked"
@@ -493,13 +514,9 @@ async fn a_check_reports_the_models_the_plan_can_reach() {
         br#"{"plan_type":"plus","rate_limit":{}}"#.to_vec(),
     )
     .await;
-    let mut admin = admin_over(authorizer(
-        dir.path(),
-        "http://127.0.0.1:1".to_string(),
-        Arc::new(|_: &str| panic!("no browser may open")),
-    ));
+    let mut admin = quiet_admin();
     admin.usage_url = Some(usage);
-    let app = router(state_with(admin, Config::default()));
+    let app = app_at(dir.path(), state_with(admin, Config::default()));
 
     let (status, body) = send(&app, "POST", "/api/providers/codex/check").await;
     assert_eq!(status, StatusCode::OK, "{body}");

--- a/crates/leviath-cli/src/commands/serve/providers/tests.rs
+++ b/crates/leviath-cli/src/commands/serve/providers/tests.rs
@@ -1,0 +1,513 @@
+//! The provider routes, driven end to end against a local issuer.
+//!
+//! The sign-in is real: a mock issuer, the stub browser the login flow already
+//! had, and port zero instead of the two registered ones. Nothing opens and
+//! nothing reaches OpenAI, and the path the Lair will drive is the path under
+//! test rather than a mocked stand-in for it.
+
+use super::*;
+use crate::commands::auth::codex::tests::{browser_that_redirects, id_token};
+use axum::Router;
+use axum::body::Body;
+use axum::http::Request;
+use axum::routing::{get, post};
+use leviath_providers::ProviderGrant;
+use leviath_providers::codex::ProviderAuthStore;
+use tokio::sync::broadcast;
+use tower::ServiceExt as _;
+
+use crate::config::Config;
+
+/// A fixed clock, so a recorded timestamp is an assertion rather than a
+/// reading of the wall.
+fn fixed_now() -> u64 {
+    1_700_000_000
+}
+
+/// An authorizer pointed at `issuer`, writing into `dir`, with `opener`
+/// playing the browser.
+fn authorizer(
+    dir: &std::path::Path,
+    issuer: String,
+    opener: leviath_mcp::BrowserOpener,
+) -> LiveAuthorizer {
+    LiveAuthorizer {
+        opener,
+        store_path: Some(dir.join("provider-auth.json")),
+        credential_store: Ok(None),
+        client: reqwest::Client::new(),
+        issuer,
+        // The registered ports are the production value; a test that bound
+        // them would fight whatever the developer has signed in.
+        ports: vec![0],
+    }
+}
+
+/// App state carrying `admin`, with the rest stubbed.
+fn state_with(admin: ProviderAdmin, config: Config) -> AppState {
+    let (tx, _) = broadcast::channel(16);
+    AppState {
+        update_check: Default::default(),
+        update_jobs: Default::default(),
+        config: crate::commands::serve::testutil::fixed_config(config),
+        event_tx: tx,
+        control: crate::commands::serve::testutil::no_daemon_client(),
+        mcp: crate::commands::serve::mcp::McpAdmin::default(),
+        providers: admin,
+        limits: Default::default(),
+    }
+}
+
+fn admin_over(authorizer: LiveAuthorizer) -> ProviderAdmin {
+    ProviderAdmin {
+        authorizer: Arc::new(authorizer),
+        in_flight: Arc::new(Mutex::new(HashMap::new())),
+        now: fixed_now,
+        usage_url: None,
+    }
+}
+
+fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/api/providers", get(list_providers))
+        .route("/api/providers/{name}/login", post(login))
+        .route("/api/providers/{name}/logout", post(logout))
+        .route("/api/providers/{name}/check", post(check))
+        .with_state(state)
+}
+
+async fn send(app: &Router, method: &str, uri: &str) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, json)
+}
+
+/// The issuer's token response, for a sign-in that is meant to succeed.
+async fn mock_issuer() -> String {
+    let body = serde_json::json!({
+        "access_token": "at-1",
+        "refresh_token": "rt-1",
+        "id_token": id_token(),
+        "expires_in": 3600,
+    });
+    leviath_testkit::spawn_mock_server(200, "OK", body.to_string().into_bytes()).await
+}
+
+/// Write a grant straight into the store, for the routes that read one.
+fn store_grant(dir: &std::path::Path) {
+    let mut store = ProviderAuthStore::default();
+    store.set(
+        "codex",
+        ProviderGrant {
+            access_token: "at".to_string(),
+            refresh_token: "rt".to_string(),
+            email: Some("someone@example.com".to_string()),
+            plan_type: Some("plus".to_string()),
+            ..Default::default()
+        },
+    );
+    store.save(&dir.join("provider-auth.json")).unwrap();
+}
+
+/// The listing separates "turned on" from "signed in", which is the whole
+/// point: either can be true alone, and a console needs to tell them apart to
+/// know which button to offer.
+#[tokio::test]
+async fn the_listing_reports_enabled_and_signed_in_separately() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = Config::default();
+    config.providers.codex_enabled = true;
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            "http://127.0.0.1:1".to_string(),
+            Arc::new(|_: &str| true),
+        )),
+        config,
+    ));
+
+    let (status, body) = send(&app, "GET", "/api/providers").await;
+    assert_eq!(status, StatusCode::OK);
+    let first = &body["providers"][0];
+    assert_eq!(first["id"], "codex");
+    assert_eq!(first["enabled"], true);
+    assert_eq!(first["signed_in"], false, "enabled is not signed in");
+    assert!(first["account"].is_null());
+    assert!(first["signin"].is_null(), "nothing is in flight");
+
+    store_grant(dir.path());
+    let (_, body) = send(&app, "GET", "/api/providers").await;
+    let first = &body["providers"][0];
+    assert_eq!(first["signed_in"], true);
+    assert_eq!(first["account"], "someone@example.com");
+    assert_eq!(first["plan"], "plus");
+}
+
+/// The listing carries no token. It is open to any caller holding the bearer,
+/// which is a wider audience than the admin routes, so what it discloses is
+/// worth pinning.
+#[tokio::test]
+async fn the_listing_never_carries_a_token() {
+    let dir = tempfile::tempdir().unwrap();
+    store_grant(dir.path());
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            "http://127.0.0.1:1".to_string(),
+            Arc::new(|_: &str| true),
+        )),
+        Config::default(),
+    ));
+
+    let (_, body) = send(&app, "GET", "/api/providers").await;
+    let text = body.to_string();
+    for secret in ["at", "rt"] {
+        assert!(
+            !text.contains(&format!("\"{secret}\"")),
+            "a token reached the listing: {text}"
+        );
+    }
+}
+
+/// The whole flow the Lair drives: start it, get a URL back without waiting
+/// for the browser, and watch the listing turn over to signed in.
+#[tokio::test]
+async fn a_login_returns_a_url_at_once_and_the_listing_settles() {
+    let dir = tempfile::tempdir().unwrap();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            mock_issuer().await,
+            browser_that_redirects(Arc::clone(&seen)),
+        )),
+        Config::default(),
+    ));
+
+    let (status, body) = send(&app, "POST", "/api/providers/codex/login").await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(body["status"], "waiting");
+    let url = body["authorize_url"].as_str().expect("a URL to open");
+    assert!(url.contains("code_challenge"), "{url}");
+
+    // The flow is still running behind the response, so the listing settles a
+    // moment later rather than immediately.
+    let mut signed_in = false;
+    for _ in 0..100 {
+        let (_, body) = send(&app, "GET", "/api/providers").await;
+        if body["providers"][0]["signed_in"] == true {
+            assert_eq!(body["providers"][0]["account"], "someone@example.com");
+            assert!(
+                body["providers"][0]["signin"].is_null(),
+                "the finished flow left a state behind: {body}"
+            );
+            signed_in = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(signed_in, "the sign-in never landed");
+}
+
+/// A flow that cannot reach its issuer reports why, and leaves the reason on
+/// the listing rather than only in the response nobody kept.
+#[tokio::test]
+async fn a_failed_login_is_reported_and_then_visible_on_the_listing() {
+    let dir = tempfile::tempdir().unwrap();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            // Nothing listens on port 1, so the code exchange fails.
+            "http://127.0.0.1:1".to_string(),
+            browser_that_redirects(Arc::clone(&seen)),
+        )),
+        Config::default(),
+    ));
+
+    let (status, _) = send(&app, "POST", "/api/providers/codex/login").await;
+    assert_eq!(status, StatusCode::ACCEPTED, "it started before it failed");
+
+    let mut failed = false;
+    for _ in 0..100 {
+        let (_, body) = send(&app, "GET", "/api/providers").await;
+        if body["providers"][0]["signin"]["state"] == "failed" {
+            assert!(
+                !body["providers"][0]["signin"]["message"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .is_empty()
+            );
+            assert_eq!(body["providers"][0]["signed_in"], false);
+            failed = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(failed, "the failure never surfaced");
+}
+
+/// A second sign-in while one is waiting is refused with the URL of the one
+/// already running, so a console that lost the response can pick it back up.
+#[tokio::test]
+async fn a_second_login_is_refused_with_the_url_of_the_first() {
+    let dir = tempfile::tempdir().unwrap();
+    // A browser that never redirects, so the first flow stays waiting.
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            "http://127.0.0.1:1".to_string(),
+            Arc::new(|_: &str| false),
+        )),
+        Config::default(),
+    ));
+
+    let (status, first) = send(&app, "POST", "/api/providers/codex/login").await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+
+    let (status, second) = send(&app, "POST", "/api/providers/codex/login").await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(second["authorize_url"], first["authorize_url"]);
+}
+
+/// A name nothing signs in with is a 404 on every route, rather than being
+/// handed to a flow written for one provider.
+#[tokio::test]
+async fn an_unknown_provider_is_a_404_everywhere() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            "http://127.0.0.1:1".to_string(),
+            Arc::new(|_: &str| panic!("no browser may open")),
+        )),
+        Config::default(),
+    ));
+
+    for route in [
+        "/api/providers/anthropic/login",
+        "/api/providers/anthropic/logout",
+    ] {
+        let (status, _) = send(&app, "POST", route).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{route}");
+    }
+}
+
+/// Signing out forgets the grant and leaves `config.toml` alone, the same as
+/// `lev auth logout`.
+#[tokio::test]
+async fn signing_out_forgets_the_grant_and_not_the_setting() {
+    let dir = tempfile::tempdir().unwrap();
+    store_grant(dir.path());
+    let mut config = Config::default();
+    config.providers.codex_enabled = true;
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            "http://127.0.0.1:1".to_string(),
+            Arc::new(|_: &str| panic!("no browser may open")),
+        )),
+        config,
+    ));
+
+    let (status, body) = send(&app, "POST", "/api/providers/codex/logout").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "signed_out");
+
+    let (_, body) = send(&app, "GET", "/api/providers").await;
+    assert_eq!(body["providers"][0]["signed_in"], false);
+    assert_eq!(
+        body["providers"][0]["enabled"], true,
+        "signing out turned the provider off"
+    );
+}
+
+/// A sign-out that cannot read the store says so rather than reporting that
+/// there was nothing to forget.
+#[tokio::test]
+async fn a_sign_out_that_cannot_read_the_store_is_an_error() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("provider-auth.json"), "{ not json").unwrap();
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            "http://127.0.0.1:1".to_string(),
+            Arc::new(|_: &str| panic!("no browser may open")),
+        )),
+        Config::default(),
+    ));
+
+    let (status, _) = send(&app, "POST", "/api/providers/codex/logout").await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+/// A login whose flow ends before it has a URL - no home to write into -
+/// reports the reason rather than the timeout.
+#[tokio::test]
+async fn a_login_that_never_starts_reports_why() {
+    let mut authorizer = authorizer(
+        std::path::Path::new("/unused"),
+        "http://127.0.0.1:1".to_string(),
+        Arc::new(|_: &str| panic!("no browser may open")),
+    );
+    authorizer.store_path = None;
+    let app = router(state_with(admin_over(authorizer), Config::default()));
+
+    let (status, body) = send(&app, "POST", "/api/providers/codex/login").await;
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("LEVIATH_HOME"),
+        "{body}"
+    );
+}
+
+/// The timestamps come from the injected clock, so a recorded `started_at` is
+/// something a test can assert rather than read off the wall.
+#[tokio::test]
+async fn a_waiting_sign_in_records_when_it_started() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            "http://127.0.0.1:1".to_string(),
+            Arc::new(|_: &str| false),
+        )),
+        Config::default(),
+    ));
+
+    send(&app, "POST", "/api/providers/codex/login").await;
+    let (_, body) = send(&app, "GET", "/api/providers").await;
+    assert_eq!(body["providers"][0]["signin"]["state"], "waiting");
+    assert_eq!(body["providers"][0]["signin"]["started_at"], fixed_now());
+}
+
+/// A grant that names nobody still reports the account and plan, because the
+/// id token carries them. The stored fields are a cache of those claims, and
+/// an older grant was written before they existed.
+#[tokio::test]
+async fn the_account_falls_back_to_the_id_token() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut store = ProviderAuthStore::default();
+    store.set(
+        "codex",
+        ProviderGrant {
+            access_token: "at".to_string(),
+            refresh_token: "rt".to_string(),
+            id_token: id_token(),
+            ..Default::default()
+        },
+    );
+    store.save(&dir.path().join("provider-auth.json")).unwrap();
+
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            "http://127.0.0.1:1".to_string(),
+            Arc::new(|_: &str| true),
+        )),
+        Config::default(),
+    ));
+
+    let (_, body) = send(&app, "GET", "/api/providers").await;
+    assert_eq!(body["providers"][0]["account"], "someone@example.com");
+    assert_eq!(body["providers"][0]["plan"], "plus");
+}
+
+/// The check reaches the network. A store with no grant in it cannot answer,
+/// and that is a 502 carrying the reason rather than a cheerful model list.
+#[tokio::test]
+async fn checking_without_a_sign_in_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            "http://127.0.0.1:1".to_string(),
+            Arc::new(|_: &str| panic!("no browser may open")),
+        )),
+        Config::default(),
+    ));
+
+    let (status, body) = send(&app, "POST", "/api/providers/codex/check").await;
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+    assert!(
+        !body["error"].as_str().unwrap_or_default().is_empty(),
+        "{body}"
+    );
+}
+
+/// And the check is refused for a provider that does not sign in at all,
+/// rather than being handed to the codex registry arm.
+#[tokio::test]
+async fn checking_an_unknown_provider_is_a_404() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = router(state_with(
+        admin_over(authorizer(
+            dir.path(),
+            "http://127.0.0.1:1".to_string(),
+            Arc::new(|_: &str| panic!("no browser may open")),
+        )),
+        Config::default(),
+    ));
+
+    let (status, _) = send(&app, "POST", "/api/providers/openai/check").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+/// The default admin resolves this machine rather than being handed paths.
+#[test]
+fn the_default_admin_points_at_this_machine() {
+    let admin = ProviderAdmin::default();
+    assert!(admin.authorizer.store_path.is_some(), "a home resolves");
+    assert!(
+        leviath_core::sync::lock(&admin.in_flight).is_empty(),
+        "nothing is in flight before anything is asked"
+    );
+}
+
+/// The whole point of the check: it asks the account. A store with a grant in
+/// it and a quota route that answers gives back the models *this plan* can
+/// reach, not the compiled table.
+#[tokio::test]
+async fn a_check_reports_the_models_the_plan_can_reach() {
+    let dir = tempfile::tempdir().unwrap();
+    store_grant(dir.path());
+    let usage = leviath_testkit::spawn_mock_server(
+        200,
+        "OK",
+        br#"{"plan_type":"plus","rate_limit":{}}"#.to_vec(),
+    )
+    .await;
+    let mut admin = admin_over(authorizer(
+        dir.path(),
+        "http://127.0.0.1:1".to_string(),
+        Arc::new(|_: &str| panic!("no browser may open")),
+    ));
+    admin.usage_url = Some(usage);
+    let app = router(state_with(admin, Config::default()));
+
+    let (status, body) = send(&app, "POST", "/api/providers/codex/check").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["status"], "ok");
+    let models = body["models"].as_array().expect("a model list");
+    assert!(!models.is_empty());
+    assert!(
+        !models.iter().any(|m| m == "gpt-5.3-codex-spark"),
+        "a pro-only model reached a plus account: {body}"
+    );
+}

--- a/crates/leviath-cli/src/commands/serve/testutil.rs
+++ b/crates/leviath-cli/src/commands/serve/testutil.rs
@@ -53,6 +53,7 @@ pub(super) fn state_with_agent_paths(paths: Vec<std::path::PathBuf>) -> super::t
         event_tx,
         control: no_daemon_client(),
         mcp: super::mcp::McpAdmin::default(),
+        providers: super::providers::ProviderAdmin::default(),
         limits: Default::default(),
     }
 }
@@ -72,6 +73,7 @@ pub(super) fn state_with_config_at(path: &std::path::Path) -> super::types::AppS
         event_tx,
         control: no_daemon_client(),
         mcp: super::mcp::McpAdmin::default(),
+        providers: super::providers::ProviderAdmin::default(),
         limits: Default::default(),
     }
 }

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -144,6 +144,8 @@ pub(crate) struct AppState {
     pub(super) control: leviath_runtime::control_socket::ControlClient,
     /// Paths + seams for the MCP management endpoints.
     pub(super) mcp: super::mcp::McpAdmin,
+    /// Seams and in-flight state for the provider sign-in endpoints.
+    pub(super) providers: super::providers::ProviderAdmin,
     /// The spawn-request restrictions from [`ServeArgs`], resolved once at
     /// startup so every handler reads the same decision.
     pub(super) limits: Arc<ServeLimits>,
@@ -1283,6 +1285,10 @@ mod tests {
             has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: None,
+            codex_enabled: false,
+            codex_reasoning_effort: None,
+            codex_verbosity: None,
+            codex_replay_reasoning: true,
             gateways: Vec::new(),
             agent_paths: vec![],
             mcp_server_count: 0,

--- a/crates/leviath-cli/src/commands/serve/update.rs
+++ b/crates/leviath-cli/src/commands/serve/update.rs
@@ -167,6 +167,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }
@@ -216,6 +217,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
 

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -224,6 +224,7 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
     }
@@ -671,6 +672,7 @@ mod tests {
             event_tx: tx,
             control: daemon.client.clone(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         let greeting = serde_json::to_value(link_greeting(&state).expect("news")).unwrap();
@@ -833,6 +835,7 @@ mod tests {
             event_tx: tx.clone(),
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         let addr = spawn_test_server(state).await;
@@ -962,6 +965,7 @@ mod tests {
             event_tx: tx.clone(),
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
         let (addr, shutdown_tx, handle) = spawn_test_server_with_shutdown(state).await;

--- a/crates/leviath-cli/src/commands/setup/catalog.rs
+++ b/crates/leviath-cli/src/commands/setup/catalog.rs
@@ -29,6 +29,50 @@ pub enum Credential {
     Signin,
 }
 
+/// Where a provider's choice lives in a [`Config`], as the row itself
+/// declares it.
+///
+/// Adding a provider used to mean adding an arm to `stored_credential`, one
+/// to `set_credential`, sometimes one to `is_configured`, and an entry in
+/// `configured_providers` - four places, none of which the compiler would
+/// mention if you missed them, and one of which shipped missed. A row that
+/// carries its own accessors is one place instead, and the functions below
+/// are then written once against any provider rather than once per provider.
+#[derive(Clone, Copy)]
+pub enum Setting {
+    /// One `Option<String>` on the config: an API key, or a base URL.
+    /// `None` means "not configured".
+    Text {
+        /// Read the value.
+        read: fn(&Config) -> Option<String>,
+        /// Write it, or clear it with `None`.
+        write: fn(&mut Config, Option<String>),
+    },
+    /// A `bool` on the config. The credential, if there is one, lives
+    /// somewhere else entirely - a browser grant, or an installed CLI.
+    Switch {
+        /// Read the switch.
+        read: fn(&Config) -> bool,
+        /// Set it.
+        write: fn(&mut Config, bool),
+    },
+    /// Written as `[model_providers]` entries under a name the user picks, so
+    /// there is no single field to read: see `is_configured`.
+    Endpoints,
+}
+
+/// Hand-written: function pointers have no useful `Debug`, and the shape is
+/// what a reader wants anyway.
+impl std::fmt::Debug for Setting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Text { .. } => "Text",
+            Self::Switch { .. } => "Switch",
+            Self::Endpoints => "Endpoints",
+        })
+    }
+}
+
 /// One configurable provider.
 #[derive(Debug, Clone)]
 pub struct Provider {
@@ -51,6 +95,8 @@ pub struct Provider {
     /// For an endpoint preset, the address a fresh entry starts with. `None`
     /// for the custom preset, which asks.
     pub preset_url: Option<&'static str>,
+    /// Where this provider's choice lives in a [`Config`].
+    pub setting: Setting,
 }
 
 /// Every provider the wizard offers, in the order it offers them.
@@ -65,6 +111,10 @@ pub(crate) fn providers() -> Vec<Provider> {
             env_var: Some("ANTHROPIC_API_KEY"),
             signup_url: Some("https://console.anthropic.com/settings/keys"),
             preset_url: None,
+            setting: Setting::Text {
+                read: |c| c.providers.anthropic_api_key.clone(),
+                write: |c, v| c.providers.anthropic_api_key = v,
+            },
         },
         Provider {
             id: "openai",
@@ -75,6 +125,10 @@ pub(crate) fn providers() -> Vec<Provider> {
             env_var: Some("OPENAI_API_KEY"),
             signup_url: Some("https://platform.openai.com/api-keys"),
             preset_url: None,
+            setting: Setting::Text {
+                read: |c| c.providers.openai_api_key.clone(),
+                write: |c, v| c.providers.openai_api_key = v,
+            },
         },
         Provider {
             id: "google",
@@ -85,6 +139,10 @@ pub(crate) fn providers() -> Vec<Provider> {
             env_var: Some("GOOGLE_API_KEY"),
             signup_url: Some("https://aistudio.google.com/app/apikey"),
             preset_url: None,
+            setting: Setting::Text {
+                read: |c| c.providers.google_api_key.clone(),
+                write: |c, v| c.providers.google_api_key = v,
+            },
         },
         Provider {
             id: "openrouter",
@@ -95,6 +153,10 @@ pub(crate) fn providers() -> Vec<Provider> {
             env_var: Some("OPENROUTER_API_KEY"),
             signup_url: Some("https://openrouter.ai/keys"),
             preset_url: None,
+            setting: Setting::Text {
+                read: |c| c.openrouter_api_key.clone(),
+                write: |c, v| c.openrouter_api_key = v,
+            },
         },
         Provider {
             id: "codex",
@@ -106,6 +168,10 @@ pub(crate) fn providers() -> Vec<Provider> {
             env_var: None,
             signup_url: Some("https://chatgpt.com/codex"),
             preset_url: None,
+            setting: Setting::Switch {
+                read: |c| c.providers.codex_enabled,
+                write: |c, v| c.providers.codex_enabled = v,
+            },
         },
         Provider {
             id: "ollama",
@@ -116,6 +182,23 @@ pub(crate) fn providers() -> Vec<Provider> {
             env_var: Some("OLLAMA_HOST"),
             signup_url: Some("https://ollama.com/download"),
             preset_url: None,
+            // Two config fields, one setting. `ollama_enabled` is "I chose
+            // Ollama" and the URL is "and it is not at the default address",
+            // so a config that names a URL counts as chosen even if it
+            // predates the switch. The default address is deliberately not
+            // stored: pinning it would stop `$OLLAMA_HOST` and the built-in
+            // default from applying.
+            setting: Setting::Text {
+                read: |c| {
+                    (c.providers.ollama_enabled || c.ollama_base_url.is_some())
+                        .then(|| c.ollama_base_url.clone().unwrap_or_default())
+                },
+                write: |c, v| {
+                    c.providers.ollama_enabled = v.is_some();
+                    c.ollama_base_url =
+                        v.filter(|url| !url.is_empty() && url != DEFAULT_OLLAMA_URL);
+                },
+            },
         },
         Provider {
             id: "llama-cpp",
@@ -127,6 +210,7 @@ pub(crate) fn providers() -> Vec<Provider> {
             env_var: None,
             signup_url: Some("https://github.com/ggml-org/llama.cpp"),
             preset_url: Some(LLAMA_CPP_URL),
+            setting: Setting::Endpoints,
         },
         Provider {
             id: "lm-studio",
@@ -138,6 +222,7 @@ pub(crate) fn providers() -> Vec<Provider> {
             env_var: None,
             signup_url: Some("https://lmstudio.ai"),
             preset_url: Some(LM_STUDIO_URL),
+            setting: Setting::Endpoints,
         },
         Provider {
             id: "openai-compatible",
@@ -149,6 +234,7 @@ pub(crate) fn providers() -> Vec<Provider> {
             env_var: None,
             signup_url: None,
             preset_url: None,
+            setting: Setting::Endpoints,
         },
     ]
 }
@@ -190,56 +276,62 @@ pub const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
 /// going faster.
 pub const OLLAMA_MAX_CONCURRENT_INFERENCES: usize = 1;
 
+/// The row for `id`, if the catalog has one.
+fn row(id: &str) -> Option<Provider> {
+    providers().into_iter().find(|p| p.id == id)
+}
+
 /// Read a provider's currently-configured credential out of a config.
 ///
-/// `openrouter_api_key` and `ollama_base_url` sit at the top level of `Config`
-/// while the other three live under `[providers]` - a legacy split this
-/// function hides from everything else.
+/// The `Switch` kinds answer a marker string rather than a secret: there is
+/// no credential in the config to read, and the wizard's "is this configured"
+/// and "did this change" both want a value that changes when the switch does.
 pub(crate) fn stored_credential(config: &Config, id: &str) -> Option<String> {
-    match id {
-        "anthropic" => config.providers.anthropic_api_key.clone(),
-        "openai" => config.providers.openai_api_key.clone(),
-        "google" => config.providers.google_api_key.clone(),
-        "openrouter" => config.openrouter_api_key.clone(),
-        "ollama" => config.ollama_base_url.clone(),
-        // Not a credential: the grant lives outside the config. The value is
-        // the on/off flag, so the wizard's "is this configured" and "did this
-        // change" both read the right thing.
-        "codex" => config
-            .providers
-            .codex_enabled
-            .then(|| "enabled".to_string()),
-        _ => None,
+    match row(id)?.setting {
+        Setting::Text { read, .. } => read(config),
+        Setting::Switch { read, .. } => read(config).then(|| "enabled".to_string()),
+        Setting::Endpoints => None,
     }
 }
 
 /// Write a provider's credential into a config. `None` clears it.
 pub(crate) fn set_credential(config: &mut Config, id: &str, value: Option<String>) {
-    match id {
-        "anthropic" => config.providers.anthropic_api_key = value,
-        "openai" => config.providers.openai_api_key = value,
-        "google" => config.providers.google_api_key = value,
-        "openrouter" => config.openrouter_api_key = value,
-        "ollama" => config.ollama_base_url = value,
-        "codex" => config.providers.codex_enabled = value.is_some(),
-        // An unknown id has nowhere to go.
-        _ => {}
+    // An id the catalog does not have goes nowhere, which is what a
+    // `_ => {}` arm used to say.
+    let Some(row) = row(id) else {
+        return;
+    };
+    match row.setting {
+        Setting::Text { write, .. } => write(config, value),
+        Setting::Switch { write, .. } => write(config, value.is_some()),
+        Setting::Endpoints => {}
     }
 }
 
-/// Whether a provider counts as configured in this config: it has a credential.
+/// Whether a provider counts as configured in this config.
 pub(crate) fn is_configured(config: &Config, id: &str) -> bool {
-    match id {
+    match row(id).map(|p| p.setting) {
         // An endpoint preset is "configured" when the file holds an endpoint
         // entry that sits under it.
-        "llama-cpp" | "lm-studio" | "openai-compatible" => config
+        Some(Setting::Endpoints) => config
             .model_providers
             .iter()
             .any(|(name, entry)| entry.is_endpoint() && preset_for(name, entry) == id),
-        // Ollama is always usable at its default endpoint, but "configured"
-        // here means "the user chose it", which is the stored URL.
         _ => stored_credential(config, id).is_some(),
     }
+}
+
+/// Every provider this config has configured, in catalog order.
+///
+/// Derived from the table rather than restated: the list that decides which
+/// providers can be the default used to be its own hard-coded tuple, and a
+/// provider missing from it was configured, usable, and not offered.
+pub(crate) fn configured(config: &Config) -> Vec<&'static str> {
+    providers()
+        .into_iter()
+        .filter(|p| is_configured(config, p.id))
+        .map(|p| p.id)
+        .collect()
 }
 
 /// Redact a credential for display.
@@ -263,6 +355,50 @@ mod tests {
     use super::*;
 
     // ─── the table ──────────────────────────────────────────────────────────
+
+    /// The hand-written `Debug` names the shape, which is the useful half:
+    /// function pointers print as addresses and tell a reader nothing.
+    #[test]
+    fn a_setting_debugs_as_its_shape() {
+        let shapes: Vec<String> = providers()
+            .iter()
+            .map(|p| format!("{:?}", p.setting))
+            .collect();
+        for shape in &shapes {
+            assert!(
+                ["Text", "Switch", "Endpoints"].contains(&shape.as_str()),
+                "{shape}"
+            );
+        }
+        assert!(shapes.iter().any(|s| s == "Text"));
+        assert!(shapes.iter().any(|s| s == "Switch"));
+        assert!(shapes.iter().any(|s| s == "Endpoints"));
+    }
+
+    /// An endpoint preset has no field of its own to write: its entries live
+    /// under names the user picks, and `is_configured` looks for those.
+    /// Writing to the preset is a no-op rather than a panic or a stray key.
+    #[test]
+    fn writing_to_an_endpoint_preset_changes_nothing() {
+        let mut config = Config::default();
+        set_credential(&mut config, "llama-cpp", Some("http://h/v1".to_string()));
+        assert!(config.model_providers.is_empty());
+        assert!(stored_credential(&config, "llama-cpp").is_none());
+        assert!(!is_configured(&config, "llama-cpp"));
+    }
+
+    /// And an id the catalog does not have goes nowhere at all.
+    #[test]
+    fn writing_to_an_unknown_provider_changes_nothing() {
+        let mut config = Config::default();
+        set_credential(&mut config, "not-a-provider", Some("x".to_string()));
+        assert!(stored_credential(&config, "not-a-provider").is_none());
+        assert!(!is_configured(&config, "not-a-provider"));
+        // And nothing landed in any of the fields a real provider writes.
+        assert!(config.providers.anthropic_api_key.is_none());
+        assert!(config.openrouter_api_key.is_none());
+        assert!(!config.providers.codex_enabled);
+    }
 
     #[test]
     fn every_provider_has_a_distinct_id_and_is_described() {

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -238,28 +238,46 @@ fn configured_providers(config: &Config) -> Vec<String> {
         .map(|(name, _)| name.as_str())
         .collect();
     endpoints.sort_unstable();
-    [
-        ("anthropic", config.providers.anthropic_api_key.is_some()),
-        ("openai", config.providers.openai_api_key.is_some()),
-        ("google", config.providers.google_api_key.is_some()),
-        ("openrouter", config.openrouter_api_key.is_some()),
-        ("claude-code", config.providers.claude_code_enabled),
+    let kind = |id: &str| {
+        catalog::providers()
+            .into_iter()
+            .find(|p| p.id == id)
+            .map(|p| p.credential)
+    };
+    let chosen: Vec<&'static str> = catalog::configured(config)
+        .into_iter()
+        // An endpoint *preset* is not a provider name: the entries under it
+        // are, and they are listed by name below.
+        .filter(|id| kind(id) != Some(catalog::Credential::Endpoint))
         // Enabled *and* signed in. Enabled alone would let a headless
         // `--codex true` make an unauthenticated provider the host default,
         // and the very next run would fail on a credential nobody was asked
         // for.
-        (
-            "codex",
-            config.providers.codex_enabled && codex_grant_exists(),
-        ),
-    ]
-    .into_iter()
-    .filter(|(_, configured)| *configured)
-    .map(|(id, _)| id)
-    .chain(endpoints)
-    .chain(config.ollama_base_url.is_some().then_some("ollama"))
-    .map(str::to_string)
-    .collect()
+        .filter(|id| *id != leviath_providers::codex::PROVIDER_NAME || codex_grant_exists())
+        .collect();
+    // A provider that needed no credential sorts last, and the first name in
+    // this list is what `--default-provider` picks when nothing else says.
+    // A local server the user happens to have is the weakest thing to choose
+    // on somebody's behalf: it should lose to every key they went and got,
+    // and to every endpoint they wrote down.
+    let (unkeyed, keyed): (Vec<&str>, Vec<&str>) = chosen
+        .into_iter()
+        .partition(|id| kind(id) == Some(catalog::Credential::BaseUrl));
+    keyed
+        .into_iter()
+        // The Claude Code transport has no catalog row: the wizard omits it
+        // by a pinned test, because the CLI adds its own context to every
+        // call. It is still a provider a run can use, so it is named here.
+        .chain(
+            config
+                .providers
+                .claude_code_enabled
+                .then_some("claude-code"),
+        )
+        .chain(endpoints)
+        .chain(unkeyed)
+        .map(str::to_string)
+        .collect()
 }
 
 /// Whether a Codex sign-in has actually been taken.
@@ -586,6 +604,9 @@ mod tests {
                 ..Default::default()
             },
         );
+        // Ollama last: a local server nobody had to sign up for should not
+        // outrank an endpoint the user wrote down when something has to pick
+        // a default.
         assert_eq!(configured_providers(&config), ["alpha", "zeta", "ollama"]);
         apply_flags(&mut config, &args());
         assert_eq!(config.default_provider, "alpha");

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -674,6 +674,148 @@ mod tests {
         });
     }
 
+    /// Choosing a provider in the wizard reaches the runtime: it is offered
+    /// as a default, and it is built into the credentials a run resolves
+    /// against.
+    ///
+    /// Over `catalog::providers()`, so a provider added to that table is
+    /// covered the day it is added rather than the day somebody remembers.
+    ///
+    /// Adding a provider means touching about eight places - the catalog row,
+    /// three match arms in `catalog`, the credential arm in `build_config`,
+    /// the tuple in `configured_providers`, the creds in
+    /// `provider_creds_from_config` and the registry arm in
+    /// `provider_creds` - and nothing held them together. Codex reached the
+    /// last two and stopped at the fifth, so it signed in, congratulated the
+    /// user, and vanished. This is the test that says so.
+    #[test]
+    fn every_offered_provider_reaches_the_runtime_when_it_is_chosen() {
+        let dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("LEVIATH_HOME", Some(dir.path()), || {
+            // Codex counts as configured only once it is signed in, so the
+            // grant has to exist before the question is asked.
+            let grants =
+                leviath_providers::codex::ProviderAuthStore::default_path().expect("a home is set");
+            let mut store = leviath_providers::codex::ProviderAuthStore::default();
+            store.set(
+                "codex",
+                leviath_providers::ProviderGrant {
+                    access_token: "at".to_string(),
+                    refresh_token: "rt".to_string(),
+                    ..Default::default()
+                },
+            );
+            store.save(&grants).unwrap();
+
+            for provider in crate::commands::setup::catalog::providers() {
+                // An endpoint preset writes `[model_providers]` entries under
+                // a name the user picks, not a credential under its own id.
+                // Those have their own tests.
+                if provider.credential == crate::commands::setup::catalog::Credential::Endpoint {
+                    continue;
+                }
+                let mut wizard = crate::commands::setup::state::tests::test_wizard(dir.path());
+                let index = wizard
+                    .providers
+                    .iter()
+                    .position(|r| r.provider.id == provider.id)
+                    .expect("the row this came from");
+                for row in &mut wizard.providers {
+                    row.selected = false;
+                    row.value = String::new();
+                }
+                wizard.providers[index].selected = true;
+                wizard.providers[index].value = match provider.credential {
+                    crate::commands::setup::catalog::Credential::ApiKey => {
+                        "a-credential".to_string()
+                    }
+                    // Not the default: that deliberately writes nothing, and
+                    // `state::tests` asserts it separately.
+                    crate::commands::setup::catalog::Credential::BaseUrl => {
+                        "http://elsewhere:11434".to_string()
+                    }
+                    _ => String::new(),
+                };
+
+                let config = wizard.build_config();
+                assert!(
+                    configured_providers(&config).contains(&provider.id.to_string()),
+                    "'{}' cannot be chosen as the default provider after being configured",
+                    provider.id
+                );
+                let creds = crate::commands::run::session::provider_creds_from_config(&config);
+                // Named up front rather than formatted into the assertion: a
+                // call that only runs when it fails is a region no passing
+                // test reaches.
+                let built: Vec<&String> = creds.iter().map(|c| &c.name).collect();
+                assert!(
+                    built.iter().any(|name| *name == provider.id),
+                    "'{}' is configured but a run would not build it: {built:?}",
+                    provider.id
+                );
+            }
+        });
+    }
+
+    /// The reported bug, end to end: choose Codex in the wizard, apply, and
+    /// find it in the file and on the default-provider list.
+    ///
+    /// The unit above proves `configured_providers` reads the two flags
+    /// correctly; it did not prove anything ever wrote the first one. It did
+    /// not: a browser sign-in types nothing, `build_config` read that as "no
+    /// credential given", and the sign-in was switched off at Apply. The
+    /// symptom was a wizard that connected, congratulated you, and left a
+    /// config with `codex_enabled` unset - no `codex/...` models, and Codex
+    /// missing from the default-provider choices on the next run through.
+    #[test]
+    fn choosing_codex_in_the_wizard_reaches_the_config_file() {
+        let dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("LEVIATH_HOME", Some(dir.path()), || {
+            let grants =
+                leviath_providers::codex::ProviderAuthStore::default_path().expect("a home is set");
+            let mut store = leviath_providers::codex::ProviderAuthStore::default();
+            store.set(
+                "codex",
+                leviath_providers::ProviderGrant {
+                    access_token: "at".to_string(),
+                    refresh_token: "rt".to_string(),
+                    ..Default::default()
+                },
+            );
+            store.save(&grants).unwrap();
+
+            let mut wizard = crate::commands::setup::state::tests::test_wizard(dir.path());
+            let index = wizard
+                .providers
+                .iter()
+                .position(|r| r.provider.id == "codex")
+                .expect("the codex row is offered");
+            for row in &mut wizard.providers {
+                row.selected = false;
+            }
+            wizard.providers[index].selected = true;
+
+            let config_path = dir.path().join("config.toml");
+            let plan = wizard.build_plan();
+            plan::apply(&plan, &config_path, &dir.path().join("agents"), None)
+                .expect("the plan applies");
+
+            let saved = Config::load_from_path_public(&config_path).expect("it reads back");
+            assert!(
+                saved.providers.codex_enabled,
+                "the sign-in was switched off on the way to disk"
+            );
+            assert!(
+                configured_providers(&saved).contains(&"codex".to_string()),
+                "codex is not offered as a default provider"
+            );
+
+            // And the text really is in the file, not only in the struct.
+            let toml = std::fs::read_to_string(&config_path).expect("the file");
+            assert!(toml.contains("codex_enabled"), "{toml}");
+        });
+    }
+
     /// The flag sets the switch and nothing else: it never opens a browser,
     /// because nothing is watching one in a non-interactive run.
     #[test]

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -1003,38 +1003,22 @@ impl Wizard {
                 // Written below, from the entries rather than the row.
                 Credential::Endpoint => {}
                 _ if !row.selected => catalog::set_credential(&mut config, row.provider.id, None),
-                // A browser sign-in types nothing, so choosing the row *is*
-                // the setting and the credential itself lives outside the
-                // config. Ahead of the empty-value arm below, which is about a
-                // credential that was not given: this one never has a value to
-                // give, so it fell there and every finished sign-in was
-                // switched back off the moment the plan was applied.
-                // A browser sign-in types nothing, so choosing the row *is*
-                // the setting and the credential itself lives outside the
-                // config. Ahead of the empty-value arm below, which is about a
-                // credential that was not given: this one never has a value to
-                // give, so it fell there and every finished sign-in was
-                // switched back off the moment the plan was applied.
-                // A browser sign-in types nothing, so choosing the row *is*
-                // the setting and the credential itself lives outside the
-                // config. Ahead of the empty-value arm below, which is about a
-                // credential that was not given: this one never has a value to
-                // give, so it fell there and every finished sign-in was
-                // switched back off the moment the plan was applied.
-                Credential::Signin => {
-                    catalog::set_credential(&mut config, row.provider.id, Some(String::new()))
-                }
-                // An environment-supplied credential is left out of the file:
-                // the user put it in their environment on purpose, and
-                // `Config::load` already reads it back from there.
-                _ if row.value.is_empty() => {
+                // A key left blank is a credential the user did not give -
+                // usually because it is in their environment on purpose, and
+                // `Config::load` reads it back from there. This is the only
+                // kind that rule holds for, and it used to be written as "any
+                // empty value", which caught the kinds that never have one: a
+                // browser sign-in types nothing, so every finished Codex
+                // sign-in was switched back off the moment the plan was
+                // applied.
+                Credential::ApiKey if row.value.is_empty() => {
                     catalog::set_credential(&mut config, row.provider.id, None)
                 }
-                Credential::BaseUrl if row.value == catalog::DEFAULT_OLLAMA_URL => {
-                    // Storing the default would pin it; leaving it unset lets
-                    // the built-in default (and `$OLLAMA_HOST`) apply.
-                    catalog::set_credential(&mut config, row.provider.id, None)
-                }
+                // Everything else: choosing the row is the setting, and
+                // whatever was typed rides along. What that means is the row's
+                // own business - Ollama drops an address equal to its default
+                // so `$OLLAMA_HOST` still applies, and a browser sign-in has
+                // nothing to store at all - and none of it is decided here.
                 _ => catalog::set_credential(&mut config, row.provider.id, Some(row.value.clone())),
             }
         }
@@ -2947,17 +2931,18 @@ pub(super) mod tests {
         }
     }
 
-    /// The one documented exception to the rule above: a base-URL provider
-    /// left on its default writes nothing.
+    /// A base-URL provider left on its default is configured, and its
+    /// address is still not written down.
     ///
-    /// Deliberate - storing the default would pin it, and `$OLLAMA_HOST` and
-    /// the built-in default would both stop applying. The cost is that
-    /// choosing Ollama and keeping the default leaves it out of
-    /// `configured_providers`, so it cannot be picked as the default
-    /// provider. Asserted rather than skipped, so changing it is a decision
-    /// somebody makes on purpose.
+    /// Those used to be the same answer: the only record of the choice was
+    /// the URL, so keeping the default meant recording nothing, and choosing
+    /// Ollama left it out of `configured_providers` entirely - it could not
+    /// be picked as the default provider, and the wizard forgot it by the
+    /// next run. Storing the default instead would pin it and stop
+    /// `$OLLAMA_HOST` applying, so the choice and the address are now two
+    /// fields saying two different things.
     #[test]
-    fn a_base_url_provider_left_on_its_default_writes_nothing() {
+    fn a_base_url_provider_left_on_its_default_is_still_chosen() {
         let dir = tempfile::tempdir().unwrap();
         let mut wizard = test_wizard(dir.path());
         let index = wizard
@@ -2975,8 +2960,21 @@ pub(super) mod tests {
         let config = wizard.build_config();
         let id = wizard.providers[index].provider.id;
         assert!(
-            !catalog::is_configured(&config, id),
-            "'{id}' on its default should leave the file alone"
+            catalog::is_configured(&config, id),
+            "'{id}' was chosen and is not configured"
+        );
+        assert_eq!(
+            config.ollama_base_url, None,
+            "the default address was pinned, so $OLLAMA_HOST stops applying"
+        );
+
+        // And a *different* address is written down, because that one is not
+        // something any default would supply.
+        wizard.providers[index].value = "http://elsewhere:11434".to_string();
+        let config = wizard.build_config();
+        assert_eq!(
+            config.ollama_base_url.as_deref(),
+            Some("http://elsewhere:11434")
         );
     }
 

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -1003,6 +1003,27 @@ impl Wizard {
                 // Written below, from the entries rather than the row.
                 Credential::Endpoint => {}
                 _ if !row.selected => catalog::set_credential(&mut config, row.provider.id, None),
+                // A browser sign-in types nothing, so choosing the row *is*
+                // the setting and the credential itself lives outside the
+                // config. Ahead of the empty-value arm below, which is about a
+                // credential that was not given: this one never has a value to
+                // give, so it fell there and every finished sign-in was
+                // switched back off the moment the plan was applied.
+                // A browser sign-in types nothing, so choosing the row *is*
+                // the setting and the credential itself lives outside the
+                // config. Ahead of the empty-value arm below, which is about a
+                // credential that was not given: this one never has a value to
+                // give, so it fell there and every finished sign-in was
+                // switched back off the moment the plan was applied.
+                // A browser sign-in types nothing, so choosing the row *is*
+                // the setting and the credential itself lives outside the
+                // config. Ahead of the empty-value arm below, which is about a
+                // credential that was not given: this one never has a value to
+                // give, so it fell there and every finished sign-in was
+                // switched back off the moment the plan was applied.
+                Credential::Signin => {
+                    catalog::set_credential(&mut config, row.provider.id, Some(String::new()))
+                }
                 // An environment-supplied credential is left out of the file:
                 // the user put it in their environment on purpose, and
                 // `Config::load` already reads it back from there.
@@ -2870,6 +2891,93 @@ pub(super) mod tests {
 
         assert!(wizard.detail_actions().is_empty());
         assert_eq!(wizard.row_count(), 0);
+    }
+
+    /// Every provider the wizard offers survives being chosen.
+    ///
+    /// Over `catalog::providers()` rather than a written-out list, so a
+    /// provider added to that table is covered the day it is added. This is
+    /// the invariant the whole screen exists to produce, and nothing else
+    /// asserted it end to end: Codex shipped selected, signed in, and switched
+    /// back off by `build_config`, because a browser sign-in types nothing and
+    /// the empty-value arm read that as "no credential given".
+    #[test]
+    fn every_offered_provider_is_configured_by_choosing_it() {
+        let dir = tempfile::tempdir().unwrap();
+        for provider in catalog::providers() {
+            // Endpoint presets are their entries, not a row credential, and
+            // have their own tests; everything else answers here.
+            if provider.credential == Credential::Endpoint {
+                continue;
+            }
+            let mut wizard = test_wizard(dir.path());
+            let index = wizard
+                .providers
+                .iter()
+                .position(|r| r.provider.id == provider.id)
+                .expect("the row this came from");
+            for row in &mut wizard.providers {
+                row.selected = false;
+                row.value = String::new();
+            }
+
+            // Unselected: not configured, whatever the file said before.
+            let off = wizard.build_config();
+            assert!(
+                !catalog::is_configured(&off, provider.id),
+                "'{}' is configured without being chosen",
+                provider.id
+            );
+
+            // Chosen, and given whatever its kind actually needs. A sign-in
+            // needs nothing typed, which is the case that broke.
+            wizard.providers[index].selected = true;
+            wizard.providers[index].value = match provider.credential {
+                Credential::ApiKey => "a-credential".to_string(),
+                // Not the default one: see the separate case below.
+                Credential::BaseUrl => "http://elsewhere:11434".to_string(),
+                Credential::Signin | Credential::Endpoint => String::new(),
+            };
+            let on = wizard.build_config();
+            assert!(
+                catalog::is_configured(&on, provider.id),
+                "choosing '{}' did not configure it",
+                provider.id
+            );
+        }
+    }
+
+    /// The one documented exception to the rule above: a base-URL provider
+    /// left on its default writes nothing.
+    ///
+    /// Deliberate - storing the default would pin it, and `$OLLAMA_HOST` and
+    /// the built-in default would both stop applying. The cost is that
+    /// choosing Ollama and keeping the default leaves it out of
+    /// `configured_providers`, so it cannot be picked as the default
+    /// provider. Asserted rather than skipped, so changing it is a decision
+    /// somebody makes on purpose.
+    #[test]
+    fn a_base_url_provider_left_on_its_default_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = test_wizard(dir.path());
+        let index = wizard
+            .providers
+            .iter()
+            .position(|r| r.provider.credential == Credential::BaseUrl)
+            .expect("the catalog offers one");
+        for row in &mut wizard.providers {
+            row.selected = false;
+            row.value = String::new();
+        }
+        wizard.providers[index].selected = true;
+        wizard.providers[index].value = catalog::DEFAULT_OLLAMA_URL.to_string();
+
+        let config = wizard.build_config();
+        let id = wizard.providers[index].provider.id;
+        assert!(
+            !catalog::is_configured(&config, id),
+            "'{id}' on its default should leave the file alone"
+        );
     }
 
     /// The codex row at its index, on a wizard whose only selection it is and

--- a/crates/leviath-cli/src/config/providers.rs
+++ b/crates/leviath-cli/src/config/providers.rs
@@ -74,6 +74,25 @@ pub struct ProviderConfig {
     #[serde(default)]
     pub claude_code_effort: Option<String>,
 
+    /// Whether to offer Ollama.
+    ///
+    /// Ollama needs no key and answers on a well-known local port, so it used
+    /// to be registered on every machine whether or not anybody asked. That
+    /// made a bare model name in a blueprint resolvable against whatever
+    /// happened to be running locally, which is a surprising place for a run
+    /// to end up.
+    ///
+    /// Kept separate from `ollama_base_url` because the two say different
+    /// things: this is "I chose Ollama", and the URL is "and it is not at the
+    /// default address". Writing the default URL to mean the first would pin
+    /// it, and `$OLLAMA_HOST` and the built-in default would both stop
+    /// applying.
+    ///
+    /// A config that names a URL counts as having chosen it, so an install
+    /// that set one before this field existed keeps working.
+    #[serde(default)]
+    pub ollama_enabled: bool,
+
     /// Whether to offer the Codex transport, which bills inference to a
     /// ChatGPT subscription rather than an API balance.
     ///
@@ -184,6 +203,7 @@ impl Default for ProviderConfig {
             claude_code_enabled: false,
             claude_code_binary: None,
             claude_code_effort: None,
+            ollama_enabled: false,
             codex_enabled: false,
             codex_originator: None,
             codex_reasoning_effort: None,

--- a/crates/leviath-providers/src/codex.rs
+++ b/crates/leviath-providers/src/codex.rs
@@ -47,6 +47,9 @@ pub mod token;
 pub mod usage;
 
 pub use claims::CodexClaims;
+// Public for the sake of `expiry`: the HTTP API reports when an access
+// token lapses, and reading it from the token beats storing a second copy
+// beside the grant that could disagree with it.
 pub use provider::CodexProvider;
 pub use refresh::HttpRefresh;
 pub use store::{ProviderAuthStore, ProviderGrant, grant_account};

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -561,6 +561,10 @@ pub fn build_provider_registry_probing(
                             .with_request_timeout(timeout)
                             .with_base_url(c.base_url.clone())
                             .with_originator(c.options.get("originator").cloned())
+                            // A separate host from `base_url` in production,
+                            // so it takes its own option rather than a path
+                            // under that one.
+                            .with_usage_url(c.options.get("usage_url").cloned())
                             .with_reasoning(
                                 c.options.get("effort").cloned(),
                                 c.options.get("verbosity").cloned(),

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -220,6 +220,7 @@ handle that on all of them rather than on a few. The body is a line of plain tex
 | `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key. A `PUT` that changes a provider key, a gateway, `default_provider` or [`default_model`](#the-default-model) applies to the next run spawned, with no daemon restart |
 | `GET /api/models` | Enumerate models, with each one's token limits and where they came from. An OpenAI-compatible gateway's detected models are listed under the gateway's name |
 | `POST /api/models/probe` *(admin)* | Ask an OpenAI-compatible server what it serves before writing a gateway for it: `{"base_url", "api_key"?, "headers"?}` → `{"models": [ids]}`, or 502 carrying the server's own error text. See [below](#gateways) |
+| `GET /api/providers` · `POST …/{name}/login` *(admin)* · `/logout` *(admin)* · `/check` *(admin)* | The providers that sign in with a browser instead of taking a key, and the sign-in itself. See [below](#signing-in-to-a-subscription-provider) |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
 | `GET /api/scripts?agent=&include=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks and validators, and the global model providers. `include=candidates` also lists the files nothing declares yet. Writes need admin. See [below](#tools-and-scripts) |
 | `GET /api/mcp/servers` · `POST …` *(admin)* · `DELETE …/{name}` *(admin)* · `GET …/{name}/status` · `POST …/{name}/login` *(admin)* · `POST …/{name}/test` *(admin)* | List, add, remove, check, log in, test. The writes need admin. A server added or removed here reaches the next run, with no daemon restart |
@@ -937,6 +938,150 @@ without an `agent`, since the answer is the same either way.
 Each listed provider carries a `provider` object with what its leading `// @` comments declare:
 `description`, `default_model`, `max_context_tokens`, `max_output_tokens` and `supports_streaming`.
 
+## Signing in to a subscription provider
+
+Most providers take an API key, which is a string a form can post. One does not: Codex bills a
+ChatGPT subscription and its credential is an OAuth grant, taken in a browser and stored outside
+`config.toml` entirely. `PUT /api/config` can turn it on and can never sign anybody in, so a
+console that only wrote the flag would leave the user enabled and unable to run anything.
+
+These four routes are the rest of it.
+
+```
+GET  /api/providers                    what exists, and what state it is in
+POST /api/providers/{name}/login       start the browser flow            (admin)
+POST /api/providers/{name}/logout      forget the grant                  (admin)
+POST /api/providers/{name}/check       prove the grant still works       (admin)
+```
+
+`GET /api/providers` is open to any caller holding the bearer token. It reports the account
+address and the plan tier - the same facts `lev auth status` prints - and never a token:
+
+```json
+{
+  "providers": [
+    {
+      "id": "codex",
+      "display": "OpenAI Codex (ChatGPT subscription)",
+      "enabled": true,
+      "signed_in": true,
+      "account": "someone@example.com",
+      "plan": "plus",
+      "expires_at": 1735689600
+    }
+  ]
+}
+```
+
+`enabled` and `signed_in` are separate on purpose. Either can be true alone, they are set by
+different routes, and the combination that breaks runs - enabled, not signed in - is the one a
+console has to be able to see. `expires_at` is when the *access* token lapses; it is refreshed
+automatically well before that, and it is here so a UI can show that the session is live rather
+than implying anybody has to act on it.
+
+### The flow
+
+`POST .../login` does not hold the request open for the whole sign-in. It answers as soon as
+there is a URL, which is immediately, and the flow carries on behind it:
+
+```mermaid
+sequenceDiagram
+  participant UI as Console
+  participant Serve as lev serve
+  participant Browser as Browser on the serving host
+  participant OpenAI
+
+  UI->>Serve: POST /api/providers/codex/login
+  Serve->>Browser: open the authorize URL
+  Serve-->>UI: 202 {status: waiting, authorize_url}
+  Note over UI: render the URL, in case no browser opened
+  Browser->>OpenAI: sign in
+  OpenAI->>Serve: redirect to localhost:1455/auth/callback
+  Serve->>OpenAI: exchange the code
+  loop until it settles
+    UI->>Serve: GET /api/providers
+    Serve-->>UI: signin.state = waiting
+  end
+  UI->>Serve: GET /api/providers
+  Serve-->>UI: signed_in: true, no signin state
+```
+
+The MCP login route does hold its request open, for up to five minutes. That is fine for a CLI
+and wrong for a browser: the tab has nothing to draw while it waits, no way to show the URL, and
+no way to give up without losing the flow. One extra poll buys a UI that can render the whole
+thing.
+
+While it runs, the provider carries a `signin` object:
+
+```json
+{ "state": "waiting", "authorize_url": "https://auth.openai.com/oauth/authorize?…",
+  "started_at": 1735689000 }
+```
+
+and if it does not finish:
+
+```json
+{ "state": "failed", "message": "could not listen on port 1455 or 1457 (…)", "at": 1735689100 }
+```
+
+A success leaves no `signin` at all - the grant store is the answer, and a second copy of "signed
+in" is how two answers come to disagree. A failure stays until the next attempt, so a console
+that was not watching still finds out what happened.
+
+Starting a second sign-in while one is waiting answers `409`, with the first one's
+`authorize_url` in the body. A console that lost the response can pick the flow back up instead
+of having to cancel it.
+
+### The browser has to be on the serving host
+
+The redirect goes to `localhost:1455` on the machine running `lev serve` and nowhere else,
+because that is the address OpenAI registered the public client id against. Leviath cannot choose
+a different one.
+
+For a console driving a daemon on the same machine, this is invisible: the browser opens and the
+callback lands. For a remote daemon, the flow still starts and `authorize_url` still comes back,
+but somebody has to open that URL on the daemon's host. Show it rather than relying on the
+opener - it silently does nothing over SSH and in a bare console.
+
+### Checking, and why the check is real
+
+`POST .../check` asks the account, not a table:
+
+```json
+{ "status": "ok", "provider": "codex", "models": ["gpt-5.6-sol", "gpt-5.6-terra", …] }
+```
+
+Codex's model list is compiled into the build, so a check that read it would answer "5 models"
+for a revoked session, an expired one, and for never having signed in. This one makes an
+authenticated call, so a `200` means the subscription really did agree, and the `models` are the
+ones *this plan* can reach. A refusal is a `502` carrying the provider's own reason.
+
+It also refreshes a lapsed access token on the way in, which makes it the cheapest way to keep a
+rarely-used sign-in alive.
+
+### Turning it on
+
+Signing in and enabling are two separate acts, and `logout` deliberately does not do both -
+signing out is not the same as turning the provider off. `PUT /api/config` carries the setting:
+
+```json
+{ "codex_enabled": true, "codex_reasoning_effort": "medium", "codex_verbosity": "medium" }
+```
+
+`codex_reasoning_effort` takes `none`, `minimal`, `low`, `medium`, `high` or `xhigh`;
+`codex_verbosity` takes `low`, `medium` or `high`. Both are validated before anything is written,
+because the provider silently ignores a value it does not recognise - a typo would otherwise be
+saved, read back by `GET /api/config`, and quietly do nothing.
+
+`codex_replay_reasoning` is on by default and worth leaving on. It is writable so it can be
+turned off from a console the day the route stops accepting a replayed reasoning blob, without
+editing `config.toml` by hand on the serving machine.
+
+The three write routes need `--allow-admin`, like the MCP login they mirror: they open a browser
+on the serving host, delete a credential, and make an authenticated outbound call. The read half
+is always mounted, so a console without admin can still show what is signed in and offer nothing
+else.
+
 ## When the config file will not load
 
 `GET /api/config` describes the config **in force**, which is not always the file on disk. A save
@@ -1126,6 +1271,7 @@ than that feature, not broken.
 | `models.probe` | `POST /api/models/probe`, which asks an OpenAI-compatible server what it serves before a gateway for it is written; admin only |
 | `fs.mkdir` | `POST /api/fs/dirs`, so a folder picker can offer "New Folder" rather than one that 404s |
 | `interaction.feedback` | `feedback` beside `approved: false` on `POST /api/agents/{id}/interaction`, and the "Deny with feedback" option on a tool approval. An older daemon drops the field without a word, so a console should only offer the box where this is announced. See [answering a question](#answering-a-question) |
+| `providers.signin` | `GET /api/providers` and the three admin routes under it: the browser sign-in for a provider that has no API key. Without it a console can write `codex_enabled` and has no way to complete the sign-in, which leaves the user enabled and unable to run anything. See [signing in to a subscription provider](#signing-in-to-a-subscription-provider) |
 | `config.health` | `config_error` and `config_mtime` on `GET /api/config`, and the `config_health` frame on the socket. Without it a missing `config_error` means nothing, so a console cannot tell a file that loads from a daemon that would not say. See [when the config file will not load](#when-the-config-file-will-not-load) |
 
 ## Live updates over WebSocket

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -463,6 +463,13 @@ answer means the account really did agree.
 If your browser does not open (an SSH session, say), the card prints the URL to
 copy.
 
+There is an HTTP route for the same thing, so a web console can offer it too:
+`GET /api/providers` reports what is signed in, and `POST
+/api/providers/codex/login` starts the flow and hands back the URL. See
+[signing in to a subscription provider](/docs/api#signing-in-to-a-subscription-provider).
+The browser still has to be on the machine running `lev serve`, because the
+redirect goes to `localhost:1455` there and OpenAI registered it that way.
+
 This is a different provider from `openai`, not a mode of it. You can hold both
 credentials; a blueprint reaches this one as `codex/gpt-5.6-sol`.
 

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -25,6 +25,13 @@ writes it into `~/.leviath/config.toml` for you, interactively or with
 
 The setup flag `--ollama-url` sets the same base URL that `OLLAMA_HOST` supplies.
 
+Every provider here is opt-in, Ollama included. It needs no key and answers on a well-known local
+port, which used to be reason enough to register it on every machine - and that made a bare model
+name in a blueprint resolvable against whatever happened to be running locally, which is a
+surprising place for a run to end up. Choose it in `lev setup`, or set `[providers]
+ollama_enabled = true`; naming an `ollama_base_url` also counts, so an install that configured it
+before the switch existed keeps working untouched.
+
 ## Model identifiers
 
 A model is always named by a `provider` and a `model` together. The `model` string is passed to that

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -32,6 +32,9 @@ claude_code_enabled = false
 anthropic_cache_ttl = "5m"
 claude_code_binary = "/usr/local/bin/claude"
 claude_code_effort = "medium"
+# Offer Ollama. Opt-in like everything else: setting `ollama_base_url` above
+# also counts as choosing it.
+ollama_enabled = false
 # Bill inference to a ChatGPT subscription instead of an API balance.
 # Sign in from `lev setup` (or `lev auth login codex` on a headless machine);
 # the grant is stored outside this file and its token renews itself.

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -86,6 +86,11 @@
             "max"
           ]
         },
+        "ollama_enabled": {
+          "description": "Offer Ollama. Opt-in like every other provider: it needs no key and answers on a well-known local port, so registering it unasked made a bare model name resolvable against whatever happened to be running on the machine. A config that sets `ollama_base_url` counts as having chosen it.",
+          "type": "boolean",
+          "default": false
+        },
         "codex_enabled": {
           "description": "Offer the Codex transport, which bills inference to a ChatGPT subscription. Sign in from `lev setup`, or with `lev auth login codex` on a headless machine.",
           "type": "boolean",

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -46,6 +46,9 @@
     },
     {
       "name": "scripts"
+    },
+    {
+      "name": "providers"
     }
   ],
   "paths": {
@@ -1216,6 +1219,146 @@
           }
         },
         "description": "Body: `request_id` (the open request's id) plus one of `value`, `choice_index`, or `approved` with an optional `scope` (`once`, `stage`, `session`). A deny (`approved: false`) may carry `feedback`, a string the model reads inside the tool result for the refused call: `[denied] User declined tool call '<tool>'. Feedback: <text>`. `feedback` beside `approved: true` is a 400. 202 once the daemon holds the answer, 404 when nothing with that id is open. Announced as `interaction.feedback`."
+      }
+    },
+    "/api/providers": {
+      "get": {
+        "tags": [
+          "providers"
+        ],
+        "summary": "Providers that sign in with a browser, and whether they are signed in",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
+          }
+        },
+        "description": "Reports `enabled` (what `config.toml` says) and `signed_in` (whether a grant is stored) separately, because either can be true alone and a provider that is enabled without a sign-in fails every run. While a sign-in is in flight `signin` carries `{\"state\": \"waiting\", \"authorize_url\": ...}`; after one fails it carries `{\"state\": \"failed\", \"message\": ...}` until the next attempt, and it is absent when there is neither. Open to any caller: it discloses the account address and plan tier, the same facts `lev auth status` prints, and no token."
+      }
+    },
+    "/api/providers/{name}/login": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Name"
+        }
+      ],
+      "post": {
+        "tags": [
+          "providers"
+        ],
+        "summary": "Start the browser sign-in for a provider",
+        "responses": {
+          "202": {
+            "description": "The flow started; poll `GET /api/providers`."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "405": {
+            "$ref": "#/components/responses/NotMounted"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "409": {
+            "$ref": "#/components/responses/Error"
+          },
+          "502": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
+          }
+        },
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed, because it opens the operator's browser on the host running the server and binds a fixed loopback port there. Returns `202` with `{\"status\": \"waiting\", \"authorize_url\": ...}` as soon as there is a URL, and the flow continues behind the response - poll `GET /api/providers` for the outcome. It does not hold the request open for the whole flow the way the MCP login does: a browser UI needs to render the URL and a progress state, and a request held open for five minutes gives it neither. **The browser has to be on the serving host**, because the redirect goes to `localhost:1455` there and nowhere else - that is what OpenAI registered the public client id against. A console driving a remote daemon can start the flow and show `authorize_url`, but somebody has to open it on that machine. `409` when a sign-in to the same provider is already waiting, with its `authorize_url` in the body so a reconnecting console can pick the flow back up rather than having to cancel it."
+      }
+    },
+    "/api/providers/{name}/logout": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Name"
+        }
+      ],
+      "post": {
+        "tags": [
+          "providers"
+        ],
+        "summary": "Forget a provider's stored sign-in",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "405": {
+            "$ref": "#/components/responses/NotMounted"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
+          }
+        },
+        "description": "Admin only, like the sign-in it undoes: it deletes a credential from the grant store, and from the OS keychain when `[security] credential_store = \"keychain\"`. `config.toml` is deliberately untouched, the same as `lev auth logout` - signing out is not the same as turning the provider off, and doing both would surprise anyone who meant to sign in again. Set `codex_enabled` through `PUT /api/config` to do the other one."
+      }
+    },
+    "/api/providers/{name}/check": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Name"
+        }
+      ],
+      "post": {
+        "tags": [
+          "providers"
+        ],
+        "summary": "Prove a provider's stored sign-in still works",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "405": {
+            "$ref": "#/components/responses/NotMounted"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "502": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
+          }
+        },
+        "description": "Admin only, the same category as `POST /api/models/probe`: it makes this host open an authenticated connection to the provider. The same check `lev setup` runs, through the same code. It asks the account rather than reading a compiled model table, so a `200` means the subscription really did agree - and it refreshes a lapsed access token on the way in, which is also what keeps a rarely-used sign-in alive. Answers `{\"status\": \"ok\", \"models\": [...]}` with the models this plan can reach, and `502` with the provider's own reason when it is refused."
       }
     },
     "/api/mcp/servers": {


### PR DESCRIPTION
`PUT /api/config` could already turn Codex on. It could not sign anybody in — Codex has no key to post, its credential is an OAuth grant taken in a browser and stored outside `config.toml` entirely. A console that could only write the flag would get a user exactly as far as *enabled and unable to run anything*, which is worse than not offering the provider.

These four routes are the rest of it, so the Lair can build the whole thing visually.

```
GET  /api/providers                  what exists, and what state it is in
POST /api/providers/{name}/login     start the browser flow            (admin)
POST /api/providers/{name}/logout    forget the grant                  (admin)
POST /api/providers/{name}/check     prove the grant still works       (admin)
```

## The listing

```json
{
  "providers": [{
    "id": "codex",
    "display": "OpenAI Codex (ChatGPT subscription)",
    "enabled": true,
    "signed_in": true,
    "account": "someone@example.com",
    "plan": "plus",
    "expires_at": 1735689600
  }]
}
```

`enabled` and `signed_in` are separate on purpose: either can be true alone, they are set by different routes, and the combination that breaks every run is the one a UI has to be able to see. The read half is open to any caller holding the bearer, so a test pins that it carries the account and plan — the facts `lev auth status` prints — and never a token.

## Login does not block

The MCP login route holds its request open for the whole flow, up to five minutes. Fine for a CLI, wrong for a browser: the tab has nothing to draw while it waits, no way to show the URL for a host whose browser did not open, and no way to give up without losing the flow.

This one answers `202` with the authorize URL as soon as there is one — immediately, since it exists the moment the loopback listener binds — and the flow continues behind it. `GET /api/providers` then carries `signin: {state: "waiting", authorize_url, started_at}`, and afterwards either the sign-in or `{state: "failed", message, at}`.

A success records nothing: the grant store is the answer, and a second copy of "signed in" is how two answers come to disagree. A failure stays until the next attempt, so a console that was not watching still finds out what happened. A second login while one waits is a `409` carrying the first one's URL, so a console that lost the response picks the flow back up rather than cancelling it.

**The browser still has to be on the serving host.** The redirect goes to `localhost:1455` there and nowhere else, because that is what OpenAI registered the public client id against. A console driving a remote daemon can start the flow and show `authorize_url`, but somebody has to open it on that machine — which is why the URL is in the response rather than only handed to the opener.

## Config

`PUT /api/config` gains `codex_enabled`, `codex_reasoning_effort`, `codex_verbosity` and `codex_replay_reasoning`, and `GET` reports all four. The two with a fixed vocabulary are validated before anything is written: the provider drops an effort it does not recognise, so an unchecked typo would be saved, read back by `GET /api/config`, and quietly do nothing.

## Verification

All 13 packages at 100% region coverage, clippy clean, structure and docs gates pass, full suite green. The OpenAPI spec, the capability list (`providers.signin`) and `docs/content/api.md` are all held to the router by existing tests — two of them failed on the first run and are what drove the docs.

The whole flow is under test against a local issuer with the stub browser the login already had, so what the Lair will drive is what runs rather than a mock of it. Two seams make that possible and are useful in their own right: the authorizer's issuer and ports, and a `usage_url` option on the codex registry arm, which is also what anybody proxying that route needs.

Two things turned up on the way. `check` read the grant through `default_path()` rather than the path the sign-in wrote to, so the two halves could disagree about whether a provider was signed in. And the `Skipped` outcome arm was a branch `verify_via_registry` never takes; reading the outcome through its own helpers removes it.

## Docs

`docs/content/api.md` gets a full section — the endpoint table row, a sequence diagram of the poll flow, the response shapes, why the browser has to be on the serving host, why the check is real, and the config fields. `providers.md` cross-links it. `openapi.json` documents all four routes.

## Not included

`main.rs` is untouched by this branch, so it needs no label.
