### PR TITLE
feat(validate): surface the script and config problems only a spawn found

### DIFF
--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -394,6 +394,71 @@ fn misdirected_rate_limits(config: &Config) -> Vec<String> {
     misdirected
 }
 
+/// `[model_providers.<name>]` script entries whose `.rhai` file is nowhere on
+/// disk, each rendered as one report line.
+///
+/// The runtime resolves such an entry to `None` with no log line, so a typo'd
+/// name, a `sript = "x.rhai"` misspelling (`flatten` keeps unknown keys, so
+/// `script` stays unset and the entry falls back to convention), and an
+/// endpoint entry that forgot its `kind` all read as "the provider does not
+/// exist" with nothing anywhere saying why. The resolution rule is the
+/// daemon's own (`script_provider.rs`): an explicit `script` value, taken
+/// verbatim when absolute and confined to the providers directory when
+/// relative, else `<name>.rhai` there by convention.
+///
+/// A missing file is a warning, not an error: it may legitimately appear
+/// later, and the rest of the config still works without it.
+pub(crate) fn missing_script_providers(
+    config: &Config,
+    providers_dir: Option<&std::path::Path>,
+) -> Vec<String> {
+    let mut missing = Vec::new();
+    for (name, entry) in &config.model_providers {
+        if entry.is_endpoint() {
+            continue;
+        }
+        let stem = entry.script.as_deref().unwrap_or(name);
+        let candidate = std::path::PathBuf::from(stem);
+        let path = if candidate.is_absolute() {
+            candidate
+        } else {
+            let filename = match stem.ends_with(".rhai") {
+                true => stem.to_string(),
+                false => format!("{stem}.rhai"),
+            };
+            // A relative path with `..` in it is refused at load outright, so
+            // it is reported as such rather than as a file to create.
+            if std::path::PathBuf::from(&filename)
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir))
+            {
+                missing.push(format!(
+                    "model_providers.{name} names a script outside the providers directory \
+                     ({stem}), which is refused at load"
+                ));
+                continue;
+            }
+            // No providers directory at all means nothing to resolve a
+            // relative path against; the daemon is in the same position, and
+            // the missing-home problem is reported elsewhere.
+            let Some(dir) = providers_dir else {
+                continue;
+            };
+            dir.join(filename)
+        };
+        if !path.is_file() {
+            missing.push(format!(
+                "model_providers.{name} is a script provider but its script is not on disk \
+                 ({}); a run that routes there finds no provider",
+                path.display()
+            ));
+        }
+    }
+    // A map iterates in arbitrary order; the report should not.
+    missing.sort_unstable();
+    missing
+}
+
 /// Report what the config named and what the registry ended up holding.
 ///
 /// Only native providers can be listed - a Rhai script provider is resolved by
@@ -418,20 +483,26 @@ fn config_check(config: &Config, registry: &ProviderRegistry) -> Check {
     // the rest of the file still applies, so this is not broken wiring.
     let mut unread = Config::unread_keys_at(&Config::config_path());
     unread.extend(misdirected_rate_limits(config));
-    if unread.is_empty() {
+    // Same posture as the unread keys, and reported beside them: the config
+    // deserializes fine and one entry of it does nothing.
+    let mut notes = missing_script_providers(config, crate::config::providers_dir().as_deref());
+    if !unread.is_empty() {
+        let subject = match unread.len() {
+            1 => "1 key in config.toml is".to_string(),
+            n => format!("{n} keys in config.toml are"),
+        };
+        notes.insert(
+            0,
+            format!(
+                "{subject} read by nothing - check the spelling: {}",
+                unread.join(", ")
+            ),
+        );
+    }
+    if notes.is_empty() {
         return Check::ok("config", detail);
     }
-    let subject = match unread.len() {
-        1 => "1 key in config.toml is",
-        n => &format!("{n} keys in config.toml are"),
-    };
-    Check::ok(
-        "config",
-        format!(
-            "{detail}  (note: {subject} read by nothing - check the spelling: {})",
-            unread.join(", ")
-        ),
-    )
+    Check::ok("config", format!("{detail}  (note: {})", notes.join("; ")))
 }
 
 /// The `config` check for a file that will not load.

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -392,6 +392,129 @@ fn config_check_says_none_when_nothing_is_registered() {
     );
 }
 
+/// The check mirrors the daemon's own resolution rule: an explicit `script`
+/// (with `.rhai` appended when the value has no extension), else the entry's
+/// own name by convention - and an endpoint entry is not a script at all.
+#[test]
+fn missing_script_providers_applies_the_daemon_resolution_rule() {
+    let providers = tempfile::tempdir().unwrap();
+    std::fs::write(providers.path().join("present.rhai"), "// a provider").unwrap();
+    let config: Config = toml::from_str(
+        r#"
+default_provider = "anthropic"
+[model_providers.present]
+[model_providers.ghost]
+[model_providers.renamed]
+script = "present"
+[model_providers.gone]
+script = "elsewhere.rhai"
+[model_providers.endpoint]
+kind = "openai-compatible"
+base_url = "http://localhost:1/v1"
+"#,
+    )
+    .expect("the config loads");
+
+    let missing = missing_script_providers(&config, Some(providers.path()));
+    let joined = missing.join("\n");
+    assert_eq!(missing.len(), 2, "only the two absent scripts: {joined}");
+    assert!(joined.contains("model_providers.ghost"), "{joined}");
+    assert!(
+        joined.contains("ghost.rhai"),
+        "the convention path: {joined}"
+    );
+    assert!(joined.contains("model_providers.gone"), "{joined}");
+    assert!(joined.contains("elsewhere.rhai"), "{joined}");
+    assert!(
+        !joined.contains("model_providers.present") && !joined.contains("model_providers.renamed"),
+        "an entry whose script exists stays quiet: {joined}"
+    );
+    assert!(
+        !joined.contains("model_providers.endpoint"),
+        "an endpoint runs no script: {joined}"
+    );
+}
+
+/// An absolute `script` is honored verbatim (the documented way to keep one
+/// elsewhere), and a relative one with `..` in it is reported as refused
+/// rather than as a file to create, because that is what the daemon does.
+#[test]
+fn missing_script_providers_honors_absolute_paths_and_flags_traversal() {
+    let providers = tempfile::tempdir().unwrap();
+    let kept = providers.path().join("kept-elsewhere.rhai");
+    std::fs::write(&kept, "// a provider").unwrap();
+    let lost = providers.path().join("never-written.rhai");
+
+    let mut config = Config::default();
+    let scripted = |path: &std::path::Path| crate::config::ModelProviderConfig {
+        script: Some(path.to_string_lossy().into_owned()),
+        ..Default::default()
+    };
+    config
+        .model_providers
+        .insert("far".to_string(), scripted(&kept));
+    config
+        .model_providers
+        .insert("lost".to_string(), scripted(&lost));
+    config.model_providers.insert(
+        "sneaky".to_string(),
+        crate::config::ModelProviderConfig {
+            script: Some("../outside".to_string()),
+            ..Default::default()
+        },
+    );
+
+    let missing = missing_script_providers(&config, Some(providers.path()));
+    let joined = missing.join("\n");
+    assert_eq!(missing.len(), 2, "{joined}");
+    assert!(joined.contains("model_providers.lost"), "{joined}");
+    assert!(
+        !joined.contains("model_providers.far"),
+        "an absolute script that exists stays quiet: {joined}"
+    );
+    assert!(joined.contains("model_providers.sneaky"), "{joined}");
+    assert!(joined.contains("refused at load"), "{joined}");
+}
+
+/// With no providers directory at all (no home), a relative entry has nothing
+/// to resolve against; the missing-home problem is somebody else's report.
+#[test]
+fn missing_script_providers_with_no_providers_dir_skips_relative_entries() {
+    let config: Config = toml::from_str("[model_providers.ghost]\n").expect("the config loads");
+    assert!(missing_script_providers(&config, None).is_empty());
+}
+
+/// A `[model_providers.<name>]` script entry whose `.rhai` file is nowhere on
+/// disk resolves to no provider with no log line, and the unknown-key check
+/// cannot see it either: `sript = "typo.rhai"` lands in the entry's flattened
+/// `extra` and round-trips, so the entry quietly falls back to the
+/// `<name>.rhai` convention and finds nothing. This is the one place that
+/// cross-checks the name against the providers directory.
+#[test]
+fn config_check_names_a_script_provider_whose_file_is_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let mut vars = crate::config::config_isolation_vars(&root);
+    vars.push(("LEVIATH_HOME", Some(root.clone().into_os_string())));
+    let check = temp_env::with_vars(vars, || {
+        let config: Config = toml::from_str(
+            "default_provider = \"anthropic\"\n[model_providers.ghost]\nsript = \"typo.rhai\"\n",
+        )
+        .expect("the typo deserializes perfectly - that is the bug class");
+        config_check(&config, &ProviderRegistry::new())
+    });
+    assert_eq!(
+        check.status,
+        CheckStatus::Ok,
+        "a warning, not broken wiring"
+    );
+    assert!(
+        check.detail.contains("model_providers.ghost"),
+        "got: {}",
+        check.detail
+    );
+}
+
 /// A `[rate_limits]` entry naming no provider throttles nothing, and the
 /// unknown-key check cannot see it: the table takes arbitrary keys, so the
 /// typo deserializes perfectly.

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -196,6 +196,13 @@ async fn execute_with_registry(
     let region_scripts =
         crate::daemon::spawn::resolve_region_scripts(&blueprint, &manifest_path.to_string_lossy())
             .map_err(|e| anyhow::anyhow!(e))?;
+    // Output validators and stage hook scripts are hard spawn errors too, so
+    // the preview loop checks them the same way; only the compile verdict is
+    // wanted here, the compiled scripts themselves run at spawn.
+    crate::daemon::spawn::resolve_output_validators(&blueprint, &manifest_path.to_string_lossy())
+        .map_err(|e| anyhow::anyhow!(e))?;
+    crate::daemon::spawn::resolve_stage_hook_scripts(&blueprint, &manifest_path.to_string_lossy())
+        .map_err(|e| anyhow::anyhow!(e))?;
 
     let registry = if !args.dry_run {
         let config = Config::load()?;
@@ -755,6 +762,69 @@ expect_contains = "world"
 
         let result = execute(args).await;
         assert!(result.is_ok());
+    }
+
+    /// `lev test` is the preview loop, so it resolves output validators the
+    /// way a spawn would: one that does not compile fails the command here,
+    /// not at the end of a paid run.
+    #[tokio::test]
+    async fn dry_run_rejects_an_output_validator_that_does_not_compile() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        let manifest = r#"
+[agent]
+name = "test-agent"
+version = "0.1.0"
+description = "test"
+
+[stages.main]
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+
+[stages.main.output]
+format = "a2ui"
+validator = "shape.rhai"
+"#;
+        write_test_agent(project, manifest);
+        std::fs::write(project.join("shape.rhai"), "fn validate(content) { ][ }").unwrap();
+        std::fs::create_dir_all(project.join("tests")).unwrap();
+
+        let args = TestArgs {
+            path: Some(project.to_str().unwrap().to_string()),
+            filter: None,
+            dry_run: true,
+        };
+        let err = execute(args).await.unwrap_err().to_string();
+        assert!(err.contains("output validator"), "{err}");
+    }
+
+    /// And the same for stage hook scripts: a hook file that is not on disk is
+    /// a spawn error, so `lev test` says so first.
+    #[tokio::test]
+    async fn dry_run_rejects_a_stage_hook_script_that_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        let manifest = r#"
+[agent]
+name = "test-agent"
+version = "0.1.0"
+description = "test"
+
+[stages.main]
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+
+[stages.main.hooks]
+on_stage_enter = "missing.rhai"
+"#;
+        write_test_agent(project, manifest);
+        std::fs::create_dir_all(project.join("tests")).unwrap();
+
+        let args = TestArgs {
+            path: Some(project.to_str().unwrap().to_string()),
+            filter: None,
+            dry_run: true,
+        };
+        let err = execute(args).await.unwrap_err().to_string();
+        assert!(err.contains("stage hook script"), "{err}");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -273,6 +273,13 @@ fn check_manifest(path: &std::path::Path) -> Result<CheckedManifest, ManifestChe
     // to find.
     crate::daemon::spawn::resolve_region_scripts(&blueprint, &manifest_path.to_string_lossy())
         .map_err(ManifestCheckError::Validation)?;
+    // Output validators and stage hook scripts get the same treatment, for the
+    // same reason: both are hard spawn errors, and the docs promise this
+    // command finds them without starting anything.
+    crate::daemon::spawn::resolve_output_validators(&blueprint, &manifest_path.to_string_lossy())
+        .map_err(ManifestCheckError::Validation)?;
+    crate::daemon::spawn::resolve_stage_hook_scripts(&blueprint, &manifest_path.to_string_lossy())
+        .map_err(ManifestCheckError::Validation)?;
 
     let agent_dir = manifest_path
         .parent()
@@ -860,6 +867,39 @@ fn broken_config_note(fault: &crate::config::ConfigFault) -> Vec<String> {
     ]
 }
 
+/// What `lev validate` says about a config file that loads but holds problems
+/// `lev doctor` would name: keys nothing reads, and script providers whose
+/// `.rhai` file is not on disk.
+///
+/// Warnings, not failures, exactly as the broken-config note is: the
+/// blueprint is what was asked about, but validating against a config the
+/// daemon will warn about is how a clean verdict here and a misrouted run
+/// stopped agreeing.
+fn loaded_config_notes(config: &crate::config::Config) -> Vec<String> {
+    let unread = crate::config::Config::unread_keys_at(&crate::config::Config::config_path());
+    let missing = crate::commands::doctor::missing_script_providers(
+        config,
+        crate::config::providers_dir().as_deref(),
+    );
+    config_note_lines(&unread, &missing)
+}
+
+/// The lines [`loaded_config_notes`] prints, from the two lists, so the
+/// rendering is assertable without planting a config file.
+fn config_note_lines(unread: &[String], missing: &[String]) -> Vec<String> {
+    let mut lines = Vec::new();
+    if !unread.is_empty() {
+        lines.push(format!(
+            "warning: config.toml has key(s) nothing reads - check the spelling: {}",
+            unread.join(", ")
+        ));
+    }
+    for entry in missing {
+        lines.push(format!("warning: {entry}"));
+    }
+    lines
+}
+
 /// Run `lev validate`: check a blueprint and print what is wrong with it.
 pub(crate) async fn execute(args: ValidateArgs) -> anyhow::Result<()> {
     // A config that will not load is said out loud. `.ok()` here would turn it
@@ -867,7 +907,15 @@ pub(crate) async fn execute(args: ValidateArgs) -> anyhow::Result<()> {
     // an install would use, which read paths are granted. The blueprint still
     // validates without one, so this is a warning rather than a refusal.
     let config = match crate::config::Config::load_faulted() {
-        Ok(config) => Some(config),
+        Ok(config) => {
+            // A config that loads can still be one the daemon warns about;
+            // saying so here keeps this command's verdict and `lev doctor`'s
+            // in agreement.
+            for line in loaded_config_notes(&config) {
+                eprintln!("{line}");
+            }
+            Some(config)
+        }
         Err(fault) => {
             for line in broken_config_note(&fault) {
                 eprintln!("{line}");
@@ -2216,6 +2264,36 @@ brain = { kind = "custom", script = "hooks/brain.rhai", max_tokens = 1000 }
         assert!(!check_manifest(empty.path()).unwrap_err().is_parse());
     }
 
+    /// docs/content/rhai-validators.md promises `lev validate <path>` compiles
+    /// output validators. Before this check existed, a blueprint whose
+    /// validator did not compile passed `lev validate` and died at spawn - the
+    /// exact failure the command exists to find early.
+    #[test]
+    fn check_manifest_rejects_an_output_validator_that_does_not_compile() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("shape.rhai"), "fn validate(content) { ][ }").unwrap();
+        let manifest = format!(
+            "{CLEAN_MANIFEST}\n[stages.main.output]\nformat = \"a2ui\"\nvalidator = \"shape.rhai\"\n"
+        );
+        write_manifest(dir.path(), &manifest);
+        let err = check_manifest(dir.path()).unwrap_err();
+        let text = format!("{err:?}");
+        assert!(text.contains("output validator"), "{text}");
+    }
+
+    /// Stage hook scripts are resolved exactly as a spawn resolves them, so a
+    /// hook file that is not there fails `lev validate` rather than the run.
+    #[test]
+    fn check_manifest_rejects_a_stage_hook_script_that_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest =
+            format!("{CLEAN_MANIFEST}\n[stages.main.hooks]\non_stage_enter = \"missing.rhai\"\n");
+        write_manifest(dir.path(), &manifest);
+        let err = check_manifest(dir.path()).unwrap_err();
+        let text = format!("{err:?}");
+        assert!(text.contains("stage hook script"), "{text}");
+    }
+
     #[test]
     fn check_manifest_direct_file_path_is_accepted() {
         let dir = tempfile::tempdir().unwrap();
@@ -2242,6 +2320,86 @@ brain = { kind = "custom", script = "hooks/brain.rhai", max_tokens = 1000 }
                 assert!(
                     execute(args_for(manifest_dir.path())).await.is_ok(),
                     "a blueprint is checked whether or not the config loads"
+                );
+            },
+        )
+        .await;
+    }
+
+    /// A config that loads can still hold problems `lev doctor` would name -
+    /// a key nothing reads, a script provider whose `.rhai` file is not on
+    /// disk. `lev validate` used to pass such a config in silence, so its
+    /// clean verdict and the daemon's behaviour disagreed.
+    #[test]
+    fn loaded_config_notes_name_stale_keys_and_missing_script_providers() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let mut vars = crate::config::config_isolation_vars(&root);
+        vars.push(("LEVIATH_HOME", Some(root.clone().into_os_string())));
+        temp_env::with_vars(vars, || {
+            std::fs::write(
+                root.join("config.toml"),
+                "default_provider = \"anthropic\"\n\
+                 [cache]\nttl = 30\n\
+                 [model_providers.ghost]\n",
+            )
+            .unwrap();
+            let config = crate::config::Config::load_faulted().expect("it loads");
+            let notes = loaded_config_notes(&config);
+            let joined = notes.join("\n");
+            assert!(joined.contains("cache"), "the stale key is named: {joined}");
+            assert!(
+                joined.contains("model_providers.ghost"),
+                "the script provider with no file is named: {joined}"
+            );
+            assert!(
+                notes.iter().all(|line| line.starts_with("warning: ")),
+                "warnings, not errors: {joined}"
+            );
+        });
+    }
+
+    /// The rendering itself: quiet on clean lists, one line per problem
+    /// otherwise, every line marked as a warning.
+    #[test]
+    fn config_note_lines_render_both_kinds_and_stay_quiet_on_clean_lists() {
+        assert!(config_note_lines(&[], &[]).is_empty());
+
+        let lines = config_note_lines(
+            &["cache.ttl".to_string()],
+            &[
+                "model_providers.ghost is a script provider but its script is not on disk"
+                    .to_string(),
+            ],
+        );
+        assert_eq!(lines.len(), 2);
+        let stale = &lines[0];
+        assert!(stale.contains("cache.ttl"), "{stale}");
+        let missing = &lines[1];
+        assert!(
+            missing.starts_with("warning: model_providers.ghost"),
+            "{missing}"
+        );
+    }
+
+    /// The other side of the coin: a config that loads but holds a stale key
+    /// gets its warning printed on the way past, and the blueprint check
+    /// still runs and still passes. A warning, never a refusal.
+    #[tokio::test]
+    async fn execute_warns_about_a_loaded_config_with_stale_keys_and_still_checks() {
+        crate::config::with_isolated_config_path_async(
+            "validate-stale-key-config",
+            |dir| async move {
+                std::fs::write(
+                    dir.join("config.toml"),
+                    "default_provider = \"anthropic\"\n[cache]\nttl = 30\n",
+                )
+                .unwrap();
+                let manifest_dir = tempfile::tempdir().unwrap();
+                write_test_agent(manifest_dir.path(), CLEAN_MANIFEST);
+                assert!(
+                    execute(args_for(manifest_dir.path())).await.is_ok(),
+                    "a stale config key is a warning, not a refusal"
                 );
             },
         )

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -682,7 +682,7 @@ restarted:
 | `lev ps` | The same fact under the run table |
 | `lev doctor` | The `config` check fails, with the line and column, or with the key |
 | `lev dash` | A warning across the top of the screen for as long as the file is broken |
-| `lev validate` | A warning that the model and read-path checks were skipped; the blueprint is still checked |
+| `lev validate` | A warning that the model and read-path checks were skipped; the blueprint is still checked. A file that *does* load gets the same scrutiny `lev doctor` gives it: stale keys and script providers whose file is missing are warned about on the way past |
 | `GET /api/config` | A `config_error` object, and a `config_health` frame on `/ws`. See [the API reference](/docs/api#when-the-config-file-will-not-load) |
 
 Two kinds of problem are reported differently, because they are found differently:
@@ -705,10 +705,16 @@ WARN config.toml has keys nothing reads; they are being ignored.
      keys=limits.max_concurrent_tool, cache, providers.anthropic_cach_ttl
 ```
 
-`lev doctor` reports the same list, for when that scrolls past. It also names a
-`[rate_limits.<provider>]` entry whose provider does not exist, which is a case the key check cannot
-see: that table takes any name, so a misspelled provider deserializes perfectly and throttles
-nothing.
+`lev doctor` and `lev validate` report the same list, for when that scrolls past. `lev doctor` also
+names a `[rate_limits.<provider>]` entry whose provider does not exist, which is a case the key
+check cannot see: that table takes any name, so a misspelled provider deserializes perfectly and
+throttles nothing.
+
+A `[model_providers.<name>]` script entry whose `.rhai` file is nowhere on disk is close kin, and
+both commands name it too, with the path they looked for. Without that check the entry resolves to
+no provider and nothing says why. It also catches `sript = "x.rhai"`: the misspelled key is kept
+and forwarded to the script (see below), so `script` stays unset, the entry falls back to
+`<name>.rhai` by convention, and finds nothing.
 
 This is a warning, not an error. Every command reads `config.toml`, so one stale key should not take
 the CLI down. A blueprint is different: it is authored and validated deliberately, and it fails on


### PR DESCRIPTION
Closes three diagnostic gaps where `lev validate` (and in one case `lev test` and `lev doctor`) stayed silent about problems the daemon would later hit.

## Gap 1: `lev validate` did not compile output validators or stage hook scripts

`docs/content/rhai-validators.md` promises that `lev validate <path>` compiles output validators. It only resolved custom region scripts; `resolve_output_validators` and `resolve_stage_hook_scripts` ran exclusively at spawn. `lev test` had the same gap.

Both commands now call both resolvers beside the existing region-script check, so a validator or hook that is missing or does not compile fails the command instead of the run.

Fail-first evidence: `check_manifest_rejects_an_output_validator_that_does_not_compile`, `check_manifest_rejects_a_stage_hook_script_that_is_missing`, `dry_run_rejects_an_output_validator_that_does_not_compile`, and `dry_run_rejects_a_stage_hook_script_that_is_missing` all failed on unfixed code with `called Result::unwrap_err() on an Ok value` (the broken blueprints passed clean).

## Gap 2: `lev validate` ignored config problems `lev doctor` reports

`Config::load_faulted()`'s Ok arm said nothing about unread or typo'd keys, though the machinery (`Config::unread_keys_at`) existed and `lev doctor` used it. `lev validate` now prints the same list as warnings on the way past, alongside Gap 3's list. Warnings, not errors, matching the repo's stale-key policy.

## Gap 3: a script provider whose `.rhai` file is missing had no diagnostic anywhere

A `[model_providers.<name>]` script entry whose file does not exist resolves to `None` with no log line. That silence also swallowed `sript = "x.rhai"` (flatten keeps the misspelled key, so the entry falls back to the `<name>.rhai` convention) and an endpoint entry that forgot `kind =`.

New `missing_script_providers` in `doctor.rs` (beside the analogous `misdirected_rate_limits`) mirrors the daemon's resolution rule from `script_provider.rs`: explicit `script` (absolute honored verbatim, relative confined to the providers dir, `..` refused), else `<name>.rhai` by convention. `lev doctor`'s `config` check notes each entry with no file on disk, and `lev validate` prints the same list. Warn, not error: the file may legitimately appear later.

Fail-first evidence: `config_check_names_a_script_provider_whose_file_is_missing` failed on unfixed code (the check detail carried no mention of the ghost entry).

## Docs

`docs/content/configuration.md`: the `lev validate` row in the broken-config table now mentions the loadable-config warnings, and "Keys nothing reads" names `lev validate` as a second surface plus the new missing-script-provider report.

## Gates

`cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo xtask structure`, `cargo xtask docs`, and `cargo xtask coverage --package leviath-cli` (100% gate) all pass.
