### PR TITLE
feat(seeds): let a blueprint seed regions from its own files

### DIFF
--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -4512,6 +4512,217 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         assert!(err.contains("outside the working directory"), "{err}");
     }
 
+    // ─── `blueprint:` seed paths ─────────────────────────────────────────────
+
+    /// A blueprint directory holding shipped seed material, a workdir somewhere
+    /// else entirely, and a secret *beside* the blueprint directory that a
+    /// prefixed path must never reach. Returns (root, manifest path, workdir).
+    fn blueprint_dir_with_files() -> (tempfile::TempDir, String, String) {
+        let root = tempfile::tempdir().expect("tempdir");
+        let bp_dir = root.path().join("agents").join("pack");
+        std::fs::create_dir_all(bp_dir.join("config")).expect("dirs");
+        std::fs::write(bp_dir.join("config").join("style.md"), "two spaces").expect("write");
+        std::fs::write(root.path().join("agents").join("secret.txt"), "sk-SECRET").expect("write");
+        let work = root.path().join("work");
+        std::fs::create_dir_all(&work).expect("dirs");
+        (
+            root,
+            bp_dir.join("agent.leviath").to_string_lossy().to_string(),
+            work.to_string_lossy().to_string(),
+        )
+    }
+
+    /// The feature itself: `blueprint:` reads from the blueprint's directory,
+    /// not the workdir - the file exists only beside the manifest.
+    #[test]
+    fn a_blueprint_prefixed_seed_file_reads_from_the_blueprint_directory() {
+        let (_root, bp_path, wd) = blueprint_dir_with_files();
+        let blueprint = bp(
+            r#"style = { kind = "pinned", max_tokens = 2000, seed = { files = ["blueprint:config/style.md"] }, required = true }"#,
+        );
+        let mut args = args_with("t", HashMap::new(), &wd);
+        args.blueprint_path = bp_path;
+        let seeds = resolve_seeds(
+            &blueprint,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
+        assert!(seeds.get("style").is_some_and(|s| s.contains("two spaces")));
+    }
+
+    /// `blueprint:` claims "a file I ship", so a path that climbs out of the
+    /// blueprint directory is a contradiction and is refused outright.
+    #[test]
+    fn a_blueprint_prefixed_seed_escaping_the_blueprint_directory_is_refused() {
+        let (_root, bp_path, wd) = blueprint_dir_with_files();
+        let blueprint = bp(
+            r#"style = { kind = "pinned", max_tokens = 2000, seed = { files = ["blueprint:../secret.txt"] } }"#,
+        );
+        let mut args = args_with("t", HashMap::new(), &wd);
+        args.blueprint_path = bp_path;
+        let err = resolve_seeds(
+            &blueprint,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
+        assert!(err.contains("outside the blueprint's directory"), "{err}");
+    }
+
+    /// The one that keeps the fence honest: `[read_paths]` widens what an agent
+    /// may read on the user's machine, not what a package pretends to ship, so
+    /// a grant covering the target must NOT rescue an escaping `blueprint:` path.
+    #[test]
+    fn a_read_paths_grant_does_not_rescue_an_escaping_blueprint_seed() {
+        let (root, bp_path, wd) = blueprint_dir_with_files();
+        let outside = root.path().to_string_lossy().to_string();
+        let mut policy = no_read_paths();
+        policy.blueprint = leviath_core::ReadPathSet::compile(
+            std::slice::from_ref(&outside),
+            std::path::Path::new(&wd),
+            None,
+            cfg!(windows),
+        )
+        .expect("declaration compiles");
+        policy.allow_blueprint = true;
+
+        let blueprint = bp(
+            r#"style = { kind = "pinned", max_tokens = 2000, seed = { files = ["blueprint:../secret.txt"] } }"#,
+        );
+        let mut args = args_with("t", HashMap::new(), &wd);
+        args.blueprint_path = bp_path;
+        let err = resolve_seeds(
+            &blueprint,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &policy,
+        )
+        .unwrap_err();
+        assert!(err.contains("outside the blueprint's directory"), "{err}");
+    }
+
+    /// A prefixed glob expands against the blueprint directory and picks up the
+    /// files shipped there.
+    #[test]
+    fn a_blueprint_prefixed_glob_seeds_shipped_files() {
+        let (root, bp_path, wd) = blueprint_dir_with_files();
+        let rubrics = root.path().join("agents").join("pack").join("rubrics");
+        std::fs::create_dir_all(&rubrics).expect("dirs");
+        std::fs::write(rubrics.join("one.md"), "rubric one").expect("write");
+        std::fs::write(rubrics.join("two.md"), "rubric two").expect("write");
+        let blueprint = bp(
+            r#"rubric = { kind = "pinned", max_tokens = 4000, seed = { glob = "blueprint:rubrics/*.md" } }"#,
+        );
+        let mut args = args_with("t", HashMap::new(), &wd);
+        args.blueprint_path = bp_path;
+        let seeds = resolve_seeds(
+            &blueprint,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
+        let rubric = seeds.get("rubric").expect("region seeded");
+        assert!(rubric.contains("rubric one") && rubric.contains("rubric two"));
+    }
+
+    /// A prefixed glob is fenced per match, exactly as the workdir form is:
+    /// `blueprint:../*` expands fine and every escaping match is refused.
+    #[test]
+    fn a_blueprint_prefixed_glob_matching_outside_is_refused() {
+        let (_root, bp_path, wd) = blueprint_dir_with_files();
+        let blueprint = bp(
+            r#"rubric = { kind = "pinned", max_tokens = 4000, seed = { glob = "blueprint:../*.txt" } }"#,
+        );
+        let mut args = args_with("t", HashMap::new(), &wd);
+        args.blueprint_path = bp_path;
+        let err = resolve_seeds(
+            &blueprint,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
+        assert!(err.contains("outside the blueprint's directory"), "{err}");
+    }
+
+    /// A rhai seed ships with the blueprint the way its hooks do: the prefix
+    /// finds the script beside the manifest and runs it.
+    #[test]
+    fn a_blueprint_prefixed_rhai_seed_runs_from_the_blueprint_directory() {
+        let (root, bp_path, wd) = blueprint_dir_with_files();
+        let seeds_dir = root.path().join("agents").join("pack").join("seeds");
+        std::fs::create_dir_all(&seeds_dir).expect("dirs");
+        std::fs::write(
+            seeds_dir.join("plan.rhai"),
+            r#""planned: " + input["task"]"#,
+        )
+        .expect("write");
+        let blueprint = bp(
+            r#"plan = { kind = "temporary", max_tokens = 500, seed = { rhai = "blueprint:seeds/plan.rhai" } }"#,
+        );
+        let mut args = args_with("go", HashMap::new(), &wd);
+        args.blueprint_path = bp_path;
+        let seeds = resolve_seeds(
+            &blueprint,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
+        assert_eq!(seeds.get("plan").map(String::as_str), Some("planned: go"));
+    }
+
+    /// A missing prefixed file answers to `required` exactly as a workdir one
+    /// does: required errors, optional leaves the region out.
+    #[test]
+    fn a_missing_blueprint_prefixed_file_honors_required_and_optional() {
+        let (_root, bp_path, wd) = blueprint_dir_with_files();
+        let req = bp(
+            r#"style = { kind = "pinned", max_tokens = 2000, seed = { files = ["blueprint:missing.md"] }, required = true }"#,
+        );
+        let mut args = args_with("t", HashMap::new(), &wd);
+        args.blueprint_path = bp_path;
+        let err = resolve_seeds(
+            &req,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
+        assert!(err.contains("missing.md"), "got: {err}");
+        let opt = bp(
+            r#"style = { kind = "pinned", max_tokens = 2000, seed = { files = ["blueprint:missing.md"] } }"#,
+        );
+        let seeds = resolve_seeds(
+            &opt,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
+        assert!(!seeds.contains_key("style"));
+    }
+
     #[test]
     fn a_rhai_seed_script_outside_the_workdir_is_refused() {
         let (_root, wd) = workdir_with_a_neighbour();

--- a/crates/leviath-cli/src/daemon/spawn/seeds.rs
+++ b/crates/leviath-cli/src/daemon/spawn/seeds.rs
@@ -54,6 +54,53 @@ pub(super) fn seed_path_within(
         .ok_or_else(refusal)
 }
 
+/// The marker a blueprint puts on a seed path to say "this file ships with
+/// me": `seed = { files = ["blueprint:config/style.md"] }` reads from the
+/// blueprint's own directory instead of the run's working directory.
+pub(super) const BLUEPRINT_SEED_PREFIX: &str = "blueprint:";
+
+/// Fence a `blueprint:`-prefixed seed path (already joined onto the
+/// blueprint's directory) inside that directory.
+///
+/// The same containment [`script_within_blueprint`] gives a hook script, and
+/// for the same reason: the prefix means "a file I ship", and a blueprint does
+/// not ship files outside its own directory. There is deliberately no
+/// `[read_paths]` fallback on this arm - that mechanism lets the
+/// workdir-relative form out with the user's consent, while an escaping
+/// `blueprint:` path is a contradiction in terms, and a grant must not turn it
+/// into a probe of whatever the grant happens to cover.
+///
+/// [`script_within_blueprint`]: super::scripts::script_within_blueprint
+pub(super) fn blueprint_seed_within(
+    blueprint_dir: &std::path::Path,
+    full: &std::path::Path,
+) -> Result<std::path::PathBuf, String> {
+    match leviath_core::resolves_within(full, blueprint_dir) {
+        true => Ok(full.to_path_buf()),
+        false => Err(format!(
+            "seed path '{}' resolves outside the blueprint's directory ({}); the \
+             'blueprint:' prefix reads only files the blueprint ships",
+            full.display(),
+            blueprint_dir.display()
+        )),
+    }
+}
+
+/// Resolve one declared seed path string: `blueprint:<rel>` against the
+/// blueprint's directory with no way out, anything else against the workdir
+/// with the `[read_paths]` fallback [`seed_path_within`] applies.
+fn declared_seed_path(
+    declared: &str,
+    workdir: &std::path::Path,
+    blueprint_dir: &std::path::Path,
+    read_paths: &leviath_core::ReadPathPolicy,
+) -> Result<std::path::PathBuf, String> {
+    match declared.strip_prefix(BLUEPRINT_SEED_PREFIX) {
+        Some(rel) => blueprint_seed_within(blueprint_dir, &blueprint_dir.join(rel)),
+        None => seed_path_within(workdir, &workdir.join(declared), read_paths),
+    }
+}
+
 /// Resolve every region's initial content from its blueprint-declared
 /// [`RegionSeed`] plus the caller-provided values on `args`, into a
 /// name→content map ready for [`spawn_agent_seeded`].
@@ -64,7 +111,9 @@ pub(super) fn seed_path_within(
 ///   `required` and the value is missing/blank this returns `Err` - the
 ///   required-at-spawn gate, before any inference.
 /// - `Files` / `Glob` read workdir files; `Literal` is verbatim; `Rhai` runs a
-///   workdir script whose `String` return seeds the region.
+///   workdir script whose `String` return seeds the region. Any of the three
+///   may point a path at the blueprint's own directory instead with the
+///   [`BLUEPRINT_SEED_PREFIX`].
 /// - `Command` runs a shell command in the workdir under `commands` -
 ///   sandboxed, time- and size-capped, and skippable. Every failure is
 ///   non-fatal unless the region is `required`.
@@ -108,6 +157,10 @@ pub(super) fn resolve_seeds(
     }
 
     let base = std::path::Path::new(workdir);
+    let blueprint_dir = std::path::Path::new(&args.blueprint_path)
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_default();
     let mut seeds: HashMap<String, String> = HashMap::new();
 
     for region in &blueprint.context_layout.regions {
@@ -137,7 +190,7 @@ pub(super) fn resolve_seeds(
             RegionSeed::Files { paths } => {
                 let resolved = paths
                     .iter()
-                    .map(|p| seed_path_within(base, &base.join(p), read_paths))
+                    .map(|p| declared_seed_path(p, base, &blueprint_dir, read_paths))
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(|e| format!("region '{}': {e}", region.name))?;
                 let content = read_and_concat(&region.name, resolved.into_iter(), region.required)?;
@@ -146,15 +199,24 @@ pub(super) fn resolve_seeds(
                 }
             }
             RegionSeed::Glob { pattern } => {
-                let full = base.join(pattern);
+                let from_blueprint = pattern.strip_prefix(BLUEPRINT_SEED_PREFIX);
+                let full = match from_blueprint {
+                    Some(rel) => blueprint_dir.join(rel),
+                    None => base.join(pattern),
+                };
                 let full = full.to_string_lossy();
                 let matches = glob::glob(&full)
                     .map_err(|e| format!("region '{}': bad glob '{pattern}': {e}", region.name))?;
                 // Each *match* is checked, not the pattern: `../../*.toml`
-                // cannot be judged before it is expanded.
+                // cannot be judged before it is expanded. The prefixed form is
+                // fenced per match on the same grounds, just against the
+                // blueprint's directory and with no `[read_paths]` way out.
                 let paths = matches
                     .filter_map(|m| m.ok())
-                    .map(|p| seed_path_within(base, &p, read_paths))
+                    .map(|p| match from_blueprint {
+                        Some(_) => blueprint_seed_within(&blueprint_dir, &p),
+                        None => seed_path_within(base, &p, read_paths),
+                    })
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(|e| format!("region '{}': {e}", region.name))?;
                 let content = read_and_concat(&region.name, paths.into_iter(), region.required)?;
@@ -172,7 +234,7 @@ pub(super) fn resolve_seeds(
                 }
             }
             RegionSeed::Rhai { script } => {
-                let path = seed_path_within(base, &base.join(script), read_paths)
+                let path = declared_seed_path(script, base, &blueprint_dir, read_paths)
                     .map_err(|e| format!("region '{}': {e}", region.name))?;
                 let src = std::fs::read_to_string(&path).map_err(|e| {
                     format!(

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -199,7 +199,7 @@ rules     = { kind = "pinned", seed = { literal = "Never edit generated files." 
 env       = { kind = "pinned", seed = { command = "git log --oneline -20" } }
 clock     = { kind = "pinned", seed = { tool = "current_time" } }
 machine   = { kind = "pinned", seed = { tools = ["current_time", "system_info"] } }
-computed  = { kind = "temporary", seed = { rhai = "seeds/plan.rhai" } }
+computed  = { kind = "temporary", seed = { rhai = "blueprint:seeds/plan.rhai" } }
 inherited = { kind = "pinned", seed = { caller = "brief" } }
 ```
 
@@ -232,7 +232,40 @@ task refuses a task outright rather than running without it.
 > them for one run, and `[security] allow_seed_commands = false` refuses them machine-wide. Seeds
 > run once: a daemon restart does not replay them.
 
-#### Seed paths stay in the working directory
+#### Where a seed path resolves
+
+`files`, `glob` and `rhai` seeds resolve against the run's working directory and may not leave it.
+A path that does is refused at spawn, before anything is read.
+
+The rule is the one `read_file` follows, for the same reason: the *blueprint* chose this path, not
+you. Seeded contents land in a region the model reads on its first turn, so a path that escaped
+would put whatever it named in front of the model without anything having asked you.
+
+To read outside on purpose, declare it under `[read_paths]` and grant it in your config. That is
+already the mechanism for "this agent is meant to read there and I agreed", and seeding answers to
+it rather than having a second one of its own. A glob is checked per match, since `../*.toml` cannot
+be judged before it is expanded.
+
+A blueprint can also seed from files it ships itself. The `blueprint:` prefix resolves the rest of
+the path against the blueprint's own directory instead of the working directory, so bundled
+material travels with the agent:
+
+```toml
+guidelines = { kind = "pinned", seed = { files = ["blueprint:config/style.md"] } }
+rubric     = { kind = "pinned", seed = { glob  = "blueprint:rubrics/*.md" } }
+plan       = { kind = "temporary", seed = { rhai = "blueprint:seeds/plan.rhai" } }
+```
+
+A prefixed path may never leave the blueprint's directory, and `[read_paths]` does not apply to it.
+A grant widens what an agent may read on your machine, not what a package pretends to ship, so
+`blueprint:../secrets.txt` is refused however the config is set. This is the same containment a
+script gets, because the claim is the same: these are the blueprint's own files, and a blueprint's
+own files live beside it.
+
+Scripts proper are stricter still and have no `[read_paths]` escape at all: a stage hook, a
+custom-region script and an output validator must all live inside the blueprint's own directory. A
+script is code the agent ships, and there is no such thing as loading your logic from somewhere
+else on purpose.
 
 ### Seeding from tools
 
@@ -304,22 +337,6 @@ previous value is stale, and stale beats absent. `lev validate` marks a refreshi
 "on every stage entry".
 
 Seeds do not re-run when a run is reloaded from a snapshot, whatever their `refresh` setting.
-
-`files`, `glob` and `rhai` seeds resolve against the run's working directory and may not leave it.
-A path that does is refused at spawn, before anything is read.
-
-The rule is the one `read_file` follows, for the same reason: the *blueprint* chose this path, not
-you. Seeded contents land in a region the model reads on its first turn, so a path that escaped
-would put whatever it named in front of the model without anything having asked you.
-
-To read outside on purpose, declare it under `[read_paths]` and grant it in your config. That is
-already the mechanism for "this agent is meant to read there and I agreed", and seeding answers to
-it rather than having a second one of its own. A glob is checked per match, since `../*.toml` cannot
-be judged before it is expanded.
-
-Scripts are stricter and have no `[read_paths]` escape: a stage hook, a custom-region script and an
-output validator must all live inside the blueprint's own directory. A script is code the agent
-ships, and there is no such thing as loading your logic from somewhere else on purpose.
 
 ## What the model sees
 


### PR DESCRIPTION
## Problem

`seed = { files = [...] }`, `{ glob = ... }` and `{ rhai = ... }` in a blueprint resolve against the run's working directory. A blueprint therefore had no way to seed a region from files it ships itself (bundled config, rubrics, seed scripts) without the user copying them into every workdir. The docs example (`seed = { rhai = "seeds/plan.rhai" }`) read as blueprint-relative while the code resolved against the workdir, so the documented behavior did not exist.

## Fix

A `blueprint:` prefix on any seed path string, no schema change:

```toml
guidelines = { kind = "pinned", seed = { files = ["blueprint:config/style.md"] } }
rubric     = { kind = "pinned", seed = { glob  = "blueprint:rubrics/*.md" } }
plan       = { kind = "temporary", seed = { rhai = "blueprint:seeds/plan.rhai" } }
```

- The prefixed remainder joins onto the blueprint's directory (from `args.blueprint_path`) and is fenced there via `leviath_core::resolves_within`, the same containment hook scripts get from `script_within_blueprint`. `blueprint:../x` and `blueprint:/etc/passwd` are refused at spawn with a clear error, before anything is read.
- Globs expand against the blueprint directory and every match is fenced individually, mirroring the workdir arm.
- Non-prefixed paths are untouched: workdir resolution with the existing `[read_paths]` fallback, byte for byte the behavior existing configs had.
- Embedded worlds keep rejecting `files`/`glob`/`rhai` seeds outright, which covers the prefixed forms too.
- Docs: the seeding section's previously empty "seed paths" heading now holds the resolution rules (they had drifted below the refresh section), states what each form resolves against, documents the prefix and its no-escape rule, and the misleading example now uses the prefix.

## Security reasoning: no `[read_paths]` fallback

The workdir arm falls back to `[read_paths]` because that is the user consenting to an agent reading a specific place on their machine. The `blueprint:` arm deliberately has no such fallback: the prefix is the blueprint claiming "this file ships with me", and a blueprint does not ship files outside its own directory. If a grant could rescue an escaping `blueprint:` path, an installed package could use the prefix to probe whatever the grant happens to cover and seed it straight into a region the model reads on its first turn. An escaping prefixed path is a contradiction in terms and is refused however the config is set. Seed contents also stay off the read-path taint bump for the same reason: blueprint-shipped files are the agent's own material, not the user's.

## Test evidence

Fail-first: the six behavioral tests were written and run against the unfixed code first. Five failed exactly as expected (`blueprint:config/style.md` joined under the workdir as a literal `blueprint:...` file name and failed to read; escapes were not refused with the blueprint-directory error). The required/optional test for a missing prefixed file passes on both sides by design, since the semantics are shared with the workdir arm.

New tests in `crates/leviath-cli/src/daemon/spawn/mod.rs`:

- `a_blueprint_prefixed_seed_file_reads_from_the_blueprint_directory`
- `a_blueprint_prefixed_seed_escaping_the_blueprint_directory_is_refused`
- `a_read_paths_grant_does_not_rescue_an_escaping_blueprint_seed` (a granting policy covering the target still refuses)
- `a_blueprint_prefixed_glob_seeds_shipped_files`
- `a_blueprint_prefixed_glob_matching_outside_is_refused` (fenced per match)
- `a_blueprint_prefixed_rhai_seed_runs_from_the_blueprint_directory`
- `a_missing_blueprint_prefixed_file_honors_required_and_optional`

Gates: `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo xtask structure`, `cargo xtask docs`, and `cargo xtask coverage --package leviath-cli` (100%) all pass; the pre-commit hook runs the full suite.
