### PR TITLE
fix(providers): normalize script-provider usage and mark its listings learned

### DIFF
--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -1888,6 +1888,44 @@ mod tests {
         }
     }
 
+    /// The rows a script's `list_models` answers are the provider's own
+    /// listing, not this build's table. `print_listing` counts its trailing
+    /// line by the `learned` flag and `--json` reports the flag verbatim, so
+    /// an unlearned script row makes a purely live table print "N rows from
+    /// this build's table; no provider listing was read" - exactly backwards.
+    #[tokio::test]
+    async fn a_script_providers_rows_count_as_its_own_listing() {
+        let dir = tempfile::tempdir().expect("a temp providers dir");
+        std::fs::write(
+            dir.path().join("listed.rhai"),
+            "fn initialize(config) { #{ ok: true } }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn list_models(state) { [ #{ id: \"listed-large\" } ] }",
+        )
+        .expect("the temp dir is writable");
+        let dir = dir.path().to_path_buf();
+        crate::config::with_isolated_config_path_async(
+            "models-a_script_providers_rows_count_as_its_own_listing",
+            |_fake_dir| async move {
+                let config = Config::load().expect("the isolated config loads");
+                let registry = script_registry(dir)(&config).expect("the registry builds");
+                let mut entries = Vec::new();
+                merge_script_provider(&registry, "listed", &mut entries)
+                    .await
+                    .expect("the script lists its models");
+                assert!(!entries.is_empty(), "the script answered a row");
+                for row in &entries {
+                    assert!(
+                        row.learned,
+                        "'{}' came from the script's own list_models, not this build's table",
+                        row.id
+                    );
+                }
+            },
+        )
+        .await;
+    }
+
     /// A script that will not compile is a candidate name the registry cannot
     /// hand back. `show` skips it the way `list` does, and still answers from
     /// whatever else it has: here, nothing, so the model is reported unknown

--- a/crates/leviath-providers/src/pricing.rs
+++ b/crates/leviath-providers/src/pricing.rs
@@ -94,6 +94,19 @@ impl TokenUsage {
         self
     }
 
+    /// The derived total reconciled with a total the provider itself reported.
+    ///
+    /// The larger of the two stands. Parts in hand are evidence, so the
+    /// derived figure never goes down; but a provider that reports only a
+    /// total (a script forwarding an endpoint that says nothing finer) has
+    /// all-zero parts, and deriving from those would zero the one figure it
+    /// gave. For a provider whose total genuinely is the sum of its parts,
+    /// this is a no-op.
+    pub fn with_reported_total(mut self, total: usize) -> Self {
+        self.total_tokens = self.total_tokens.max(total);
+        self
+    }
+
     /// All input tokens, however they were billed.
     pub fn input_tokens(&self) -> usize {
         self.prompt_tokens

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -394,6 +394,18 @@ impl ModelInfo {
         self
     }
 
+    /// This entry marked as read from the provider's own listing, for a
+    /// listing that reports rows directly (a script's `list_models`) rather
+    /// than through a [`crate::learned::LearnedModel`] record.
+    ///
+    /// Rows synthesized from configuration claims (`serves = [...]`,
+    /// `[model_capabilities]`) are someone describing a model, not the
+    /// provider answering for itself, and must not pass through here.
+    pub fn listed(mut self) -> Self {
+        self.learned = true;
+        self
+    }
+
     /// This entry marked as read from the listing, carrying what it said.
     pub fn learned_from(mut self, learned: &crate::learned::LearnedModel) -> Self {
         self.display_name = learned.display_name.clone();

--- a/crates/leviath-providers/src/provider/stream.rs
+++ b/crates/leviath-providers/src/provider/stream.rs
@@ -331,6 +331,12 @@ impl PartialToolCall {
 /// across chunks and each names a different slice of the same call, while the
 /// cost, when a provider states one at all, is the whole call's price and comes
 /// once.
+///
+/// The totals add too, reconciled against the sum of the merged parts. For
+/// every built-in provider the two figures are identical, but a script
+/// provider's chunk may carry a total its parts do not account for (an
+/// endpoint that reports nothing finer), and rebuilding the running total from
+/// the parts alone would silently drop it.
 fn merge_usage(into: TokenUsage, chunk: TokenUsage) -> TokenUsage {
     TokenUsage::new(
         into.prompt_tokens.saturating_add(chunk.prompt_tokens),
@@ -340,6 +346,7 @@ fn merge_usage(into: TokenUsage, chunk: TokenUsage) -> TokenUsage {
         into.completion_tokens
             .saturating_add(chunk.completion_tokens),
     )
+    .with_reported_total(into.total_tokens.saturating_add(chunk.total_tokens))
     .with_reported_cost(chunk.reported_cost_usd.or(into.reported_cost_usd))
 }
 
@@ -654,6 +661,32 @@ mod tests {
         let err = collect_stream(stream).await.expect_err("the stream failed");
 
         assert_eq!(err.failure_kind(), Some(FailureKind::Timeout));
+    }
+
+    /// A usage report carrying only a total (a script provider whose endpoint
+    /// says nothing finer) survives the fold. Rebuilding the running total
+    /// from the parts alone would silently zero it.
+    #[tokio::test]
+    async fn collect_stream_keeps_a_total_only_usage_report() {
+        let total_only = TokenUsage {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 9,
+            cached_tokens: 0,
+            cache_write_tokens: 0,
+            reported_cost_usd: None,
+        };
+        let stream = chunks(vec![StreamChunk {
+            delta: String::new(),
+            tool_calls: Vec::new(),
+            tokens: Some(total_only),
+            finish_reason: Some(FinishReason::Complete),
+            reasoning: None,
+        }]);
+
+        let response = collect_stream(stream).await.expect("a complete stream");
+
+        assert_eq!(response.tokens_used.total_tokens, 9);
     }
 
     /// Chunk counts accumulate across a stream; two large reports must clamp

--- a/crates/leviath-providers/src/rhai_provider/convert.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert.rs
@@ -39,14 +39,32 @@ fn parse_usage(obj: Option<&Value>) -> TokenUsage {
     let cost = obj
         .and_then(|v| v.get("cost_usd").or_else(|| v.get("cost")))
         .and_then(|v| v.as_f64());
-    TokenUsage {
-        prompt_tokens: usize_field(obj, "prompt_tokens"),
-        completion_tokens: usize_field(obj, "completion_tokens"),
-        total_tokens: usize_field(obj, "total_tokens"),
-        cached_tokens: usize_field(obj, "cached_tokens"),
-        cache_write_tokens: usize_field(obj, "cache_write_tokens"),
-        reported_cost_usd: cost,
-    }
+    let cached = usize_field(obj, "cached_tokens");
+    let cache_write = usize_field(obj, "cache_write_tokens");
+    // `prompt_tokens` here is the whole prompt, cache counts included, because
+    // that is what a script forwarding an OpenAI-shaped usage object sends
+    // verbatim. `TokenUsage::prompt_tokens` is the fresh figure, so the cache
+    // counts come back out - the same normalization the native OpenAI provider
+    // applies, and without it a cached token is billed once at the full input
+    // rate inside `prompt_tokens` and again at the cache rate. Saturating: a
+    // script whose cache counts exceed its own prompt count is malformed, and
+    // zero fresh input beats a wrapped figure.
+    //
+    // Going through `TokenUsage::new` derives the total from the parts, so a
+    // script that reports the parts but no total (an Anthropic-shaped upstream
+    // has no `total_tokens` to forward) no longer records zero tokens. A
+    // reported total larger than the derived one stands: a script that knows
+    // only a total has all-zero parts, and that total is the whole answer.
+    TokenUsage::new(
+        usize_field(obj, "prompt_tokens")
+            .saturating_sub(cached)
+            .saturating_sub(cache_write),
+        cached,
+        cache_write,
+        usize_field(obj, "completion_tokens"),
+    )
+    .with_reported_total(usize_field(obj, "total_tokens"))
+    .with_reported_cost(cost)
 }
 
 /// Convert the map returned by a script's `inference` function into an

--- a/crates/leviath-providers/src/rhai_provider/convert/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert/tests.rs
@@ -70,6 +70,68 @@ fn parse_inference_full() {
     assert_eq!(r.finish_reason, FinishReason::ToolCall);
 }
 
+/// The common case: an upstream that reports `prompt_tokens` and
+/// `completion_tokens` but no total (the Anthropic shape, and the docs' own
+/// `usage_of` helper before it learned better). The total is derived from the
+/// parts, not read back as zero - a zero here is what the rate limiter records
+/// and what the run reports as `tokens_used`.
+#[test]
+fn usage_without_a_total_still_reports_one() {
+    let r = parse_inference_dynamic(dyn_from_json(
+        r#"{"content":"","tokens_used":{"prompt_tokens":3,"completion_tokens":2}}"#,
+    ))
+    .unwrap();
+    assert_eq!(r.tokens_used.total_tokens, 5);
+}
+
+/// A script forwarding an OpenAI-shaped usage object verbatim sends a
+/// `prompt_tokens` that INCLUDES the cached slice. The host subtracts the
+/// cache counts back out, the same normalization the native OpenAI provider
+/// applies, so the cached tokens are not billed once at the full input rate
+/// inside `prompt_tokens` and again at the cache rate.
+#[test]
+fn an_openai_shaped_usage_forwarded_verbatim_is_not_double_counted() {
+    let r = parse_inference_dynamic(dyn_from_json(
+        r#"{"content":"","tokens_used":{
+                "prompt_tokens":100,"completion_tokens":5,"total_tokens":105,
+                "cached_tokens":80}}"#,
+    ))
+    .unwrap();
+    assert_eq!(r.tokens_used.prompt_tokens, 20, "fresh input only");
+    assert_eq!(r.tokens_used.cached_tokens, 80);
+    assert_eq!(r.tokens_used.input_tokens(), 100);
+    assert_eq!(r.tokens_used.total_tokens, 105);
+}
+
+/// A script that knows only a total (an endpoint that reports nothing finer)
+/// keeps it: deriving the total from all-zero parts and discarding the one
+/// figure the script had would zero the call.
+#[test]
+fn a_total_only_usage_keeps_its_total() {
+    let r = parse_inference_dynamic(dyn_from_json(
+        r#"{"content":"","tokens_used":{"total_tokens":9}}"#,
+    ))
+    .unwrap();
+    assert_eq!(r.tokens_used.total_tokens, 9);
+    assert_eq!(r.tokens_used.prompt_tokens, 0);
+    assert_eq!(r.tokens_used.completion_tokens, 0);
+}
+
+/// A malformed report whose cache counts exceed its own prompt count clamps
+/// to zero fresh input rather than wrapping, and the total never reads lower
+/// than what the parts add up to.
+#[test]
+fn a_usage_whose_parts_exceed_its_prompt_count_saturates() {
+    let r = parse_inference_dynamic(dyn_from_json(
+        r#"{"content":"","tokens_used":{
+                "prompt_tokens":10,"completion_tokens":5,
+                "cached_tokens":80,"cache_write_tokens":40}}"#,
+    ))
+    .unwrap();
+    assert_eq!(r.tokens_used.prompt_tokens, 0);
+    assert_eq!(r.tokens_used.total_tokens, 125);
+}
+
 #[test]
 fn parse_inference_defaults_and_missing_fields() {
     let r = parse_inference_dynamic(dyn_from_json("{}")).unwrap();

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -732,7 +732,14 @@ fn parse_models(value: Dynamic, provider: &str) -> Vec<ModelInfo> {
                         .get("display_name")
                         .and_then(|v| v.as_str())
                         .map(str::to_string);
-                    Some(ModelInfo::new(id, provider, capabilities).named(display_name))
+                    // `listed`: these rows are the script's own answer, not a
+                    // table compiled into this build, and `lev models list`
+                    // counts which is which by the flag.
+                    Some(
+                        ModelInfo::new(id, provider, capabilities)
+                            .named(display_name)
+                            .listed(),
+                    )
                 })
                 .collect()
         })

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -293,6 +293,67 @@ async fn infer_no_http() {
     assert_eq!(exec.call_count(), 0);
 }
 
+/// A script that reports the parts but no total (an Anthropic-shaped upstream
+/// has no `total_tokens` field to forward) still records a real total: it is
+/// what the rate limiter counts and what the run reports as `tokens_used`.
+#[tokio::test]
+async fn infer_derives_a_total_the_script_did_not_send() {
+    let src = format!(
+        "{NOOP_INIT}fn inference(state, request) {{ \
+         #{{ content: \"hello\", \
+            tokens_used: #{{ prompt_tokens: 3, completion_tokens: 2 }} }} }}"
+    );
+    let p = build(&src, FakeExecutor::new()).unwrap();
+    let r = p.infer(&request("m")).await.unwrap();
+    assert_eq!(r.tokens_used.total_tokens, 5);
+}
+
+/// The docs' `usage_of` helper, verbatim: an OpenAI-shaped usage object
+/// forwarded as it arrives comes out normalized (cached tokens not double
+/// counted), and an upstream that omits `prompt_tokens_details` falls back
+/// cleanly through the `?? #{}` default.
+#[tokio::test]
+async fn the_documented_usage_helper_forwards_an_openai_usage_object() {
+    let src = format!(
+        "{NOOP_INIT}\
+         fn usage_of(u) {{ \
+             if u == () {{ return #{{ total_tokens: 0 }}; }} \
+             let details = u.prompt_tokens_details ?? #{{}}; \
+             #{{ \
+                 prompt_tokens: u.prompt_tokens ?? 0, \
+                 completion_tokens: u.completion_tokens ?? 0, \
+                 total_tokens: u.total_tokens ?? 0, \
+                 cached_tokens: details.cached_tokens ?? 0, \
+                 cache_write_tokens: 0, \
+             }} }}\n\
+         fn inference(state, request) {{ \
+             let resp = parse_json(http_post(\"http://api/x\", \"{{}}\", #{{}})); \
+             #{{ content: \"ok\", tokens_used: usage_of(resp.usage) }} }}"
+    );
+    let exec = FakeExecutor::with_responses(vec![
+        Ok(
+            "{\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":5,\"total_tokens\":105,\
+            \"prompt_tokens_details\":{\"cached_tokens\":80}}}"
+                .to_string(),
+        ),
+        Ok(
+            "{\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":2,\"total_tokens\":12}}"
+                .to_string(),
+        ),
+    ]);
+    let p = build(&src, exec).unwrap();
+
+    let cached = p.infer(&request("m")).await.unwrap();
+    assert_eq!(cached.tokens_used.prompt_tokens, 20, "fresh input only");
+    assert_eq!(cached.tokens_used.cached_tokens, 80);
+    assert_eq!(cached.tokens_used.total_tokens, 105);
+
+    let plain = p.infer(&request("m")).await.unwrap();
+    assert_eq!(plain.tokens_used.prompt_tokens, 10);
+    assert_eq!(plain.tokens_used.cached_tokens, 0);
+    assert_eq!(plain.tokens_used.total_tokens, 12);
+}
+
 #[tokio::test]
 async fn infer_single_http_post() {
     let src = format!(
@@ -602,6 +663,9 @@ async fn list_models_parses_and_filters() {
     assert_eq!(models[0].provider, "test");
     assert_eq!(models[0].capabilities.max_context_tokens, 1000);
     assert_eq!(models[0].capabilities.max_output_tokens, 256);
+    // These rows are the script's own answer, not a table compiled into this
+    // build: `lev models list` counts them as a provider listing by this flag.
+    assert!(models[0].learned, "a script's list_models is a listing");
 }
 
 #[tokio::test]

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -146,7 +146,8 @@ and must return:
   "content": "...",
   "tool_calls":  [ { "id": "...", "name": "...", "arguments": { /* parsed */ } } ],
   "tokens_used": { "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0,
-                   "cached_tokens": 0, "cache_write_tokens": 0 },
+                   "cached_tokens": 0, "cache_write_tokens": 0,
+                   "cost_usd": 0.0 },
   "finish_reason": "Complete"   // "Complete" | "ToolCall" | "TokenLimit" | "Stop"
 }
 ```
@@ -154,6 +155,21 @@ and must return:
 `finish_reason` also accepts the common wire spellings (`tool_calls`, `tool_use`, `length`,
 `max_tokens`, `stop_sequence`), and anything unrecognized reads as `Complete`, so most APIs'
 values pass through unmapped.
+
+Every `tokens_used` field is optional, and the host normalizes what you send:
+
+- `prompt_tokens` is the whole prompt, cache counts included, which is what an
+  OpenAI-shaped `usage` object reports and what you should forward verbatim. The host
+  subtracts `cached_tokens` and `cache_write_tokens` back out, so each token class is billed
+  once at its own rate. If your API reports its input counts separately, the way Anthropic
+  does, send `prompt_tokens` as their sum.
+- `total_tokens` may be omitted: the host derives it from the other counts. Send it when your
+  API reports one (a total larger than the sum of the parts you sent is kept, so an endpoint
+  that reports only a total still records real usage).
+- `cost_usd` (or `cost`) is what the endpoint said the call cost, in USD. It is kept verbatim
+  and never recomputed: your script is the only thing that saw the invoice figure, and
+  Leviath has no rate card for a model it has never heard of. Omit it and the call reports
+  its cost as unknown rather than zero.
 
 ## Host functions
 
@@ -300,13 +316,17 @@ fn map_finish(reason) {
     }
 }
 
+// Forward the OpenAI-shaped usage object as it arrives: `prompt_tokens`
+// includes the cached slice, and the host subtracts `cached_tokens` back out.
+// An API that reports no total is fine; the host derives one from the parts.
 fn usage_of(u) {
     if u == () { return #{ total_tokens: 0 }; }
+    let details = u.prompt_tokens_details ?? #{};
     #{
         prompt_tokens: u.prompt_tokens ?? 0,
         completion_tokens: u.completion_tokens ?? 0,
         total_tokens: u.total_tokens ?? 0,
-        cached_tokens: 0,
+        cached_tokens: details.cached_tokens ?? 0,
         cache_write_tokens: 0,
     }
 }

--- a/docs/examples/groq.rhai
+++ b/docs/examples/groq.rhai
@@ -66,13 +66,17 @@ fn map_finish(reason) {
     }
 }
 
+// Forward the OpenAI-shaped usage object as it arrives: `prompt_tokens`
+// includes the cached slice, and the host subtracts `cached_tokens` back out.
+// An API that reports no total is fine; the host derives one from the parts.
 fn usage_of(u) {
     if u == () { return #{ total_tokens: 0 }; }
+    let details = u.prompt_tokens_details ?? #{};
     #{
         prompt_tokens: u.prompt_tokens ?? 0,
         completion_tokens: u.completion_tokens ?? 0,
         total_tokens: u.total_tokens ?? 0,
-        cached_tokens: 0,
+        cached_tokens: details.cached_tokens ?? 0,
         cache_write_tokens: 0,
     }
 }


### PR DESCRIPTION
## Defect A: script-provider usage bypassed `TokenUsage::new`

`parse_usage` (`crates/leviath-providers/src/rhai_provider/convert.rs`) built `TokenUsage` by struct literal, bypassing the constructor `pricing.rs` documents as "the one constructor for a parsed response, so a provider cannot ship a total that disagrees with its parts". Two consequences:

- A script reporting `prompt_tokens`/`completion_tokens` but no `total_tokens` yielded `total_tokens: 0`. This is the common case: Anthropic-shaped upstreams have no total to forward, and the docs' own `usage_of` helper wrote `total_tokens: u.total_tokens ?? 0`. The rate limiter recorded 0 tokens and `InferenceResult.tokens_used` was 0.
- `prompt_tokens` is specified as disjoint from the cache counts, but the script path did no normalization, so a script forwarding an OpenAI-shaped usage object verbatim double-counted cache reads.

### Normalization rule implemented

- `fresh = prompt_tokens.saturating_sub(cached_tokens).saturating_sub(cache_write_tokens)`, the same rule the native OpenAI parser applies, so a script forwards an OpenAI usage object verbatim and it comes out right. The docs now say to send `prompt_tokens` as the whole prompt (cache counts included); an API that reports its counts disjointly sends their sum.
- The total is derived by `TokenUsage::new` from the parts; a new `TokenUsage::with_reported_total` then keeps `max(derived, reported)`. The derived figure never goes down (parts in hand are evidence), but a script that supplies only `total_tokens` has all-zero parts and keeps its total instead of recording zero.
- `merge_usage` (`provider/stream.rs`) folds totals the same way (`sum of totals`, reconciled with the derived sum), so a total-only usage chunk survives `collect_stream`. For every built-in provider chunk the two figures are identical and this is a no-op.
- `cost_usd`/`cost` were already parsed but undocumented; the response schema in `docs/content/rhai-providers.md` now documents them, states the disjointness rule, and the `usage_of` helper (docs and `docs/examples/groq.rhai`) now forwards `prompt_tokens_details.cached_tokens`. A new engine-level test runs the documented helper verbatim against the real Rhai engine.

## Defect B: script-provider rows mislabeled in `lev models list`

`parse_models` built rows with `ModelInfo::new(...)`, which sets `learned: false`. `print_listing` counts learned rows as "rows from the providers' own listings", so a table of purely script-provider rows printed "N rows from this build's table; no provider listing was read", exactly backwards, and `--json` reported `"learned": false`.

Rows a script's `list_models` answers now go through a new `ModelInfo::listed()` builder. Rows synthesized from config `serves = [...]` / `[model_capabilities]` claims never become `ModelInfo` rows anywhere (they surface only as `served_catalog()` strings), so nothing else changes and the distinction stays honest; `listed()`'s doc comment pins that rule down.

## Fail-first evidence

All six new probes failed against the unfixed code before the fix, and pass after:

- `usage_without_a_total_still_reports_one`: left 0, right 5
- `an_openai_shaped_usage_forwarded_verbatim_is_not_double_counted`: `prompt_tokens` left 100, right 20
- `a_usage_whose_parts_exceed_its_prompt_count_saturates`: left 10, right 0
- `collect_stream_keeps_a_total_only_usage_report`: left 0, right 9
- `infer_derives_a_total_the_script_did_not_send` (end to end through `infer`): left 0, right 5
- `list_models_parses_and_filters` (+learned assertion): "a script's list_models is a listing"
- `a_script_providers_rows_count_as_its_own_listing` (leviath-cli, through `merge_script_provider`): "'listed-large' came from the script's own list_models, not this build's table"

`a_total_only_usage_keeps_its_total` passed before and after, guarding the one behavior that already worked.

## Gates

- `cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo xtask structure`, `cargo xtask docs`: clean
- `cargo xtask coverage --package leviath-providers`: 100.00% functions/lines/regions
- `cargo xtask coverage --package leviath-cli`: 100.00% functions/lines/regions
- Full suite via pre-commit: passed
