### PR TITLE
feat(regions): honest on_write rejections, key-aware hooks, and render-time upsert

### DIFF
--- a/crates/leviath-core/src/error.rs
+++ b/crates/leviath-core/src/error.rs
@@ -90,6 +90,22 @@ pub enum Error {
         max: usize,
     },
 
+    /// A custom region's `on_write` hook rejected the write.
+    ///
+    /// Only raised for agent-origin writes (`context_write`, `context_append`,
+    /// routed tool results), where the refusal and its reason can be reported
+    /// back to the writer. A framework write that a hook rejects is stored
+    /// unchanged with a warning instead - a script must not be able to delete
+    /// an assistant turn or a system record.
+    #[error("Region '{region}' refused the write: {reason}")]
+    RegionRefusedWrite {
+        /// The region whose hook refused the write.
+        region: String,
+        /// Why, as the hook said it (or a generic phrase when it only
+        /// returned `false`).
+        reason: String,
+    },
+
     /// Pinned regions alone exceed total token budget
     #[error("Pinned regions ({pinned_tokens}) exceed total budget ({total_budget})")]
     PinnedRegionsOverBudget {
@@ -197,6 +213,18 @@ mod tests {
             max: 100,
         };
         assert_eq!(e.to_string(), "Content exceeds token budget: 500 > 100");
+    }
+
+    #[test]
+    fn error_region_refused_write() {
+        let e = Error::RegionRefusedWrite {
+            region: "claims".into(),
+            reason: "needs a source line".into(),
+        };
+        assert_eq!(
+            e.to_string(),
+            "Region 'claims' refused the write: needs a source line"
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -96,6 +96,43 @@ pub struct AssembledContext {
     pub system_hash: u64,
 }
 
+/// Whose write a region write is.
+///
+/// A custom region's `on_write` hook may reject a write, and what a rejection
+/// does depends on whether anyone can be told about it. An agent-origin write
+/// (a `context_write`/`context_append` call, a routed tool result) has a tool
+/// result to carry the refusal, so it becomes an error naming the reason. A
+/// system-origin write (an assistant turn, a delivered message, a framework
+/// record) has no such channel, and a script must not be able to silently
+/// delete it - the rejection is downgraded to accept-unchanged plus a warning.
+///
+/// When classifying a new write path, `System` is the safe default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WriteOrigin {
+    /// A write the model itself asked for; a rejection is reported back to it.
+    Agent,
+    /// A framework record; a rejection is stored unchanged with a warning.
+    System,
+}
+
+/// What a custom region's `on_write` hook decided about one write, with the
+/// original content carried through the `Refused` arm so a system-origin
+/// caller can store it unchanged.
+enum HookDecision {
+    /// Store this content (possibly replaced), with this token count and,
+    /// when the hook chose one, this key instead of the one the write named.
+    Store(String, usize, Option<String>),
+    /// The hook refused the write; the original entry rides along.
+    Refused {
+        /// The content exactly as the write carried it.
+        content: String,
+        /// Its original token count.
+        tokens: usize,
+        /// The hook's reason, when it gave one.
+        reason: Option<String>,
+    },
+}
+
 /// Context window component storing the agent's memory regions.
 #[derive(Component, Debug, Clone)]
 pub struct ContextWindow {
@@ -192,34 +229,101 @@ impl ContextWindow {
     }
 
     /// Run a custom region's `on_write` hook (when defined) for an incoming
-    /// entry. `None` means the script dropped the entry - the write reports
-    /// success without storing anything. Non-custom regions, missing scripts,
-    /// and hook failures all accept the entry unchanged.
+    /// entry. Non-custom regions, missing scripts, and hook failures all
+    /// store the entry unchanged; what a `Refused` decision does is the
+    /// origin adapters' business ([`Self::on_write_agent`],
+    /// [`Self::on_write_system`]).
     ///
     /// Deliberately NOT invoked by the layout-swap carry or restore overlay:
     /// those re-add entries the hook already accepted once.
-    fn on_write_outcome(
+    fn on_write_decision(
         &self,
         region_name: &str,
         content: String,
         tokens: usize,
         kind: &leviath_core::EntryKind,
-    ) -> Option<(String, usize)> {
+        key: Option<&str>,
+    ) -> HookDecision {
         let Some(script) = self.custom_script_for(region_name) else {
-            return Some((content, tokens));
+            return HookDecision::Store(content, tokens, None);
         };
         if !script.has_on_write() {
-            return Some((content, tokens));
+            return HookDecision::Store(content, tokens, None);
         }
         // The region exists - custom_script_for resolved through it.
         let region = self
             .get_region(region_name)
             .expect("custom_script_for resolved through this region");
-        match crate::custom_region::apply_on_write(&script, region, content, tokens, kind) {
-            crate::custom_region::OnWriteOutcome::Accept(content, tokens) => {
-                Some((content, tokens))
+        let incoming = crate::custom_region::IncomingEntry {
+            content: &content,
+            tokens,
+            kind,
+            key,
+        };
+        match crate::custom_region::apply_on_write(&script, region, incoming) {
+            crate::custom_region::OnWriteOutcome::Accept {
+                content,
+                tokens,
+                key_override,
+            } => HookDecision::Store(content, tokens, key_override),
+            crate::custom_region::OnWriteOutcome::Reject(reason) => HookDecision::Refused {
+                content,
+                tokens,
+                reason,
+            },
+        }
+    }
+
+    /// [`Self::on_write_decision`] for an agent-origin write: a refusal
+    /// becomes an error carrying the hook's reason, which the tool result
+    /// reports back to the model.
+    fn on_write_agent(
+        &self,
+        region_name: &str,
+        content: String,
+        tokens: usize,
+        kind: &leviath_core::EntryKind,
+        key: Option<&str>,
+    ) -> leviath_core::Result<(String, usize, Option<String>)> {
+        match self.on_write_decision(region_name, content, tokens, kind, key) {
+            HookDecision::Store(content, tokens, key_override) => {
+                Ok((content, tokens, key_override))
             }
-            crate::custom_region::OnWriteOutcome::Drop => None,
+            HookDecision::Refused { reason, .. } => Err(leviath_core::Error::RegionRefusedWrite {
+                region: region_name.to_string(),
+                reason: reason
+                    .unwrap_or_else(|| "the region's on_write hook declined it".to_string()),
+            }),
+        }
+    }
+
+    /// [`Self::on_write_decision`] for a system-origin write: a refusal is
+    /// downgraded to store-unchanged plus a warning, because these writes are
+    /// framework records (assistant turns, delivered messages, nudges) that a
+    /// script must never be able to silently delete.
+    fn on_write_system(
+        &self,
+        region_name: &str,
+        content: String,
+        tokens: usize,
+        kind: &leviath_core::EntryKind,
+        key: Option<&str>,
+    ) -> (String, usize, Option<String>) {
+        match self.on_write_decision(region_name, content, tokens, kind, key) {
+            HookDecision::Store(content, tokens, key_override) => (content, tokens, key_override),
+            HookDecision::Refused {
+                content,
+                tokens,
+                reason,
+            } => {
+                tracing::warn!(
+                    region = %region_name,
+                    reason = reason.as_deref().unwrap_or("none given"),
+                    "on_write rejected a system-origin write; storing unchanged \
+                     (a script cannot drop framework records)"
+                );
+                (content, tokens, None)
+            }
         }
     }
 
@@ -267,7 +371,7 @@ impl ContextWindow {
         content: String,
         tokens: usize,
     ) -> leviath_core::Result<()> {
-        self.add_to_region_keyed(region_name, None, content, tokens)
+        self.add_to_region_keyed(WriteOrigin::System, region_name, None, content, tokens)
     }
 
     /// Add an entry that may carry a key, so the agent can name it again to
@@ -280,16 +384,61 @@ impl ContextWindow {
     /// on one region kind and dropped on the rest.
     pub(crate) fn add_to_region_keyed(
         &mut self,
+        origin: WriteOrigin,
         region_name: &str,
         key: Option<&str>,
         content: String,
         tokens: usize,
     ) -> leviath_core::Result<()> {
-        let Some((content, tokens)) =
-            self.on_write_outcome(region_name, content, tokens, &leviath_core::EntryKind::Text)
-        else {
-            return Ok(()); // the region's script dropped the entry
+        let (content, tokens, key_override) = match origin {
+            WriteOrigin::Agent => self.on_write_agent(
+                region_name,
+                content,
+                tokens,
+                &leviath_core::EntryKind::Text,
+                key,
+            )?,
+            WriteOrigin::System => self.on_write_system(
+                region_name,
+                content,
+                tokens,
+                &leviath_core::EntryKind::Text,
+                key,
+            ),
         };
+        let key = key_override.as_deref().or(key);
+        self.write_to_region(region_name, tokens, &mut |region, tokens| match key {
+            Some(k) => region.add_keyed_entry(k, content.clone(), tokens),
+            None => region.add_entry(content.clone(), tokens),
+        })
+    }
+
+    /// Replace a region's content with a single (possibly keyed) entry on the
+    /// agent's own behalf: `context_write`'s non-hashmap arm.
+    ///
+    /// The `on_write` hook runs BEFORE anything is cleared, so a rejection
+    /// leaves the region exactly as it was - refusing the replacement and
+    /// clearing anyway would be a second way to lose content.
+    pub(crate) fn agent_replace_region(
+        &mut self,
+        region_name: &str,
+        key: Option<&str>,
+        content: String,
+        tokens: usize,
+    ) -> leviath_core::Result<()> {
+        let (content, tokens, key_override) = self.on_write_agent(
+            region_name,
+            content,
+            tokens,
+            &leviath_core::EntryKind::Text,
+            key,
+        )?;
+        let Some(region) = self.get_region_mut(region_name) else {
+            return Err(leviath_core::Error::RegionNotFound(region_name.to_string()));
+        };
+        region.clear();
+        self.current_tokens = self.calculate_tokens();
+        let key = key_override.as_deref().or(key);
         self.write_to_region(region_name, tokens, &mut |region, tokens| match key {
             Some(k) => region.add_keyed_entry(k, content.clone(), tokens),
             None => region.add_entry(content.clone(), tokens),
@@ -307,16 +456,24 @@ impl ContextWindow {
         tokens: usize,
     ) -> bool {
         // The replacement passes through on_write like any incoming entry - a
-        // custom region's script sees (and may transform or refuse) it.
-        let Some((content, tokens)) =
-            self.on_write_outcome(region_name, content, tokens, &leviath_core::EntryKind::Text)
-        else {
-            // Dropped by the script: the region keeps its current content.
-            return self.get_region(region_name).is_some();
-        };
+        // custom region's script sees (and may transform) it. These callers
+        // are all framework lanes (stage seeds, transforms, interaction
+        // answers), so a hook rejection is downgraded inside the adapter to
+        // store-unchanged plus a warning: a script that could veto the
+        // replacement could silently delete an interaction answer.
+        let (content, tokens, key_override) = self.on_write_system(
+            region_name,
+            content,
+            tokens,
+            &leviath_core::EntryKind::Text,
+            None,
+        );
         if let Some(region) = self.get_region_mut(region_name) {
             region.clear();
-            let _ = region.add_entry(content, tokens);
+            let _ = match key_override.as_deref() {
+                Some(k) => region.add_keyed_entry(k, content, tokens),
+                None => region.add_entry(content, tokens),
+            };
             self.current_tokens = self.calculate_tokens();
             true
         } else {
@@ -353,17 +510,56 @@ impl ContextWindow {
         tokens: usize,
         reasoning: Option<String>,
     ) -> leviath_core::Result<()> {
-        let Some((content, tokens)) = self.on_write_outcome(region_name, content, tokens, &kind)
-        else {
-            return Ok(());
+        self.typed_write(
+            WriteOrigin::System,
+            region_name,
+            kind,
+            content,
+            tokens,
+            None,
+        )?;
+        // On success the entry just written is the last one: the region may
+        // have evicted to make room, but it appends what it accepted. Same
+        // after-the-push attachment the core's reasoning-carrying add uses.
+        if reasoning.is_some()
+            && let Some(region) = self.get_region_mut(region_name)
+            && let Some(entry) = region.content.last_mut()
+        {
+            entry.reasoning = reasoning;
+        }
+        Ok(())
+    }
+
+    /// Shared core of the typed write methods: run the `on_write` seam with
+    /// the caller's origin, then insert the entry with its kind and (when
+    /// given) taint level, honouring a key override from the hook.
+    pub(crate) fn typed_write(
+        &mut self,
+        origin: WriteOrigin,
+        region_name: &str,
+        kind: leviath_core::EntryKind,
+        content: String,
+        tokens: usize,
+        taint: Option<leviath_core::TaintLevel>,
+    ) -> leviath_core::Result<()> {
+        let (content, tokens, key_override) = match origin {
+            WriteOrigin::Agent => self.on_write_agent(region_name, content, tokens, &kind, None)?,
+            WriteOrigin::System => self.on_write_system(region_name, content, tokens, &kind, None),
         };
         self.write_to_region(region_name, tokens, &mut |region, tokens| {
-            region.add_typed_entry_with_reasoning(
-                content.clone(),
-                tokens,
-                kind.clone(),
-                reasoning.clone(),
-            )
+            match taint {
+                Some(level) => {
+                    region.add_typed_tainted_entry(content.clone(), tokens, kind.clone(), level)?;
+                }
+                None => region.add_typed_entry(content.clone(), tokens, kind.clone())?,
+            }
+            // A key override from the hook names the entry just pushed.
+            if let Some(key) = key_override.as_deref()
+                && let Some(entry) = region.content.last_mut()
+            {
+                entry.key = Some(key.to_string());
+            }
+            Ok(())
         })
     }
 
@@ -913,37 +1109,14 @@ impl ContextWindow {
         tokens: usize,
         taint_level: leviath_core::TaintLevel,
     ) -> leviath_core::Result<()> {
-        let Some((content, tokens)) =
-            self.on_write_outcome(region_name, content, tokens, &leviath_core::EntryKind::Text)
-        else {
-            return Ok(());
-        };
-        self.write_to_region(region_name, tokens, &mut |region, tokens| {
-            region.add_tainted_entry(content.clone(), tokens, taint_level)
-        })
-    }
-
-    /// Add a typed entry to a region with a specific taint level.
-    ///
-    /// The typed+tainted counterpart of [`add_typed_entry`](Self::add_typed_entry)
-    /// and [`add_tainted_to_region`](Self::add_tainted_to_region): the entry keeps
-    /// its `EntryKind` (so turn-group eviction stays intact) while contributing
-    /// the given taint level (so the taint gate sees sensitive tool output).
-    pub(crate) fn add_typed_tainted_to_region(
-        &mut self,
-        region_name: &str,
-        kind: leviath_core::EntryKind,
-        content: String,
-        tokens: usize,
-        taint_level: leviath_core::TaintLevel,
-    ) -> leviath_core::Result<()> {
-        let Some((content, tokens)) = self.on_write_outcome(region_name, content, tokens, &kind)
-        else {
-            return Ok(());
-        };
-        self.write_to_region(region_name, tokens, &mut |region, tokens| {
-            region.add_typed_tainted_entry(content.clone(), tokens, kind.clone(), taint_level)
-        })
+        self.typed_write(
+            WriteOrigin::System,
+            region_name,
+            leviath_core::EntryKind::Text,
+            content,
+            tokens,
+            Some(taint_level),
+        )
     }
 
     /// Get the overall taint level (max across all regions).

--- a/crates/leviath-runtime/src/components/mod.rs
+++ b/crates/leviath-runtime/src/components/mod.rs
@@ -1803,12 +1803,13 @@ mod tests {
             )
             .unwrap();
         window
-            .add_typed_tainted_to_region(
+            .typed_write(
+                crate::components::WriteOrigin::System,
                 "brain",
                 leviath_core::EntryKind::UserMessage,
                 "d".to_string(),
                 1,
-                leviath_core::TaintLevel::Public,
+                Some(leviath_core::TaintLevel::Public),
             )
             .unwrap();
 
@@ -1833,57 +1834,189 @@ mod tests {
         assert_eq!(region.content[0].content, "text:e");
     }
 
+    /// The inversion of the old contract, where `false` from a hook silently
+    /// dropped a system write while the caller was told it succeeded. A
+    /// system-origin write a hook rejects is now stored unchanged (with a
+    /// warning), because these writes are framework records - an assistant
+    /// turn, a nudge - that a script must never be able to delete.
     #[test]
-    fn custom_region_on_write_drop_reports_success_without_storing() {
+    fn custom_region_on_write_reject_cannot_drop_system_writes() {
         let src = r#"
             fn render(ctx) { "" }
             fn on_write(ctx) { false }
         "#;
         let mut window = custom_window(src, false);
-        window
-            .add_to_region("brain", "spam".to_string(), 1)
-            .unwrap();
-        assert!(window.get_region("brain").unwrap().content.is_empty());
+        with_tracing(|| window.add_to_region("brain", "turn".to_string(), 1)).unwrap();
+        assert_eq!(
+            window.get_region("brain").unwrap().content[0].content,
+            "turn"
+        );
 
-        // A dropped replacement leaves existing content in place.
-        assert!(window.replace_region("brain", "more spam".to_string(), 1));
-        assert!(window.get_region("brain").unwrap().content.is_empty());
+        // Same for a system replacement: the rejection is downgraded and the
+        // replacement happens, rather than the script vetoing (say) an
+        // interaction answer.
+        assert!(with_tracing(|| window.replace_region(
+            "brain",
+            "revised".to_string(),
+            1
+        )));
+        let region = window.get_region("brain").unwrap();
+        assert_eq!(region.content.len(), 1);
+        assert_eq!(region.content[0].content, "revised");
     }
 
     #[test]
-    fn custom_region_on_write_drop_covers_typed_and_tainted_methods() {
-        // Every write method's drop arm, not just add_to_region's.
+    fn custom_region_on_write_reject_is_downgraded_across_typed_and_tainted_methods() {
+        // Every system-origin write method's reject arm, not just
+        // add_to_region's: each stores its entry unchanged.
         let src = r#"
             fn render(ctx) { "" }
-            fn on_write(ctx) { false }
+            fn on_write(ctx) { #{ action: "reject", reason: "no thanks" } }
+        "#;
+        let mut window = custom_window(src, false);
+        with_tracing(|| {
+            window
+                .add_typed_entry(
+                    "brain",
+                    leviath_core::EntryKind::UserMessage,
+                    "a".to_string(),
+                    1,
+                )
+                .unwrap();
+            window
+                .add_tainted_to_region(
+                    "brain",
+                    "b".to_string(),
+                    1,
+                    leviath_core::TaintLevel::Public,
+                )
+                .unwrap();
+            window
+                .typed_write(
+                    crate::components::WriteOrigin::System,
+                    "brain",
+                    leviath_core::EntryKind::UserMessage,
+                    "c".to_string(),
+                    1,
+                    Some(leviath_core::TaintLevel::Public),
+                )
+                .unwrap();
+        });
+        let contents: Vec<_> = window
+            .get_region("brain")
+            .unwrap()
+            .content
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect();
+        assert_eq!(contents, vec!["a", "b", "c"]);
+    }
+
+    /// The agent-origin half of the same contract: a rejection surfaces as an
+    /// error carrying the hook's reason, and nothing is stored.
+    #[test]
+    fn custom_region_on_write_reject_errors_agent_writes_with_the_reason() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { #{ action: "reject", reason: "cite a source" } }
+        "#;
+        let mut window = custom_window(src, false);
+        let err = window
+            .add_to_region_keyed(
+                crate::components::WriteOrigin::Agent,
+                "brain",
+                Some("claim-1"),
+                "unsourced".to_string(),
+                2,
+            )
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Region 'brain' refused the write: cite a source"
+        );
+        assert!(window.get_region("brain").unwrap().content.is_empty());
+
+        // A bare `false` still rejects, with a generic reason.
+        let mut window =
+            custom_window("fn render(ctx) { \"\" }\nfn on_write(ctx) { false }", false);
+        let err = window
+            .typed_write(
+                crate::components::WriteOrigin::Agent,
+                "brain",
+                leviath_core::EntryKind::Text,
+                "x".to_string(),
+                1,
+                None,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("declined"), "{err}");
+    }
+
+    /// `agent_replace_region` runs the hook before clearing, so a rejection
+    /// leaves the region exactly as it was.
+    #[test]
+    fn agent_replace_region_reject_leaves_existing_content() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) {
+                if ctx.entry.content == "bad" { false } else { true }
+            }
+        "#;
+        let mut window = custom_window(src, false);
+        window
+            .agent_replace_region("brain", None, "good".to_string(), 1)
+            .unwrap();
+        let err = window
+            .agent_replace_region("brain", None, "bad".to_string(), 1)
+            .unwrap_err();
+        assert!(err.to_string().contains("refused"), "{err}");
+        assert_eq!(
+            window.get_region("brain").unwrap().content[0].content,
+            "good"
+        );
+
+        // And a region that does not exist is still its own error.
+        let err = window
+            .agent_replace_region("ghost", None, "x".to_string(), 1)
+            .unwrap_err();
+        assert!(err.to_string().contains("ghost"), "{err}");
+    }
+
+    /// A hook's key override lands on the stored entry for typed writes too,
+    /// so render-time dedupe can bucket what the hook renamed.
+    #[test]
+    fn custom_region_on_write_key_override_reaches_typed_entries() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { #{ key: "bucket" } }
         "#;
         let mut window = custom_window(src, false);
         window
             .add_typed_entry(
                 "brain",
                 leviath_core::EntryKind::UserMessage,
-                "a".to_string(),
+                "hello".to_string(),
                 1,
             )
             .unwrap();
-        window
-            .add_tainted_to_region(
-                "brain",
-                "b".to_string(),
-                1,
-                leviath_core::TaintLevel::Public,
-            )
-            .unwrap();
-        window
-            .add_typed_tainted_to_region(
-                "brain",
-                leviath_core::EntryKind::UserMessage,
-                "c".to_string(),
-                1,
-                leviath_core::TaintLevel::Public,
-            )
-            .unwrap();
-        assert!(window.get_region("brain").unwrap().content.is_empty());
+        let entry = &window.get_region("brain").unwrap().content[0];
+        assert_eq!(entry.key.as_deref(), Some("bucket"));
+        assert_eq!(entry.content, "hello");
+    }
+
+    /// The system replacement path honours a key override too, so a hook can
+    /// name the single entry an authoritative-document region holds.
+    #[test]
+    fn replace_region_honours_a_hook_key_override() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { #{ key: "current" } }
+        "#;
+        let mut window = custom_window(src, false);
+        assert!(window.replace_region("brain", "v1".to_string(), 1));
+        let entry = &window.get_region("brain").unwrap().content[0];
+        assert_eq!(entry.key.as_deref(), Some("current"));
+        assert_eq!(entry.content, "v1");
     }
 
     #[test]
@@ -2821,7 +2954,7 @@ mod tests {
         assert_eq!(assembled.messages[0].content.as_text(), "Begin.");
     }
 
-    // ─── add_typed_entry / add_typed_tainted_to_region error paths ────────
+    // ─── add_typed_entry / typed_write (tainted) error paths ──────────────
 
     #[test]
     fn test_add_typed_entry_to_nonexistent_region() {
@@ -2843,12 +2976,13 @@ mod tests {
     #[test]
     fn test_add_typed_tainted_to_nonexistent_region() {
         let mut window = ContextWindow::new(10000);
-        let result = window.add_typed_tainted_to_region(
+        let result = window.typed_write(
+            crate::components::WriteOrigin::System,
             "ghost",
             leviath_core::EntryKind::UserMessage,
             "data".to_string(),
             10,
-            leviath_core::TaintLevel::Public,
+            Some(leviath_core::TaintLevel::Public),
         );
         assert!(result.is_err());
         let err_str = result.unwrap_err().to_string();
@@ -3101,7 +3235,7 @@ mod tests {
     // ─── Coverage for ContextWindow typed+tainted methods ─────────────────
 
     #[test]
-    fn test_add_typed_tainted_to_region_success() {
+    fn typed_tainted_write_success() {
         let mut window = ContextWindow::new(10000);
         let mut region = Region::new(
             "conv".to_string(),
@@ -3115,7 +3249,8 @@ mod tests {
         window.add_region(region);
 
         window
-            .add_typed_tainted_to_region(
+            .typed_write(
+                crate::components::WriteOrigin::System,
                 "conv",
                 leviath_core::EntryKind::ToolResult {
                     tool_call_id: "tc_1".to_string(),
@@ -3124,7 +3259,7 @@ mod tests {
                 },
                 "secret data".to_string(),
                 100,
-                leviath_core::TaintLevel::Private,
+                Some(leviath_core::TaintLevel::Private),
             )
             .unwrap();
 
@@ -3136,14 +3271,15 @@ mod tests {
     }
 
     #[test]
-    fn test_add_typed_tainted_to_region_not_found() {
+    fn typed_tainted_write_not_found() {
         let mut window = ContextWindow::new(10000);
-        let result = window.add_typed_tainted_to_region(
+        let result = window.typed_write(
+            crate::components::WriteOrigin::System,
             "nonexistent",
             leviath_core::EntryKind::Text,
             "data".to_string(),
             10,
-            leviath_core::TaintLevel::Public,
+            Some(leviath_core::TaintLevel::Public),
         );
         assert!(result.is_err());
     }
@@ -3517,19 +3653,20 @@ mod tests {
     }
 
     #[test]
-    fn test_add_typed_tainted_to_region_propagates_budget_error() {
+    fn typed_tainted_write_propagates_budget_error() {
         // Region is found, but the entry exceeds its token budget, so the
         // inner `add_typed_tainted_entry` error must propagate through the `?`.
         let mut window = ContextWindow::new(10_000);
         let region = Region::new("conv".to_string(), RegionKind::Temporary, 10);
         window.add_region(region);
 
-        let result = window.add_typed_tainted_to_region(
+        let result = window.typed_write(
+            crate::components::WriteOrigin::System,
             "conv",
             leviath_core::EntryKind::Text,
             "far too many tokens".to_string(),
             100,
-            leviath_core::TaintLevel::Public,
+            Some(leviath_core::TaintLevel::Public),
         );
         assert!(result.is_err());
     }

--- a/crates/leviath-runtime/src/context_tools.rs
+++ b/crates/leviath-runtime/src/context_tools.rs
@@ -157,11 +157,11 @@ pub(crate) fn handle_context_tool(
                     Err(e) => format!("[error] {e}"),
                 }
             } else {
-                // Through the window method (not region.add_entry directly)
-                // so a custom region's on_write hook sees the write.
-                region.clear();
-                window.current_tokens = window.calculate_tokens();
-                match window.add_to_region_keyed(region_name, key, content.to_string(), tokens) {
+                // Through the window method (not region.clear + add directly)
+                // so a custom region's on_write hook sees the write BEFORE the
+                // region is cleared, and a refusal reaches the model as an
+                // error instead of a false "Stored".
+                match window.agent_replace_region(region_name, key, content.to_string(), tokens) {
                     Ok(()) => match key {
                         Some(k) => format!("Stored in '{region_name}' section under key '{k}'."),
                         None => format!("Stored in '{region_name}' section."),
@@ -211,7 +211,15 @@ pub(crate) fn handle_context_tool(
                 // honoured here rather than dropped: it was accepted on every
                 // region kind and only ever stored on HashMap ones, so an agent
                 // could name an entry that `context_delete` could never find.
-                match window.add_to_region_keyed(region_name, key, content.to_string(), tokens) {
+                // Agent origin: this is the model's own write, so a custom
+                // region's refusal comes back here as the error the model reads.
+                match window.add_to_region_keyed(
+                    crate::components::WriteOrigin::Agent,
+                    region_name,
+                    key,
+                    content.to_string(),
+                    tokens,
+                ) {
                     Ok(()) => match key {
                         Some(k) => {
                             format!("Appended to '{region_name}' section under key '{k}'.")
@@ -925,6 +933,107 @@ mod tests {
         // No regions configured.
         let mut empty = ContextWindow::new(100_000);
         assert!(call(&mut empty, "context_list", json!({})).contains("No context window sections"));
+    }
+
+    /// A window with one custom region (`brain`) whose script is `src`.
+    fn custom_window(src: &str) -> ContextWindow {
+        let mut w = ContextWindow::new(10_000);
+        w.add_region(Region::new(
+            "brain".to_string(),
+            RegionKind::Custom {
+                script: "s.rhai".to_string(),
+                persistent: false,
+            },
+            1000,
+        ));
+        w.region_scripts.insert(
+            "s.rhai".to_string(),
+            std::sync::Arc::new(leviath_scripting::region_hook::compile("s.rhai", src).unwrap()),
+        );
+        w
+    }
+
+    /// The headline defect: a hook that declined a `context_write` used to
+    /// report "Stored in 'brain' section." to the model while storing nothing.
+    /// A refusal must be visible to the writer.
+    #[test]
+    fn a_hook_rejection_reaches_the_context_write_result() {
+        let mut w = custom_window("fn render(ctx) { \"\" }\nfn on_write(ctx) { false }");
+        let out = call(
+            &mut w,
+            "context_write",
+            json!({"region": "brain", "content": "spam"}),
+        );
+        assert!(
+            out.starts_with("[error]"),
+            "a refused write must not report success: {out}"
+        );
+        assert!(w.get_region("brain").unwrap().content.is_empty());
+    }
+
+    /// A rejection with a reason hands the reason to the model verbatim.
+    #[test]
+    fn a_hook_rejection_reason_reaches_the_model_verbatim() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { #{ action: "reject", reason: "claims need a source line" } }
+        "#;
+        let mut w = custom_window(src);
+        let out = call(
+            &mut w,
+            "context_append",
+            json!({"region": "brain", "content": "unsourced claim"}),
+        );
+        assert!(out.starts_with("[error]"), "{out}");
+        assert!(out.contains("claims need a source line"), "{out}");
+        assert!(w.get_region("brain").unwrap().content.is_empty());
+    }
+
+    /// A rejected `context_write` must leave whatever the region already held
+    /// in place: refusing the replacement and clearing anyway would be a
+    /// second way to lose content.
+    #[test]
+    fn a_rejected_context_write_leaves_existing_content_alone() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) {
+                if ctx.entry.content == "bad" { #{ action: "reject", reason: "no" } } else { true }
+            }
+        "#;
+        let mut w = custom_window(src);
+        let ok = call(
+            &mut w,
+            "context_write",
+            json!({"region": "brain", "content": "good"}),
+        );
+        assert!(ok.contains("Stored"), "{ok}");
+        let refused = call(
+            &mut w,
+            "context_write",
+            json!({"region": "brain", "content": "bad"}),
+        );
+        assert!(refused.starts_with("[error]"), "{refused}");
+        assert_eq!(w.get_region("brain").unwrap().content[0].content, "good");
+    }
+
+    /// The hook sees the key the write named, and can override it; the stored
+    /// entry carries the override so `context_delete` finds it by that name.
+    #[test]
+    fn a_hook_key_override_names_the_stored_entry() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { #{ key: `norm-${ctx.entry.key}` } }
+        "#;
+        let mut w = custom_window(src);
+        let out = call(
+            &mut w,
+            "context_append",
+            json!({"region": "brain", "key": "RFC 9110", "content": "the spec"}),
+        );
+        assert!(!out.starts_with("[error]"), "{out}");
+        let region = w.get_region("brain").unwrap();
+        assert_eq!(region.content[0].key.as_deref(), Some("norm-RFC 9110"));
+        assert_eq!(region.content[0].content, "the spec");
     }
 
     #[test]

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -43,10 +43,32 @@ pub struct AssembleMeta {
 
 /// What `on_write` decided about an incoming entry.
 pub(crate) enum OnWriteOutcome {
-    /// Store the entry with this (possibly replaced) content and token count.
-    Accept(String, usize),
-    /// The script declined the entry; report success to the writer.
-    Drop,
+    /// Store the entry.
+    Accept {
+        /// The content to store (possibly replaced by the hook).
+        content: String,
+        /// Its token count (re-estimated when the content was replaced).
+        tokens: usize,
+        /// A key the hook chose over the one the write named, when it did.
+        key_override: Option<String>,
+    },
+    /// The script refused the entry, with the reason it gave (if any). What a
+    /// refusal does is the caller's business: an agent-origin write becomes an
+    /// error carrying the reason, a system-origin write is stored unchanged
+    /// with a warning.
+    Reject(Option<String>),
+}
+
+/// One entry headed into a custom region, as `on_write` sees it.
+pub(crate) struct IncomingEntry<'a> {
+    /// The content the write carries.
+    pub content: &'a str,
+    /// Its estimated token count.
+    pub tokens: usize,
+    /// The entry kind the write would store.
+    pub kind: &'a EntryKind,
+    /// The key the write named, when it named one.
+    pub key: Option<&'a str>,
 }
 
 /// Serialize one region entry for a hook ctx. Typed metadata crosses as plain
@@ -97,12 +119,38 @@ fn region_to_json(region: &Region) -> serde_json::Value {
     })
 }
 
+/// The entries a custom region renders from: last-wins per key, unkeyed
+/// entries always kept, in stored order.
+///
+/// This is the upsert view a repeated keyed write earns: the store appends
+/// (so `on_overflow` indices and `context_delete` positions stay honest), and
+/// the model sees only the newest entry under each key. Shadowed entries keep
+/// holding budget until overflow or an explicit release removes them - which
+/// is also why `apply_overflow` hands its hook the UNFILTERED store: the
+/// indices it returns address every stored entry.
+fn render_entries(region: &Region) -> Vec<&RegionEntry> {
+    let mut seen = std::collections::HashSet::new();
+    let mut keep: Vec<bool> = vec![true; region.content.len()];
+    for (index, entry) in region.content.iter().enumerate().rev() {
+        if let Some(key) = &entry.key
+            && !seen.insert(key.as_str())
+        {
+            keep[index] = false;
+        }
+    }
+    region
+        .content
+        .iter()
+        .zip(keep)
+        .filter_map(|(entry, kept)| kept.then_some(entry))
+        .collect()
+}
+
 /// The Temporary-style block a custom region falls back to whenever its hook
 /// can't run or misbehaves - identical to the plain-`assemble` arm, so the
 /// region is never silently dropped.
 fn fallback_block(region: &Region) -> leviath_providers::SystemBlock {
-    let text = region
-        .content
+    let text = render_entries(region)
         .iter()
         .map(|e| e.content.as_str())
         .collect::<Vec<_>>()
@@ -179,7 +227,10 @@ pub(crate) fn render_custom_region(render: RegionRender<'_>, out: RenderSink<'_>
 
     let ctx = serde_json::json!({
         "region": region_to_json(region),
-        "entries": region.content.iter().map(entry_to_json).collect::<Vec<_>>(),
+        "entries": render_entries(region)
+            .into_iter()
+            .map(entry_to_json)
+            .collect::<Vec<_>>(),
         "stage_name": meta.stage_name,
         "stage_iterations": meta.stage_iterations,
         "model": meta.model,
@@ -455,14 +506,25 @@ fn message_from_json(value: &serde_json::Value) -> Result<leviath_providers::Mes
 
 /// Run `on_write` for an entry headed into a custom region. Failure of any
 /// kind accepts the entry unchanged - a script bug must not lose writes.
+///
+/// The vocabulary mirrors the stage hooks' ([`leviath_scripting::stage_hook`]),
+/// deliberately - an author who has written one has written the other:
+///
+/// - a string: accept, replacing the content
+/// - `true` or `()`: accept unchanged
+/// - `false`: reject, with no reason given
+/// - `#{ action: "reject", reason: "..." }`: reject with that reason
+/// - `#{ content: "...", key: "..." }` (both optional, `action: "accept"`
+///   implied): accept, optionally replacing content and/or key
+///
+/// Anything else - other types, a map with unknown keys or wrongly typed
+/// fields, a script error - warns and accepts unchanged.
 pub(crate) fn apply_on_write(
     script: &RegionScript,
     region: &Region,
-    content: String,
-    tokens: usize,
-    kind: &EntryKind,
+    entry: IncomingEntry<'_>,
 ) -> OnWriteOutcome {
-    let kind_str = match kind {
+    let kind_str = match entry.kind {
         EntryKind::Text => "text",
         EntryKind::UserMessage => "user_message",
         EntryKind::AssistantTurn { .. } => "assistant_turn",
@@ -470,25 +532,50 @@ pub(crate) fn apply_on_write(
     };
     let ctx = serde_json::json!({
         "region": region_to_json(region),
-        "entry": { "content": content, "kind": kind_str, "tokens": tokens },
+        "entry": {
+            "content": entry.content,
+            "kind": kind_str,
+            "tokens": entry.tokens,
+            "key": entry.key,
+        },
     });
+    let accept_unchanged = || OnWriteOutcome::Accept {
+        content: entry.content.to_string(),
+        tokens: entry.tokens,
+        key_override: None,
+    };
     match run_on_write(script, ctx) {
         Ok(serde_json::Value::String(replacement)) => {
             let tokens = leviath_core::estimate_tokens(&replacement);
-            OnWriteOutcome::Accept(replacement, tokens)
+            OnWriteOutcome::Accept {
+                content: replacement,
+                tokens,
+                key_override: None,
+            }
         }
-        Ok(serde_json::Value::Bool(false)) => OnWriteOutcome::Drop,
-        Ok(serde_json::Value::Bool(true)) | Ok(serde_json::Value::Null) => {
-            OnWriteOutcome::Accept(content, tokens)
-        }
+        Ok(serde_json::Value::Bool(false)) => OnWriteOutcome::Reject(None),
+        Ok(serde_json::Value::Bool(true)) | Ok(serde_json::Value::Null) => accept_unchanged(),
+        Ok(serde_json::Value::Object(map)) => match on_write_map_outcome(&map, &entry) {
+            Ok(outcome) => outcome,
+            Err(reason) => {
+                tracing::warn!(
+                    region = %region.name,
+                    script = %script.path,
+                    reason = %reason,
+                    "on_write returned an invalid map; accepting entry unchanged"
+                );
+                accept_unchanged()
+            }
+        },
         Ok(other) => {
             tracing::warn!(
                 region = %region.name,
                 script = %script.path,
                 returned = %other,
-                "on_write must return a string, true/false, or unit; accepting entry unchanged"
+                "on_write must return a string, true/false, unit, or a map; \
+                 accepting entry unchanged"
             );
-            OnWriteOutcome::Accept(content, tokens)
+            accept_unchanged()
         }
         Err(e) => {
             tracing::warn!(
@@ -497,8 +584,55 @@ pub(crate) fn apply_on_write(
                 error = %e,
                 "on_write failed; accepting entry unchanged"
             );
-            OnWriteOutcome::Accept(content, tokens)
+            accept_unchanged()
         }
+    }
+}
+
+/// Interpret an `on_write` map return. Strict on shape: an unknown key or a
+/// wrongly typed field is an `Err` the caller turns into accept-unchanged,
+/// because a typo'd instruction must not silently read as a different one.
+fn on_write_map_outcome(
+    map: &serde_json::Map<String, serde_json::Value>,
+    entry: &IncomingEntry<'_>,
+) -> Result<OnWriteOutcome, String> {
+    for field in map.keys() {
+        if !matches!(field.as_str(), "action" | "reason" | "content" | "key") {
+            return Err(format!("unknown field '{field}'"));
+        }
+    }
+    let action = match map.get("action") {
+        None => "accept",
+        Some(serde_json::Value::String(s)) => s.as_str(),
+        Some(other) => return Err(format!("action must be a string, found {other}")),
+    };
+    let string_field = |name: &str| -> Result<Option<String>, String> {
+        match map.get(name) {
+            None | Some(serde_json::Value::Null) => Ok(None),
+            Some(serde_json::Value::String(s)) => Ok(Some(s.clone())),
+            Some(other) => Err(format!("{name} must be a string, found {other}")),
+        }
+    };
+    match action {
+        "reject" => Ok(OnWriteOutcome::Reject(string_field("reason")?)),
+        "accept" => {
+            let key_override = string_field("key")?;
+            let (content, tokens) = match string_field("content")? {
+                Some(replacement) => {
+                    let tokens = leviath_core::estimate_tokens(&replacement);
+                    (replacement, tokens)
+                }
+                None => (entry.content.to_string(), entry.tokens),
+            };
+            Ok(OnWriteOutcome::Accept {
+                content,
+                tokens,
+                key_override,
+            })
+        }
+        other => Err(format!(
+            "unknown action '{other}' (expected accept or reject)"
+        )),
     }
 }
 
@@ -787,6 +921,69 @@ mod tests {
     }
 
     #[test]
+    fn render_ctx_dedupes_keyed_entries_last_wins() {
+        // Two writes under `plan`: the hook sees only the newest, while the
+        // unkeyed entry and the other key survive in stored order.
+        let mut region = region_with(&[("unkeyed", EntryKind::Text)]);
+        region
+            .add_keyed_entry("plan", "v1".to_string(), 10)
+            .unwrap();
+        region
+            .add_keyed_entry("note", "n1".to_string(), 10)
+            .unwrap();
+        region
+            .add_keyed_entry("plan", "v2".to_string(), 10)
+            .unwrap();
+
+        let src = r#"
+            fn render(ctx) {
+                let out = "";
+                for entry in ctx.entries { out += `${entry.content}|`; }
+                out
+            }
+        "#;
+        let (blocks, _) = render(&region, Some(&script(src)), false);
+        assert_eq!(blocks[0].text, "unkeyed|n1|v2|");
+    }
+
+    #[test]
+    fn fallback_block_dedupes_keyed_entries_too() {
+        let mut region = region_with(&[]);
+        region
+            .add_keyed_entry("plan", "v1".to_string(), 10)
+            .unwrap();
+        region
+            .add_keyed_entry("plan", "v2".to_string(), 10)
+            .unwrap();
+
+        let (blocks, _) = render(&region, None, false);
+        assert_eq!(blocks[0].text, "[brain]:\nv2");
+    }
+
+    #[test]
+    fn on_overflow_sees_the_unfiltered_store() {
+        // Two entries under one key: render shows only the newest, but the
+        // overflow ctx must address the whole store or its indices would name
+        // the wrong entries. Dropping index 0 removes the SHADOWED copy.
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_overflow(ctx) { if ctx.entries.len() == 2 { [0] } else { [] } }
+        "#;
+        let mut region = region_with(&[]);
+        region
+            .add_keyed_entry("plan", "v1".to_string(), 10)
+            .unwrap();
+        region
+            .add_keyed_entry("plan", "v2".to_string(), 10)
+            .unwrap();
+
+        let freed = with_tracing(|| apply_overflow(&script(src), &mut region, 5));
+        assert_eq!(freed, 10);
+        assert_eq!(region.content.len(), 1);
+        assert_eq!(region.content[0].content, "v2");
+    }
+
+    #[test]
     fn render_missing_script_on_empty_region_emits_nothing() {
         let region = region_with(&[]);
         let (blocks, messages) = render(&region, None, false);
@@ -958,17 +1155,59 @@ mod tests {
 
     // ─── on_write ────────────────────────────────────────────────────────
 
-    /// Run `apply_on_write` and collapse the outcome to an Option - both
-    /// enum arms are exercised across this suite (through this one shared
-    /// mapping), so it has no never-taken branch.
-    fn on_write_kind(src: &str, content: &str, kind: &EntryKind) -> Option<(String, usize)> {
+    /// Run `apply_on_write` over an entry of `kind` carrying `key`.
+    fn on_write_keyed(
+        src: &str,
+        content: &str,
+        kind: &EntryKind,
+        key: Option<&str>,
+    ) -> OnWriteOutcome {
         let region = region_with(&[]);
-        let outcome =
-            with_tracing(|| apply_on_write(&script(src), &region, content.to_string(), 5, kind));
-        match outcome {
-            OnWriteOutcome::Accept(content, tokens) => Some((content, tokens)),
-            OnWriteOutcome::Drop => None,
+        with_tracing(|| {
+            apply_on_write(
+                &script(src),
+                &region,
+                IncomingEntry {
+                    content,
+                    tokens: 5,
+                    kind,
+                    key,
+                },
+            )
+        })
+    }
+
+    impl OnWriteOutcome {
+        /// The accepted `(content, tokens, key_override)`; `None` on a
+        /// rejection. Both arms are exercised across this suite through this
+        /// one shared mapping, so it has no never-taken branch.
+        fn accepted(self) -> Option<(String, usize, Option<String>)> {
+            match self {
+                OnWriteOutcome::Accept {
+                    content,
+                    tokens,
+                    key_override,
+                } => Some((content, tokens, key_override)),
+                OnWriteOutcome::Reject(_) => None,
+            }
         }
+
+        /// The rejection's reason slot; `None` when the entry was accepted.
+        /// The same both-arms note as [`Self::accepted`] applies.
+        fn rejected(self) -> Option<Option<String>> {
+            match self {
+                OnWriteOutcome::Accept { .. } => None,
+                OnWriteOutcome::Reject(reason) => Some(reason),
+            }
+        }
+    }
+
+    /// [`on_write_keyed`] collapsed to the accepted content and tokens; `None`
+    /// on a rejection.
+    fn on_write_kind(src: &str, content: &str, kind: &EntryKind) -> Option<(String, usize)> {
+        on_write_keyed(src, content, kind, None)
+            .accepted()
+            .map(|(content, tokens, _)| (content, tokens))
     }
 
     fn on_write_of(src: &str, content: &str) -> Option<(String, usize)> {
@@ -976,7 +1215,7 @@ mod tests {
     }
 
     #[test]
-    fn on_write_replaces_accepts_and_drops() {
+    fn on_write_replaces_accepts_and_rejects() {
         let replaced = on_write_of(
             "fn render(ctx) { \"\" }\nfn on_write(ctx) { ctx.entry.content.to_upper() }",
             "hi",
@@ -998,8 +1237,108 @@ mod tests {
         assert_eq!(
             on_write_of("fn render(ctx) { \"\" }\nfn on_write(ctx) { false }", "x"),
             None,
-            "false drops the entry"
+            "false rejects the entry"
         );
+    }
+
+    #[test]
+    fn on_write_false_is_a_reasonless_rejection() {
+        let rejected = on_write_keyed(
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { false }",
+            "x",
+            &EntryKind::Text,
+            None,
+        )
+        .rejected();
+        assert_eq!(rejected, Some(None), "false carries no reason");
+
+        // And an acceptance is not a rejection - the other arm of the probe.
+        let accepted = on_write_keyed(
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { true }",
+            "x",
+            &EntryKind::Text,
+            None,
+        )
+        .rejected();
+        assert_eq!(accepted, None);
+    }
+
+    #[test]
+    fn on_write_reject_map_carries_its_reason() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { #{ action: "reject", reason: "not sourced" } }
+        "#;
+        assert_eq!(
+            on_write_keyed(src, "claim", &EntryKind::Text, None).rejected(),
+            Some(Some("not sourced".to_string()))
+        );
+    }
+
+    #[test]
+    fn on_write_reject_map_without_reason_rejects_reasonless() {
+        let src = "fn render(ctx) { \"\" }\nfn on_write(ctx) { #{ action: \"reject\" } }";
+        assert_eq!(
+            on_write_keyed(src, "x", &EntryKind::Text, None).rejected(),
+            Some(None)
+        );
+    }
+
+    #[test]
+    fn on_write_accept_map_replaces_content_and_key() {
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { #{ content: "tidied", key: "slot" } }
+        "#;
+        assert_eq!(
+            on_write_keyed(src, "messy", &EntryKind::Text, Some("orig")).accepted(),
+            Some((
+                "tidied".to_string(),
+                leviath_core::estimate_tokens("tidied"),
+                Some("slot".to_string()),
+            ))
+        );
+    }
+
+    #[test]
+    fn on_write_accept_map_fields_are_each_optional() {
+        // An explicit accept with neither field, and a key-only override
+        // that keeps the content and its original token count.
+        for (src, want_key) in [
+            (
+                "fn render(ctx) { \"\" }\nfn on_write(ctx) { #{ action: \"accept\" } }",
+                None,
+            ),
+            (
+                "fn render(ctx) { \"\" }\nfn on_write(ctx) { #{ key: \"k2\" } }",
+                Some("k2".to_string()),
+            ),
+        ] {
+            assert_eq!(
+                on_write_keyed(src, "orig", &EntryKind::Text, Some("k1")).accepted(),
+                Some(("orig".to_string(), 5, want_key)),
+                "src: {src}"
+            );
+        }
+    }
+
+    #[test]
+    fn on_write_ctx_carries_the_incoming_key() {
+        // The hook echoes the key back as content, proving it saw it; an
+        // unkeyed write shows up as unit.
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) {
+                if ctx.entry.key == () { "unkeyed" } else { ctx.entry.key }
+            }
+        "#;
+        let content_of = |key| {
+            on_write_keyed(src, "x", &EntryKind::Text, key)
+                .accepted()
+                .map(|(content, ..)| content)
+        };
+        assert_eq!(content_of(Some("rfc-9110")).as_deref(), Some("rfc-9110"));
+        assert_eq!(content_of(None).as_deref(), Some("unkeyed"));
     }
 
     #[test]
@@ -1007,6 +1346,29 @@ mod tests {
         for src in [
             "fn render(ctx) { \"\" }\nfn on_write(ctx) { 42 }",
             "fn render(ctx) { \"\" }\nfn on_write(ctx) { throw \"bad\" }",
+        ] {
+            assert_eq!(
+                on_write_of(src, "keep"),
+                Some(("keep".to_string(), 5)),
+                "src: {src}"
+            );
+        }
+    }
+
+    #[test]
+    fn on_write_invalid_maps_accept_unchanged() {
+        // A typo'd instruction must not read as a different one: every bad
+        // map shape warns and stores the entry exactly as written.
+        for src in [
+            // unknown field
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { #{ contents: \"typo\" } }",
+            // unknown action
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { #{ action: \"drop\" } }",
+            // wrongly typed fields
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { #{ action: 1 } }",
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { #{ content: 1 } }",
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { #{ key: 1 } }",
+            "fn render(ctx) { \"\" }\nfn on_write(ctx) { #{ action: \"reject\", reason: 1 } }",
         ] {
             assert_eq!(
                 on_write_of(src, "keep"),

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -5969,12 +5969,13 @@ fn call_had_no_effect_covers_every_refusal_prefix() {
 fn tainted_conv_window() -> ContextWindow {
     let mut w = conv_window();
     w.enable_taint_tracking();
-    let _ = w.add_typed_tainted_to_region(
+    let _ = w.typed_write(
+        crate::components::WriteOrigin::System,
         "conversation",
         leviath_core::EntryKind::UserMessage,
         "secret".to_string(),
         5,
-        leviath_core::TaintLevel::Internal,
+        Some(leviath_core::TaintLevel::Internal),
     );
     w
 }
@@ -16243,6 +16244,133 @@ fn a_pointer_says_when_the_region_could_not_take_the_whole_result() {
     assert!(
         !text.contains("already in this prompt"),
         "and must not claim the result is there to read: {text}"
+    );
+}
+
+/// Add a custom region backed by an `on_write` script to `window`.
+fn add_scripted_region(window: &mut ContextWindow, name: &str, budget: usize, src: &str) {
+    window.add_region(leviath_core::Region::new(
+        name.to_string(),
+        leviath_core::RegionKind::Custom {
+            script: "s.rhai".to_string(),
+            persistent: false,
+        },
+        budget,
+    ));
+    window.region_scripts.insert(
+        "s.rhai".to_string(),
+        std::sync::Arc::new(leviath_scripting::region_hook::compile("s.rhai", src).unwrap()),
+    );
+}
+
+/// A custom region's `on_write` hook can refuse a routed result, and the
+/// pointer must say so - carrying the hook's reason - instead of promising
+/// content the region never kept. Before this, `Stored::Whole` was reported
+/// for a write the script had dropped, and the model went on reasoning as
+/// though the result were stored.
+#[test]
+fn a_pointer_reports_a_hook_rejection_with_its_reason() {
+    let mut window = routed_window(&[], &[]);
+    add_scripted_region(
+        &mut window,
+        "findings",
+        20_000,
+        r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) { #{ action: "reject", reason: "raw pages are not findings" } }
+        "#,
+    );
+    let (calls, results) = one_read_call();
+    apply_tool_results(
+        &mut window,
+        "",
+        &calls,
+        &results,
+        Some(&routed_to("findings")),
+        None,
+        None,
+    );
+    let text: String = window
+        .get_region("conversation")
+        .expect("conversation")
+        .content
+        .iter()
+        .map(|e| e.content.clone())
+        .collect();
+    assert!(
+        text.contains("refused by context region 'findings'"),
+        "{text}"
+    );
+    assert!(text.contains("raw pages are not findings"), "{text}");
+    assert!(
+        !text.contains("already in this prompt"),
+        "must not claim the result is there to read: {text}"
+    );
+    assert!(
+        window
+            .get_region("findings")
+            .expect("target")
+            .content
+            .is_empty(),
+        "a refused write stores nothing"
+    );
+}
+
+/// The hook re-runs over the truncated fallback, and may refuse that shape
+/// even though it accepted the full one: still reported as a rejection, not
+/// as a truncation that happened.
+#[test]
+fn a_hook_that_refuses_the_truncated_fallback_is_reported_as_a_rejection() {
+    let mut window = routed_window(&[], &[]);
+    // Budget 200: the full result (about 500 tokens) fails the budget, and
+    // the truncated retry carries the `[truncated ...]` marker the hook keys
+    // off.
+    add_scripted_region(
+        &mut window,
+        "findings",
+        200,
+        r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) {
+                if ctx.entry.content.contains("[truncated") {
+                    #{ action: "reject", reason: "no partial pages" }
+                } else {
+                    true
+                }
+            }
+        "#,
+    );
+    let calls = vec![crate::components::ToolCall {
+        tool_id: "call-1".to_string(),
+        name: "read_file".to_string(),
+        arguments: serde_json::json!({"path": "manual.md"}),
+        thought_signature: None,
+    }];
+    let results = vec![("call-1".to_string(), "x".repeat(2000))];
+    apply_tool_results(
+        &mut window,
+        "",
+        &calls,
+        &results,
+        Some(&routed_to("findings")),
+        None,
+        None,
+    );
+    let text: String = window
+        .get_region("conversation")
+        .expect("conversation")
+        .content
+        .iter()
+        .map(|e| e.content.clone())
+        .collect();
+    assert!(text.contains("no partial pages"), "{text}");
+    assert!(
+        window
+            .get_region("findings")
+            .expect("target")
+            .content
+            .is_empty(),
+        "neither the full nor the truncated form was stored"
     );
 }
 

--- a/crates/leviath-runtime/src/pipeline/tool_results.rs
+++ b/crates/leviath-runtime/src/pipeline/tool_results.rs
@@ -12,7 +12,7 @@ pub(crate) struct ToolResults(pub UnboundedReceiver<ToolOutcome>);
 /// output went, and the pointer is only worth anything if it is true: the
 /// region may have been too full to take the result whole, in which case
 /// "stored in region X" is a claim about tokens that are not there.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum Stored {
     /// The result went in as written.
     Whole,
@@ -20,6 +20,9 @@ enum Stored {
     Truncated { omitted: usize },
     /// The region refused even a truncated entry; only a marker is there.
     Dropped,
+    /// The region's `on_write` hook rejected the write for this reason;
+    /// nothing was stored.
+    Rejected(String),
 }
 
 /// Tools whose first argument is a path into the workspace, and which therefore
@@ -235,21 +238,31 @@ pub(crate) fn apply_one_tool_result(
     // Add `content` (with entry `kind`) to `region`, honoring taint and falling
     // back to a truncated (then omitted) entry if the region is full.
     //
-    // Reports which of the three happened, because the pointer left in the
+    // Reports which of the four happened, because the pointer left in the
     // conversation describes this write: it must not promise the full result
-    // when the region kept less than that.
+    // when the region kept less than that - or nothing at all.
+    //
+    // `origin` is per write: the routed store is the model's own output
+    // landing where the stage routed it (Agent, so a custom region's
+    // refusal comes back with its reason), while the conversation entries
+    // (the tool_result pairing and the pointer) are framework records a
+    // script must not be able to delete (System).
     let add_kind = |window: &mut ContextWindow,
                     region: &str,
                     kind: leviath_core::EntryKind,
                     content: String,
-                    tokens: usize|
+                    tokens: usize,
+                    origin: crate::components::WriteOrigin|
      -> Stored {
-        let put = |w: &mut ContextWindow, c: String, t: usize| match taint_level {
-            Some(level) => w.add_typed_tainted_to_region(region, kind.clone(), c, t, level),
-            None => w.add_typed_entry(region, kind.clone(), c, t),
+        let put = |w: &mut ContextWindow, c: String, t: usize| {
+            w.typed_write(origin, region, kind.clone(), c, t, taint_level)
         };
-        if put(window, content.clone(), tokens).is_ok() {
-            return Stored::Whole;
+        match put(window, content.clone(), tokens) {
+            Ok(()) => return Stored::Whole,
+            Err(leviath_core::Error::RegionRefusedWrite { reason, .. }) => {
+                return Stored::Rejected(reason);
+            }
+            Err(_) => {}
         }
         let available = window
             .get_region(region)
@@ -270,8 +283,14 @@ pub(crate) fn apply_one_tool_result(
             )
         };
         let trunc_tokens = leviath_core::estimate_tokens(&truncated);
-        if put(window, truncated, trunc_tokens).is_ok() {
-            return Stored::Truncated { omitted };
+        match put(window, truncated, trunc_tokens) {
+            Ok(()) => return Stored::Truncated { omitted },
+            // The hook re-ran over the truncated text and refused that shape:
+            // still a rejection, not a budget problem.
+            Err(leviath_core::Error::RegionRefusedWrite { reason, .. }) => {
+                return Stored::Rejected(reason);
+            }
+            Err(_) => {}
         }
         let _ = put(window, "[result omitted]".to_string(), 5);
         Stored::Dropped
@@ -284,13 +303,15 @@ pub(crate) fn apply_one_tool_result(
 
     if target_region == "conversation" {
         // Not routed (or routed back to the message stream): the tool_result
-        // lives in `conversation`, paired with its tool_use.
+        // lives in `conversation`, paired with its tool_use. System origin -
+        // the pairing is required by the provider, so a script cannot refuse it.
         add_kind(
             window,
             "conversation",
             result_kind(),
             result_text,
             result_tokens,
+            crate::components::WriteOrigin::System,
         );
     } else {
         // Routed to a knowledge region. Anthropic requires each tool_result to sit
@@ -318,6 +339,7 @@ pub(crate) fn apply_one_tool_result(
             leviath_core::EntryKind::Text,
             result_text,
             result_tokens,
+            crate::components::WriteOrigin::Agent,
         );
         // What this text asks the model to do is the whole point of it.
         //
@@ -350,6 +372,9 @@ pub(crate) fn apply_one_tool_result(
             (false, Stored::Dropped) => format!(
                 "[output could NOT be stored - context region '{target_region}' is full and refused it, so only this preview survives. Release what you are finished with (context_delete) and fetch it again if you still need it. Preview: {preview}{ellipsis}]"
             ),
+            (false, Stored::Rejected(reason)) => format!(
+                "[output was refused by context region '{target_region}': {reason}. Nothing was stored there; only this preview survives. Preview: {preview}{ellipsis}]"
+            ),
         };
         let pointer_tokens = leviath_core::estimate_tokens(&pointer);
         add_kind(
@@ -358,6 +383,7 @@ pub(crate) fn apply_one_tool_result(
             result_kind(),
             pointer,
             pointer_tokens,
+            crate::components::WriteOrigin::System,
         );
     }
 }

--- a/crates/leviath-scripting/src/region_hook.rs
+++ b/crates/leviath-scripting/src/region_hook.rs
@@ -9,7 +9,12 @@
 //!   assembled context. Returns a string (one system block) or a map
 //!   `#{ system: ..., messages: [...] }`.
 //! - `on_write(ctx)` - optional. Sees each incoming entry; returns a string
-//!   (replace the content), `true`/`()` (accept unchanged), or `false` (drop).
+//!   (replace the content), `true`/`()` (accept unchanged), `false` (reject),
+//!   `#{ action: "reject", reason: "..." }` (reject with a reason), or
+//!   `#{ content: "...", key: "..." }` (accept with an optional content
+//!   replacement and/or key override) - the same map vocabulary the stage
+//!   hooks use. What a rejection does depends on the write's origin; the
+//!   runtime decides that.
 //! - `on_overflow(ctx)` - optional. Chooses what to evict under budget
 //!   pressure; returns an array of entry indices to drop.
 //!
@@ -355,6 +360,29 @@ mod tests {
             let out = run_on_write(&s, json!({"entry": {"content": "x"}})).unwrap();
             assert_eq!(out, expected, "body: {body}");
         }
+    }
+
+    #[test]
+    fn on_write_returns_maps_as_plain_objects() {
+        // The reject/accept maps cross the JSON boundary untouched; their
+        // interpretation is the runtime's job.
+        let src = r#"
+            fn render(ctx) { "" }
+            fn on_write(ctx) {
+                if ctx.entry.key == () {
+                    #{ action: "reject", reason: "keyless" }
+                } else {
+                    #{ content: "tidied", key: ctx.entry.key }
+                }
+            }
+        "#;
+        let s = compile("w.rhai", src).unwrap();
+        let rejected =
+            run_on_write(&s, json!({ "entry": { "content": "x", "key": null } })).unwrap();
+        assert_eq!(rejected, json!({ "action": "reject", "reason": "keyless" }));
+        let accepted =
+            run_on_write(&s, json!({ "entry": { "content": "x", "key": "k1" } })).unwrap();
+        assert_eq!(accepted, json!({ "content": "tidied", "key": "k1" }));
     }
 
     #[test]

--- a/docs/content/rhai-regions.md
+++ b/docs/content/rhai-regions.md
@@ -19,6 +19,7 @@ questions, and nothing else changes:
 ```mermaid
 flowchart LR
   W["The agent writes<br/>something to the region"] -->|"on_write(ctx)"| STORE["Stored"]
+  W -.->|"rejected"| R["Refused, and the<br/>writer is told why"]
   STORE -->|"render(ctx)"| M["What the model sees"]
   STORE -->|"on_overflow(ctx)<br/>when over budget"| DROP["What gets dropped"]
 ```
@@ -26,7 +27,7 @@ flowchart LR
 | Hook | Answers |
 |---|---|
 | `render` | What does this region look like in the model's context? |
-| `on_write` | What happens to each incoming entry? |
+| `on_write` | What happens to each incoming entry: keep it, reshape it, or refuse it? |
 | `on_overflow` | What goes when the region is over budget? |
 
 Only `render` is required.
@@ -99,8 +100,33 @@ the conversation always ends the request. Declaring a region after the conversat
 trailing reminder does not work; use a [nudge](/docs/stages) for that.
 
 `on_write(ctx)` is **optional**. It sees each entry headed into the region, with
-`ctx = { region, entry: { content, kind, tokens } }`. Return a string to replace the content (tokens
-re-estimated, kind preserved), `true` or `()` to accept unchanged, or `false` to drop the entry.
+`ctx = { region, entry: { content, kind, tokens, key } }` (`key` is `()` unless the write named
+one). Return:
+
+| Return | Meaning |
+|---|---|
+| a string | Accept, replacing the content (tokens re-estimated, kind preserved) |
+| `true` or `()` | Accept unchanged |
+| `false` | Reject, with no reason given |
+| `#{ action: "reject", reason: "..." }` | Reject, and tell the writer why |
+| `#{ content: "...", key: "..." }` | Accept; both fields optional (`action: "accept"` implied). `content` replaces the text, `key` stores the entry under a different key than the write named |
+
+The map forms use the same vocabulary as [stage hooks](/docs/rhai-hooks), on purpose.
+
+What a rejection does depends on who is writing. When the model writes through `context_write` or
+`context_append`, or a tool result is routed into the region, the tool result reports the refusal
+and its reason instead of claiming success, and nothing is stored. When the framework writes (an
+assistant turn, a delivered message, a system nudge), the entry is stored unchanged and a warning
+is logged: a script cannot delete the conversation record.
+
+### Keyed writes render as an upsert
+
+When several stored entries share a key, `render` sees only the newest one for that key; unkeyed
+entries always appear, in order. Combined with `context_write`'s `key` argument (or a `key`
+override from `on_write`), repeated writes to one key give the model an upserted view without any
+hashmap plumbing in your script. The shadowed entries stay in the store, though: they keep holding
+budget until `on_overflow` or `context_delete` removes them, and `on_overflow` always sees the
+whole unfiltered store so its indices stay honest.
 
 `on_overflow(ctx)` is **optional**. It runs when the region must shrink, with
 `ctx = { region, entries, needed_tokens }`. Return an array of entry indices to drop. If the hook is
@@ -153,7 +179,9 @@ Load-time problems fail fast. Runtime problems never break an inference:
 |---|---|
 | Script missing, does not compile, or has no `fn render(ctx)` | **Hard spawn error**, also caught by `lev validate` |
 | `render` errors or returns an invalid shape | Warning, and the region renders as a plain `[name]:` block |
-| `on_write` errors or returns an invalid type | Warning, and the entry is accepted unchanged |
+| `on_write` errors, or returns an invalid type or a malformed map | Warning, and the entry is accepted unchanged. A typo'd map must not read as a different instruction |
+| `on_write` rejects an agent write | The tool result carries the refusal and the reason; nothing is stored |
+| `on_write` rejects a framework write | Warning, and the entry is stored unchanged. Earlier releases treated `false` as a silent drop that still reported success; that no longer happens |
 | `on_overflow` errors or returns invalid indices | Warning, and oldest-first eviction runs |
 | Rendered output exceeds the region's budget | Warning only, and it is sent anyway. The [context-window guard](/docs/context#requests-are-measured-before-they-are-sent) refuses it only if the whole request would overflow the model |
 
@@ -171,8 +199,10 @@ The point of the escape hatch is that you could write the built-ins yourself, an
   typed messages. Exact, and the reason typed message emission exists.
 - **compacting**: approximable with deterministic condensing in `on_overflow`. The LLM
   summarization lane is not script-accessible.
-- **hashmap**: not recreatable. Keyed upsert is built-in only, because `on_write` cannot modify an
-  existing entry.
+- **hashmap**: close. Keyed writes plus last-wins rendering give the model the same upserted view,
+  and `on_write` can normalize keys on the way in. The difference is in the store: a real `hashmap`
+  region replaces the old entry and frees its tokens immediately, while a custom region only
+  shadows it at render time until eviction or an explicit release catches up.
 
 ## Previewing
 
@@ -188,5 +218,8 @@ parses and defines `render`.
   cannot override it per call.
 - Reordering or reshaping content between inferences can cost you provider prompt-cache hits. The
   script owns that tradeoff.
+- Entries shadowed by a newer write to the same key still hold their tokens until eviction or an
+  explicit `context_delete` releases them. A region rewritten under one key every turn should pair
+  the pattern with an `on_overflow` that drops the shadowed copies first.
 
 See [Context](/docs/context) for how regions, budgets, and cache hints fit together.


### PR DESCRIPTION
## The two defects (both verified against the old code)

1. **A drop was reported as success.** `on_write` could answer only replace-string / accept / drop, and a drop lied to the writer: `context_write` and `context_append` reported `Stored in '<region>' section.` for content the script had discarded, and a routed tool result returned `Stored::Whole`, so the conversation pointer told the model its output was "already in this prompt" when the region held nothing. Fail-first evidence: the new regression `a_hook_rejection_reaches_the_context_write_result` was run against unfixed code first and failed with exactly `a refused write must not report success: Stored in 'brain' section.` (its two siblings failed the same way, one with `Appended to 'brain' section.`).
2. **No upsert story.** The hook never saw the entry's `key`, custom regions appended duplicates under a repeated key, and nothing deduped at render.

## The new on_write vocabulary (back-compat preserved)

| Return | Meaning |
|---|---|
| a string | Accept, replacing the content (tokens re-estimated, kind preserved) |
| `true` / `()` | Accept unchanged |
| `false` | Reject, no reason given |
| `#{ action: "reject", reason: "..." }` | Reject with that reason |
| `#{ content: "...", key: "..." }` | Accept; both fields optional (`action: "accept"` implied). `content` replaces the text, `key` overrides the stored key |
| anything else, malformed maps, script errors | Warn and accept unchanged, exactly as before |

The map forms deliberately mirror the stage-hook vocabulary. `ctx.entry` now also carries `key` (unit when the write named none).

## The origin rule

A rejection may only refuse a write that has somewhere to send the reason:

- **Agent-origin** (the model's own actions: `context_write`, `context_append`, and the routed tool-result store): a rejection becomes a real error (`Error::RegionRefusedWrite`) carrying the reason. The `context_*` tool result reports it verbatim, and the tool-result pointer gains a `Stored::Rejected(reason)` arm that says the output was refused and why, never promising content the region does not hold. `context_write`'s non-hashmap arm now runs the hook **before** clearing, so a refused replacement leaves the region as it was.
- **System-origin** (everything else: assistant turns, delivered messages, nudges, stage seeds, transforms, interaction answers, the final-output mirror, watchdog/convergence/compaction notes): a rejection is downgraded to store-unchanged plus a `tracing::warn!`. A script can no longer silently delete an assistant turn or a system record.

### Behavior change, called out explicitly

`false` from an `on_write` hook **changed meaning**. Before: silent drop, reported as success, on every path. Now: an agent write gets an honest error, and a framework write is stored unchanged with a warning. Any script that relied on `false` to filter framework writes (e.g. dropping assistant turns from a custom region) will now see those entries stored; the filtering belongs in `render`/`on_overflow` instead.

### Write call-site classification (every caller of the five window write methods)

- Agent: `context_tools.rs` `context_write` (via new `agent_replace_region`) and `context_append` (via `add_to_region_keyed(WriteOrigin::Agent, ...)`); `pipeline/tool_results.rs` routed knowledge-region store (via `typed_write(WriteOrigin::Agent, ...)`).
- System (all remaining callers, enumerated): tool_results' conversation tool_result and pointer writes plus the assistant-turn record and repetition nudges; `pipeline/response.rs` (text replies, nudges); `pipeline/messaging.rs` (delivered messages); `pipeline/transition_choice.rs`; `pipeline/watchdog.rs`; `pipeline/convergence.rs`; `pipeline/compaction.rs`; `pipeline/transition.rs`; `output_tool.rs` (final-output mirror); `interaction_points.rs` (answers, records); `context_setup.rs` (stage seeds/instructions); `context_transform.rs`; `stage_seeds.rs`; `restore.rs`; `fanout/*`; `runtime_info_tool.rs`; CLI `policy.rs`. The seam's default is System, so any future path is safe until deliberately classified.

## Dedupe-by-key at render (the upsert story)

`render` and the no-script/failed-hook fallback block now see a last-wins-per-key view: only the newest entry under each key renders; unkeyed entries always survive in order. With keyed `context_write` calls (or a `key` override from the hook) this gives the model an upserted view without hashmap plumbing. The **store still appends**: shadowed entries hold their tokens until `on_overflow` or `context_delete` removes them (documented, with a Known-limits note), and the `on_overflow` ctx is deliberately **not** deduped so its indices keep addressing the unfiltered store.

## Tests

- Fail-first regressions: rejection reaches the `context_write`/`context_append` result with the reason verbatim; a rejected `context_write` leaves existing content; key override names the stored entry.
- The two tests that encoded the bug (`custom_region_on_write_drop_reports_success_without_storing` and its typed/tainted sibling) are inverted into the new contract: system writes cannot be dropped, agent writes error with the reason.
- New coverage: map forms (reject with/without reason, content+key, each field optional, malformed maps accept unchanged), ctx `key` visibility, render dedupe, fallback dedupe, on_overflow over the unfiltered store, routed-rejection pointer text, hook refusing the truncated fallback, replace_region key override, throw/invalid still accept unchanged.

## Gates

- `cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo xtask structure`: 451 files, none over the limit
- `cargo xtask docs`: 40 pages, no problems
- `cargo xtask coverage` at 100% for leviath-core, leviath-scripting, leviath-runtime (each after `rm -rf target/llvm-cov-target`, run serially)
- Full suite via pre-commit: 1718 runtime lib tests plus the rest, all green
