### PR TITLE
fix(outputs): warn when a format override retires declared checks

### DIFF
--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -98,8 +98,10 @@ pub struct RunArgs {
     /// the label and any instructions are handed to the model, which produces
     /// the bytes. Read the answer back with `lev result <run-id>`.
     ///
-    /// Naming a format without `--output-schema` drops a schema the blueprint
-    /// declared, since a check written for one shape says nothing about another.
+    /// Naming a format the blueprint does not declare retires any Rhai
+    /// validator and JSON schema it declared, since a check written for one
+    /// shape says nothing about another; a warning names what was retired.
+    /// Pass `--output-schema` when the new shape should still be checked.
     #[arg(long, value_name = "LABEL")]
     pub output_format: Option<String>,
 

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -44,6 +44,30 @@ fn output_request(body: &SpawnAgentReq) -> Option<leviath_core::output::OutputSp
     })
 }
 
+/// What this spawn should tell its caller alongside the run id: today, the
+/// declared shape checks the request's `output_format` retires.
+///
+/// The daemon logs the same retirement at spawn, but into its own log, which
+/// the API caller never reads; the check they may be counting on deserves a
+/// line in the response they do. Best-effort on purpose: a manifest that will
+/// not read or parse is the daemon's to report as the spawn error, and this
+/// must never be why one fails.
+fn spawn_warnings(
+    manifest_path: &std::path::Path,
+    request: Option<&leviath_core::output::OutputSpec>,
+) -> Vec<String> {
+    if request.is_none() {
+        return Vec::new();
+    }
+    let Ok(content) = std::fs::read_to_string(manifest_path) else {
+        return Vec::new();
+    };
+    let Ok(blueprint) = leviath_core::manifest::parse_manifest(&content) else {
+        return Vec::new();
+    };
+    leviath_core::output::retired_check_warnings(&blueprint, request)
+}
+
 pub(super) async fn spawn_agent(
     State(state): State<AppState>,
     Json(body): Json<SpawnAgentReq>,
@@ -109,6 +133,7 @@ pub(super) async fn spawn_agent(
         // Serve spawns are top-level runs.
         parent_run_id: None,
     };
+    let warnings = spawn_warnings(&manifest_path, args.output.as_ref());
 
     match state.control.spawn(args).await {
         Ok(ControlResponse::Spawned { run_id }) => {
@@ -120,6 +145,7 @@ pub(super) async fn spawn_agent(
             Ok(Json(SpawnAgentResp {
                 agent_id: run_id.clone(),
                 run_id,
+                warnings,
             }))
         }
         Ok(ControlResponse::Error { message }) => Err(err(
@@ -1254,6 +1280,128 @@ system_prompt = "Plan the work"
         );
         assert!(seen(true, PLAIN).await, "the flag opts out for the caller");
         assert!(seen(true, OPTED_OUT).await, "both is still out");
+    }
+
+    /// A router over `POST /api/agents` whose one blueprint, "checked",
+    /// declares an output format with a Rhai validator, plus the fake daemon
+    /// answering it. For the retirement-warning tests below.
+    fn checked_spawn_app() -> (
+        Router,
+        tempfile::TempDir,
+        tempfile::TempDir,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (control, dir, srv) = fake_daemon(|_| ControlResponse::Spawned {
+            run_id: "run-1".to_string(),
+        });
+        let agents = tempfile::tempdir().unwrap();
+        let bp = agents.path().join("checked");
+        std::fs::create_dir_all(&bp).unwrap();
+        std::fs::write(
+            bp.join("agent.leviath"),
+            r#"
+[agent]
+name = "checked"
+version = "1.0.0"
+description = "declares a validator"
+
+[agent.output]
+format = "markdown"
+validator = "checks/report.rhai"
+
+[stages.plan]
+system_prompt = "Plan the work"
+"#,
+        )
+        .unwrap();
+        let state = test_state_with_agent_paths(vec![agents.path().to_path_buf()], control);
+        let app = Router::new()
+            .route("/api/agents", axum::routing::post(spawn_agent))
+            .with_state(state);
+        (app, agents, dir, srv)
+    }
+
+    /// POST a spawn and return the response body as JSON (asserting 200).
+    async fn post_spawn_json(app: Router, body: &str) -> serde_json::Value {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/agents")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// The headline: a spawn whose `output_format` differs from the declared
+    /// one retires the blueprint's Rhai validator, and the response now says
+    /// so instead of leaving the caller to believe the check still runs.
+    #[tokio::test]
+    async fn spawn_with_a_differing_format_reports_the_retired_checks() {
+        let (app, _agents, _dir, _srv) = checked_spawn_app();
+        let body = post_spawn_json(
+            app,
+            r#"{"blueprint":"checked","task":"t","workdir":"/tmp","output_format":"json"}"#,
+        )
+        .await;
+        let warnings = body["warnings"].as_array().cloned().unwrap_or_default();
+        assert!(
+            !warnings.is_empty(),
+            "the response carries warnings: {body}"
+        );
+        let joined = warnings
+            .iter()
+            .filter_map(|w| w.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(joined.contains("checks/report.rhai"), "{joined}");
+        assert!(joined.contains("'plan'"), "{joined}");
+        assert!(joined.contains("'json'"), "{joined}");
+    }
+
+    /// Re-stating the format the blueprint already declares retires nothing
+    /// (the checks keep running), so there is nothing to warn about.
+    #[tokio::test]
+    async fn spawn_restating_the_declared_format_warns_about_nothing() {
+        let (app, _agents, _dir, _srv) = checked_spawn_app();
+        let body = post_spawn_json(
+            app,
+            r#"{"blueprint":"checked","task":"t","workdir":"/tmp","output_format":"markdown"}"#,
+        )
+        .await;
+        assert!(body.get("warnings").is_none(), "{body}");
+    }
+
+    /// The lenient arms: a manifest that is not there or will not parse stays
+    /// quiet here, because the spawn itself is where that failure is reported.
+    #[test]
+    fn spawn_warnings_give_up_quietly_on_a_bad_manifest() {
+        let request = Some(leviath_core::output::OutputSpec {
+            format: Some("json".to_string()),
+            ..leviath_core::output::OutputSpec::default()
+        });
+        let dir = tempfile::tempdir().unwrap();
+        assert!(spawn_warnings(&dir.path().join("nope.leviath"), request.as_ref()).is_empty());
+        let unparseable = dir.path().join("agent.leviath");
+        std::fs::write(&unparseable, "not valid toml [[[").unwrap();
+        assert!(spawn_warnings(&unparseable, request.as_ref()).is_empty());
+    }
+
+    /// No format request, no retirement: the response stays exactly what
+    /// existing clients parse.
+    #[tokio::test]
+    async fn spawn_without_a_format_request_warns_about_nothing() {
+        let (app, _agents, _dir, _srv) = checked_spawn_app();
+        let body = post_spawn_json(
+            app,
+            r#"{"blueprint":"checked","task":"t","workdir":"/tmp"}"#,
+        )
+        .await;
+        assert!(body.get("warnings").is_none(), "{body}");
     }
 
     #[tokio::test]
@@ -3213,10 +3361,20 @@ system_prompt = "Plan the work"
         let resp = SpawnAgentResp {
             agent_id: "coder".to_string(),
             run_id: "run-abc-123".to_string(),
+            warnings: Vec::new(),
         };
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("\"agent_id\":\"coder\""));
         assert!(json.contains("\"run_id\":\"run-abc-123\""));
+        // Nothing to say stays absent, so existing clients parse what they
+        // always did; something to say serializes as a plain string array.
+        assert!(!json.contains("warnings"));
+        let resp = SpawnAgentResp {
+            warnings: vec!["the validator is retired".to_string()],
+            ..resp
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"warnings\":[\"the validator is retired\"]"));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -656,8 +656,11 @@ pub(super) struct SpawnAgentReq {
     /// inspects the answer's contents, and only because you asked: a submission
     /// that fails is refused back to the agent to correct.
     ///
-    /// Naming `output_format` without this drops a schema the blueprint
-    /// declared, since a check written for one shape says nothing about another.
+    /// An `output_format` that differs from the blueprint's retires any Rhai
+    /// validator and JSON schema the blueprint declared, since a check written
+    /// for one shape says nothing about another; the response's `warnings`
+    /// names what was retired. Supply this field when the new shape should
+    /// still be checked.
     pub(super) output_schema: Option<serde_json::Value>,
 }
 
@@ -699,6 +702,12 @@ impl From<leviath_core::output::FinalOutput> for FinalOutputResp {
 pub(super) struct SpawnAgentResp {
     pub(super) agent_id: String,
     pub(super) run_id: String,
+    /// Things the caller should know about how this run will differ from what
+    /// its blueprint declares: today, the Rhai validator or JSON schema that a
+    /// differing `output_format` retired. Omitted when there is nothing to
+    /// say, so existing clients see the exact response they always did.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) warnings: Vec<String>,
 }
 
 #[derive(Deserialize)]

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -339,6 +339,37 @@ fn held_checkpoint_warning_for_spawn(spawn_args: &SpawnArgs) -> Vec<String> {
     lines
 }
 
+/// Say, before the run starts, that `--output-format` retires the declared
+/// shape checks.
+///
+/// Overriding the format retires any Rhai validator and JSON schema the
+/// blueprint declared, because a check written for one shape cannot judge
+/// another. That is deliberate and stays; what cannot stay is the silence. The
+/// daemon logs the retirement at spawn, but into `daemon.log`, and the person
+/// who typed the override is the one counting on a check that will not run.
+fn warn_retired_output_checks(spawn_args: &SpawnArgs) {
+    for line in retired_check_warning_for_spawn(spawn_args) {
+        eprintln!("warning: {line}");
+    }
+}
+
+/// The retirement warning for a spawn request, read from the real manifest.
+/// Empty when nothing is retired, and empty when the manifest cannot be read
+/// or parsed: best-effort for the same reason as
+/// [`warn_ungranted_read_paths`].
+fn retired_check_warning_for_spawn(spawn_args: &SpawnArgs) -> Vec<String> {
+    if spawn_args.output.is_none() {
+        return Vec::new();
+    }
+    let Ok(content) = std::fs::read_to_string(&spawn_args.blueprint_path) else {
+        return Vec::new();
+    };
+    let Ok(blueprint) = leviath_core::manifest::parse_manifest(&content) else {
+        return Vec::new();
+    };
+    leviath_core::output::retired_check_warnings(&blueprint, spawn_args.output.as_ref())
+}
+
 /// What `lev run --json` prints on a successful spawn.
 ///
 /// `lev run` hands the agent to the daemon and returns, so the run id is the
@@ -410,6 +441,7 @@ pub(crate) async fn send_spawn(
     warn_broken_config();
     warn_ungranted_read_paths(&spawn_args);
     warn_held_checkpoints(&spawn_args);
+    warn_retired_output_checks(&spawn_args);
     let spawned = spawn_once(client, spawn_args).await?;
     println!("{}", spawn_report(&spawned, json));
     Ok(())
@@ -444,6 +476,7 @@ pub async fn send_spawn_batch(
     warn_broken_config();
     warn_ungranted_read_paths(&spawn_args);
     warn_held_checkpoints(&spawn_args);
+    warn_retired_output_checks(&spawn_args);
     let mut spawned = Vec::with_capacity(count);
     for _ in 0..count {
         let mut args = spawn_args.clone();
@@ -1487,6 +1520,108 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
             assert!(joined.contains("plan_approval"), "{joined}");
             assert!(joined.contains("until somebody answers"), "{joined}");
         });
+    }
+
+    /// A manifest declaring a Rhai validator for its output, written to disk,
+    /// so the retirement warning is exercised through the real read-and-parse
+    /// path.
+    fn manifest_with_a_validator(dir: &std::path::Path) -> String {
+        let manifest = dir.join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            r#"
+[agent]
+name = "checked"
+version = "0.1.0"
+description = "declares a validator"
+
+[agent.output]
+format = "markdown"
+validator = "checks/report.rhai"
+
+[stages.plan]
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+"#,
+        )
+        .unwrap();
+        manifest.to_string_lossy().into_owned()
+    }
+
+    /// A request whose only content is a format label, the shape every
+    /// `--output-format` flag arrives in.
+    fn format_request(label: &str) -> Option<leviath_core::output::OutputSpec> {
+        Some(leviath_core::output::OutputSpec {
+            format: Some(label.to_string()),
+            ..leviath_core::output::OutputSpec::default()
+        })
+    }
+
+    /// `--output-format` over a blueprint with a validator retires the check,
+    /// and stderr now says so before the run starts; re-stating the declared
+    /// format retires nothing and stays quiet, as does no override at all.
+    #[test]
+    fn an_output_format_override_announces_the_retired_checks() {
+        let dir = tempfile::tempdir().unwrap();
+        let blueprint_path = manifest_with_a_validator(dir.path());
+        let args = SpawnArgs {
+            blueprint_path: blueprint_path.clone(),
+            output: format_request("json"),
+            ..SpawnArgs::default()
+        };
+        let joined = retired_check_warning_for_spawn(&args).join("\n");
+        assert!(joined.contains("checks/report.rhai"), "{joined}");
+        assert!(joined.contains("stage 'plan'"), "{joined}");
+        assert!(joined.contains("'json'"), "{joined}");
+        warn_retired_output_checks(&args);
+
+        assert!(
+            retired_check_warning_for_spawn(&SpawnArgs {
+                blueprint_path: blueprint_path.clone(),
+                output: format_request("markdown"),
+                ..SpawnArgs::default()
+            })
+            .is_empty(),
+            "re-stating the declared format keeps the checks"
+        );
+        assert!(
+            retired_check_warning_for_spawn(&SpawnArgs {
+                blueprint_path,
+                output: None,
+                ..SpawnArgs::default()
+            })
+            .is_empty(),
+            "no override, nothing retired"
+        );
+    }
+
+    /// The same lenient arms as every warning on this path: a manifest that is
+    /// not there or will not parse must stay quiet, never stop a spawn.
+    #[test]
+    fn the_retirement_warning_gives_up_quietly() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            retired_check_warning_for_spawn(&SpawnArgs {
+                blueprint_path: dir
+                    .path()
+                    .join("nope.leviath")
+                    .to_string_lossy()
+                    .into_owned(),
+                output: format_request("json"),
+                ..SpawnArgs::default()
+            })
+            .is_empty()
+        );
+
+        let unparseable = dir.path().join("agent.leviath");
+        std::fs::write(&unparseable, "not valid toml [[[").unwrap();
+        assert!(
+            retired_check_warning_for_spawn(&SpawnArgs {
+                blueprint_path: unparseable.to_string_lossy().into_owned(),
+                output: format_request("json"),
+                ..SpawnArgs::default()
+            })
+            .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -441,6 +441,22 @@ fn log_blueprint_lint(content: &str, blueprint: &Blueprint, manifest_path: &str)
     }
 }
 
+/// Log the declared shape checks a caller's output-format override retires.
+///
+/// The CLI and the REST server also tell their own callers, but sub-agent and
+/// ACP spawns have no warning channel of their own, so this line in the daemon
+/// log is the one place the retirement is guaranteed to be recorded. Named
+/// rather than inlined so a test can drive the warning path directly.
+fn warn_retired_output_checks(
+    run_id: &str,
+    blueprint: &Blueprint,
+    request: Option<&leviath_core::output::OutputSpec>,
+) {
+    for line in leviath_core::output::retired_check_warnings(blueprint, request) {
+        tracing::warn!(run_id = %run_id, agent_name = %blueprint.name, "{line}");
+    }
+}
+
 fn build_agent_inner(
     world: &mut World,
     deps: SpawnDeps<'_>,
@@ -796,6 +812,12 @@ fn build_agent_inner(
     let region_scripts = resolve_region_scripts(&blueprint, &args.blueprint_path)?;
     let stage_hooks = resolve_stage_hook_scripts(&blueprint, &args.blueprint_path)?;
     let output_validators = resolve_output_validators(&blueprint, &args.blueprint_path)?;
+
+    // A requested output format that differs from the declared one retires the
+    // blueprint's validator and schema for the reshaped stages (see
+    // `resolve_output_spec`). Deliberate, but no longer silent: every spawn
+    // path funnels through here, so the daemon log always says what was lost.
+    warn_retired_output_checks(&args.run_id, &blueprint, args.output.as_ref());
 
     // Whether any stage can produce a file change the framework would see -
     // asked here, while the blueprint is still in hand, because it cannot
@@ -1285,6 +1307,29 @@ system = { kind = "pinned", max_tokens = 1000 }
         bp.output = agent_script.map(spec);
         bp.stages[0].output = stage_script.map(spec);
         bp
+    }
+
+    /// The daemon-log lines for a format override that retires a declared
+    /// validator. The wording lives in `leviath_core::output` and is tested
+    /// there; this drives the logging path every spawn walks through, both
+    /// when it has something to say and when it has nothing.
+    #[test]
+    fn warn_retired_output_checks_logs_the_retirement() {
+        // Under a real subscriber, so the macro's field expressions run.
+        crate::test_support::with_tracing(|| {
+            let bp = validator_blueprint(Some("validators/shape.rhai"), None);
+            let request = leviath_core::output::OutputSpec {
+                format: Some("json".to_string()),
+                ..leviath_core::output::OutputSpec::default()
+            };
+            assert_eq!(
+                leviath_core::output::retired_check_warnings(&bp, Some(&request)).len(),
+                1,
+                "the fixture needs a retirement for the log line to run"
+            );
+            warn_retired_output_checks("run-1", &bp, Some(&request));
+            warn_retired_output_checks("run-1", &bp, None);
+        });
     }
 
     /// Compiled at spawn, so a broken validator stops the run before any tokens

--- a/crates/leviath-core/src/output.rs
+++ b/crates/leviath-core/src/output.rs
@@ -284,6 +284,147 @@ pub fn resolve_output_spec(
     })
 }
 
+/// The warnings a caller's requested output shape earns at spawn: what
+/// [`resolve_output_spec`] will retire, said out loud before it happens.
+///
+/// Retiring the declared Rhai validator and JSON schema when the request names
+/// a different format is deliberate and stays: a check written for one shape
+/// cannot judge another. What this adds is the saying-so. Before it, the
+/// retirement was completely silent, so a caller who typed
+/// `--output-format json` over a blueprint with a validator kept believing the
+/// run was still being checked.
+///
+/// One line per group of stages losing the same checks, so an agent-level
+/// validator shared by four stages reads as one sentence naming four stages.
+/// Empty when there is nothing to say: no request, no format in it, the
+/// declared format re-stated (which retires nothing), or nothing declared that
+/// could be retired. A declared schema the request *replaces* with its own is
+/// also not warned about: supplying a schema for the new shape is exactly what
+/// the warning would have asked for. A declared validator is always worth the
+/// line, because no request can bring a replacement for it.
+pub fn retired_check_warnings(
+    blueprint: &crate::Blueprint,
+    request: Option<&OutputSpec>,
+) -> Vec<String> {
+    let Some(requested) = request.and_then(|r| r.format.as_deref()) else {
+        return Vec::new();
+    };
+    let request_has_schema = request.is_some_and(|r| r.schema.is_some());
+    let mut groups: Vec<(RetiredChecks, Vec<String>)> = Vec::new();
+    for stage in &blueprint.stages {
+        let Some(retired) = retired_checks_for_stage(
+            blueprint.output.as_ref(),
+            stage.output.as_ref(),
+            requested,
+            request_has_schema,
+        ) else {
+            continue;
+        };
+        match groups.iter_mut().find(|(g, _)| *g == retired) {
+            Some((_, stages)) => stages.push(stage.name.clone()),
+            None => groups.push((retired, vec![stage.name.clone()])),
+        }
+    }
+    groups
+        .iter()
+        .map(|(checks, stages)| checks.warning_line(requested, stages, request_has_schema))
+        .collect()
+}
+
+/// The declared checks one stage loses to a format override. Two stages with
+/// equal values lose the same thing and share one warning line.
+#[derive(PartialEq, Eq)]
+struct RetiredChecks {
+    /// The format the retired checks were written for, when one was declared.
+    declared_format: Option<String>,
+    /// The retired Rhai validator's path, when one was declared.
+    validator: Option<String>,
+    /// Whether a declared JSON schema is retired with nothing in its place.
+    schema: bool,
+}
+
+/// What `requested` retires for one stage, or `None` when it retires nothing.
+///
+/// Asks [`resolve_output_spec`]'s question ahead of time, with the same
+/// cascade: the stage's declaration wins over the agent's, and re-stating the
+/// declared format keeps every check. Kept beside it so the two cannot drift.
+fn retired_checks_for_stage(
+    agent: Option<&OutputSpec>,
+    stage: Option<&OutputSpec>,
+    requested: &str,
+    request_has_schema: bool,
+) -> Option<RetiredChecks> {
+    let declared =
+        |get: fn(&OutputSpec) -> Option<&str>| stage.and_then(get).or_else(|| agent.and_then(get));
+    let declared_format = declared(|s| s.format.as_deref());
+    if declared_format == Some(requested) {
+        return None;
+    }
+    let validator = declared(|s| s.validator.as_deref());
+    let schema = !request_has_schema
+        && stage
+            .and_then(|s| s.schema.as_ref())
+            .or_else(|| agent.and_then(|a| a.schema.as_ref()))
+            .is_some();
+    if validator.is_none() && !schema {
+        return None;
+    }
+    Some(RetiredChecks {
+        declared_format: declared_format.map(str::to_string),
+        validator: validator.map(str::to_string),
+        schema,
+    })
+}
+
+impl RetiredChecks {
+    /// The warning itself, worded for a person on any spawn path: what was
+    /// requested, what it retires, and how to get the new shape checked. The
+    /// closing advice depends on the request: a caller who already brought a
+    /// schema for the new shape has nothing further to supply.
+    fn warning_line(&self, requested: &str, stages: &[String], request_has_schema: bool) -> String {
+        let cause = match &self.declared_format {
+            Some(declared) => format!(
+                "requested output format '{requested}' differs from the declared '{declared}'"
+            ),
+            None => format!(
+                "requested output format '{requested}' reshapes an output declared without a \
+                 format"
+            ),
+        };
+        let what = match (&self.validator, self.schema) {
+            (Some(v), true) => format!("the Rhai validator '{v}' and the JSON schema"),
+            (Some(v), false) => format!("the Rhai validator '{v}'"),
+            (None, _) => "the JSON schema".to_string(),
+        };
+        let tail = match request_has_schema {
+            true => "the schema supplied with the request is what checks the answer now",
+            false => {
+                "nothing checks the answer's shape; supply a schema with the request if the new \
+                 shape needs one"
+            }
+        };
+        format!(
+            "{cause}: {what} declared for {} will not run, because a check written for one shape \
+             cannot judge another. Instead, {tail}.",
+            stage_phrase(stages)
+        )
+    }
+}
+
+/// `stage 'plan'`, `stages 'plan' and 'wrap'`, `stages 'a', 'b', and 'c'`.
+/// Callers only group stages they saw, so the slice is never empty.
+fn stage_phrase(stages: &[String]) -> String {
+    let quoted: Vec<String> = stages.iter().map(|s| format!("'{s}'")).collect();
+    match quoted.split_last() {
+        Some((last, [])) => format!("stage {last}"),
+        Some((last, [first])) => format!("stages {first} and {last}"),
+        Some((last, head)) => format!("stages {}, and {last}", head.join(", ")),
+        // Unreachable by construction; an empty phrase keeps the sentence
+        // grammatical if a future caller ever passes one.
+        None => "its stages".to_string(),
+    }
+}
+
 /// Render a resolved spec as the guidance an agent reads.
 ///
 /// Used twice for the same text: once in the `submit_output` tool description
@@ -519,6 +660,214 @@ mod tests {
             .expect("the agent asked for one");
         assert_eq!(resolved.format.as_deref(), Some("json"));
         assert_eq!(resolved.schema, Some(json!({"type": "object"})));
+    }
+
+    /// A parsed blueprint whose agent-level output is `agent`, over stages
+    /// named and shaped by `stages`. Both take TOML output tables (or `None`),
+    /// because a manifest is where these declarations really come from.
+    fn blueprint_with(agent: Option<&str>, stages: &[(&str, Option<&str>)]) -> crate::Blueprint {
+        let mut manifest =
+            String::from("[agent]\nname = \"checked\"\nversion = \"1.0.0\"\ndescription = \"d\"\n");
+        if let Some(fields) = agent {
+            manifest.push_str(&format!("\n[agent.output]\n{fields}\n"));
+        }
+        for (name, output) in stages {
+            manifest.push_str(&format!("\n[stages.{name}]\nsystem_prompt = \"p\"\n"));
+            if let Some(fields) = output {
+                manifest.push_str(&format!("\n[stages.{name}.output]\n{fields}\n"));
+            }
+        }
+        crate::manifest::parse_manifest(&manifest).expect("the test manifest parses")
+    }
+
+    /// The headline: a differing format retires the declared validator, and
+    /// the warning names the stage, the script, and both formats.
+    #[test]
+    fn a_differing_format_earns_a_warning_naming_the_retired_validator() {
+        let bp = blueprint_with(
+            Some("format = \"markdown\"\nvalidator = \"checks/report.rhai\""),
+            &[("plan", None)],
+        );
+        let request = spec(Some("json"), None);
+        let warnings = retired_check_warnings(&bp, Some(&request));
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        let line = &warnings[0];
+        assert!(line.contains("'json'"), "{line}");
+        assert!(line.contains("'markdown'"), "{line}");
+        assert!(
+            line.contains("the Rhai validator 'checks/report.rhai'"),
+            "{line}"
+        );
+        assert!(line.contains("stage 'plan'"), "{line}");
+    }
+
+    /// Re-stating the declared format keeps the checks (see
+    /// `re_stating_the_declared_format_keeps_its_shape_checks`), so it earns
+    /// no warning - and neither does a request with no format in it, nor no
+    /// request at all.
+    #[test]
+    fn nothing_retired_means_nothing_warned() {
+        let bp = blueprint_with(
+            Some("format = \"markdown\"\nvalidator = \"v.rhai\"\nschema = { type = \"object\" }"),
+            &[("plan", None)],
+        );
+        let restated = spec(Some("markdown"), None);
+        assert!(retired_check_warnings(&bp, Some(&restated)).is_empty());
+        let formatless = OutputSpec {
+            instructions: Some("keep it short".to_string()),
+            ..OutputSpec::default()
+        };
+        assert!(retired_check_warnings(&bp, Some(&formatless)).is_empty());
+        assert!(retired_check_warnings(&bp, None).is_empty());
+        // And a blueprint with nothing retirable has nothing to lose.
+        let unchecked = blueprint_with(Some("format = \"markdown\""), &[("plan", None)]);
+        let reshaped = spec(Some("json"), None);
+        assert!(retired_check_warnings(&unchecked, Some(&reshaped)).is_empty());
+    }
+
+    /// A schema alone, a validator alone, and the two together each word the
+    /// loss precisely.
+    #[test]
+    fn the_warning_names_exactly_what_is_lost() {
+        let request = spec(Some("json"), None);
+        let schema_only = blueprint_with(
+            Some("format = \"markdown\"\nschema = { type = \"object\" }"),
+            &[("plan", None)],
+        );
+        let warnings = retired_check_warnings(&schema_only, Some(&request));
+        assert!(
+            warnings[0].contains("the JSON schema declared"),
+            "{warnings:?}"
+        );
+        let both = blueprint_with(
+            Some("format = \"markdown\"\nvalidator = \"v.rhai\"\nschema = { type = \"object\" }"),
+            &[("plan", None)],
+        );
+        let warnings = retired_check_warnings(&both, Some(&request));
+        assert!(
+            warnings[0].contains("the Rhai validator 'v.rhai' and the JSON schema"),
+            "{warnings:?}"
+        );
+    }
+
+    /// A caller who brings a schema for the new shape replaced the declared
+    /// one on purpose, so only the validator - which nothing can replace - is
+    /// still worth a warning.
+    #[test]
+    fn a_replacement_schema_is_not_warned_about() {
+        let bp = blueprint_with(
+            Some("format = \"markdown\"\nvalidator = \"v.rhai\"\nschema = { type = \"object\" }"),
+            &[("plan", None)],
+        );
+        let request = spec(Some("json"), Some(json!({"type": "array"})));
+        let warnings = retired_check_warnings(&bp, Some(&request));
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(
+            warnings[0].contains("the Rhai validator 'v.rhai'"),
+            "{warnings:?}"
+        );
+        assert!(
+            !warnings[0].contains("JSON schema declared"),
+            "{warnings:?}"
+        );
+        // And the advice acknowledges the schema they brought rather than
+        // asking for one.
+        assert!(
+            warnings[0].contains("the schema supplied with the request"),
+            "{warnings:?}"
+        );
+        // With nothing but the schema declared, the replacement leaves nothing
+        // retired at all.
+        let schema_only = blueprint_with(
+            Some("format = \"markdown\"\nschema = { type = \"object\" }"),
+            &[("plan", None)],
+        );
+        assert!(retired_check_warnings(&schema_only, Some(&request)).is_empty());
+    }
+
+    /// An agent-level validator shared by several stages is one line naming
+    /// them all, and a stage with its own distinct declaration gets its own.
+    #[test]
+    fn stages_losing_the_same_checks_share_one_line() {
+        let bp = blueprint_with(
+            Some("format = \"markdown\"\nvalidator = \"shared.rhai\""),
+            &[
+                ("plan", None),
+                ("draft", None),
+                ("wrap", Some("format = \"a2ui\"\nvalidator = \"a2ui.rhai\"")),
+            ],
+        );
+        let request = spec(Some("json"), None);
+        let warnings = retired_check_warnings(&bp, Some(&request));
+        assert_eq!(warnings.len(), 2, "{warnings:?}");
+        assert!(
+            warnings[0].contains("stages 'plan' and 'draft'"),
+            "{warnings:?}"
+        );
+        assert!(warnings[1].contains("stage 'wrap'"), "{warnings:?}");
+        assert!(warnings[1].contains("'a2ui'"), "{warnings:?}");
+    }
+
+    /// A declaration that lives only on a stage retires the same way: the
+    /// warning does not need an agent-level `[agent.output]` to exist.
+    #[test]
+    fn a_stage_level_declaration_retires_without_an_agent_one() {
+        let bp = blueprint_with(
+            None,
+            &[(
+                "plan",
+                Some("format = \"markdown\"\nvalidator = \"v.rhai\""),
+            )],
+        );
+        let request = spec(Some("json"), None);
+        let warnings = retired_check_warnings(&bp, Some(&request));
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(
+            warnings[0].contains("the Rhai validator 'v.rhai'"),
+            "{warnings:?}"
+        );
+    }
+
+    /// A stage that re-declares the requested format keeps its checks even
+    /// while its siblings lose theirs, because the cascade is per stage.
+    #[test]
+    fn a_stage_already_in_the_requested_format_keeps_its_checks() {
+        let bp = blueprint_with(
+            Some("format = \"markdown\"\nvalidator = \"shared.rhai\""),
+            &[("plan", None), ("emit", Some("format = \"json\""))],
+        );
+        let request = spec(Some("json"), None);
+        let warnings = retired_check_warnings(&bp, Some(&request));
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("stage 'plan'"), "{warnings:?}");
+    }
+
+    /// A validator declared without any format is still retired by naming one
+    /// (the request reshapes an output that never named its shape), and the
+    /// warning says so without inventing a declared format.
+    #[test]
+    fn a_formatless_declaration_is_reshaped_by_any_request() {
+        let bp = blueprint_with(Some("validator = \"v.rhai\""), &[("plan", None)]);
+        let request = spec(Some("json"), None);
+        let warnings = retired_check_warnings(&bp, Some(&request));
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(
+            warnings[0].contains("declared without a format"),
+            "{warnings:?}"
+        );
+    }
+
+    /// The three list shapes, plus the guard for a slice no caller produces.
+    #[test]
+    fn stage_phrases_read_as_prose() {
+        let names = |names: &[&str]| names.iter().map(|n| n.to_string()).collect::<Vec<_>>();
+        assert_eq!(stage_phrase(&names(&["a"])), "stage 'a'");
+        assert_eq!(stage_phrase(&names(&["a", "b"])), "stages 'a' and 'b'");
+        assert_eq!(
+            stage_phrase(&names(&["a", "b", "c"])),
+            "stages 'a', 'b', and 'c'"
+        );
+        assert_eq!(stage_phrase(&[]), "its stages");
     }
 
     #[test]

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -1396,7 +1396,9 @@ curl -X POST http://localhost:3000/api/agents \
 
 Then read it back from `GET /api/agents/{id}/result`, where `final_output` carries the answer, its
 format label, and the stage that produced it. Add `output_schema` when you want the answer validated
-against a JSON Schema. [Final outputs](/docs/outputs) covers the whole cascade.
+against a JSON Schema. A format that differs from the blueprint's retires any Rhai validator and
+JSON schema the blueprint declared, and the spawn response says so: a `warnings` array beside the
+run id names each retired check. [Final outputs](/docs/outputs) covers the whole cascade.
 
 ## Spawning with a signed webhook
 

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -172,9 +172,12 @@ flowchart LR
   C --> D["what the model is asked for"]
 ```
 
-One rule breaks that pattern on purpose. If you name a `format` and supply no schema, any schema the
-blueprint declared is dropped. A check written for one shape says nothing about another. Supply your
-own schema alongside your format when you want the answer validated.
+One rule breaks that pattern on purpose. If you name a `format` other than the one the blueprint
+declares, any Rhai validator and any JSON schema it declared are retired together. A check written
+for one shape says nothing about another. The retirement is not silent: `lev run` warns on stderr,
+the REST spawn response carries a `warnings` array naming what was retired, and the daemon logs a
+line for every spawn path. Re-stating the format the blueprint already declares retires nothing.
+Supply your own schema alongside your format when you want the answer validated.
 
 ### It outranks the stage's prompt
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2596,7 +2596,7 @@
           },
           "output_format": {
             "type": "string",
-            "description": "Ask for the final output in this shape, overriding the blueprint's. Any label works - nothing converts between shapes; the label reaches the model, which produces the bytes. Naming this without output_schema drops a schema the blueprint declared."
+            "description": "Ask for the final output in this shape, overriding the blueprint's. Any label works - nothing converts between shapes; the label reaches the model, which produces the bytes. Naming a format the blueprint does not declare retires any Rhai validator and JSON schema it declared (a check written for one shape says nothing about another); the response's warnings array names what was retired. Supply output_schema when the new shape should still be checked."
           },
           "output_instructions": {
             "type": "string",
@@ -2634,6 +2634,13 @@
           },
           "run_id": {
             "type": "string"
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "How this run will differ from what its blueprint declares: today, the Rhai validator or JSON schema that a differing output_format retired. Omitted when there is nothing to say."
           }
         }
       },


### PR DESCRIPTION
## Problem

Passing `--output-format` (CLI), `output_format` (REST spawn), or the sub-agent/ACP equivalents with a label that differs from what the blueprint declares retires the declared Rhai validator and JSON schema for the reshaped stages. That is deliberate and stays: a check written for one shape cannot judge another. But the retirement was completely silent, so a caller who typed `--output-format json` over a blueprint with a validator kept believing the run was still being checked. The user-facing text also under-described it, mentioning only the schema.

## What warns where

The decision is asked ahead of time by a new `leviath_core::output::retired_check_warnings`, kept beside `resolve_output_spec` with the same per-stage cascade, so the two cannot drift: re-stating the declared format warns about nothing, a stage's declaration wins over the agent's, and stages losing the same checks share one line. A schema supplied with the request is acknowledged rather than warned about (replacing the declared schema is exactly what the warning would ask for); a declared validator is always named, because no request can bring a replacement for it.

- **Daemon (all spawn paths, including sub-agent and ACP):** `build_agent_inner` logs a `tracing::warn!` naming the run, agent, stages, and retired script/schema. Every spawn funnels through it.
- **`lev run`:** the warning prints to stderr before the run starts, beside the existing read-path/held-checkpoint warnings, read from the real manifest and best-effort like them.
- **REST `POST /api/agents`:** the response gains an additive `warnings: Vec<String>`, `skip_serializing_if` empty, so existing clients parse exactly the response they always did. The OpenAPI schema documents it.

## Text fixes

- `--output-format` help now says a differing label retires the declared Rhai validator and JSON schema, not just "drops a schema".
- REST `output_schema` field docs, the OpenAPI `output_format` description, `docs/content/outputs.md`, and `docs/content/api.md` say the same and point at the warning. `docs/content/rhai-validators.md` already stated it and is unchanged.

## Fail-first evidence

The headline test (`spawn_with_a_differing_format_reports_the_retired_checks`, REST spawn over a blueprint declaring a validator) was written and run before the fix:

```
panicked at crates/leviath-cli/src/commands/serve/agents.rs:1327:32:
the response carries warnings: {"agent_id":"run-1","run_id":"run-1"}
```

With the fix it passes, alongside the required negatives: re-stating the declared format produces no warning, and no format request produces no warning (asserted on both the REST response and the `lev run` warning path, plus the resolve-mirror unit tests in `leviath-core`).

## Gates

- `cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo xtask structure`, `cargo xtask docs`: clean
- `cargo xtask coverage --package leviath-core` and `--package leviath-cli`: 100%
- Full `leviath-cli` lib suite: 4400+ tests green

No behaviour change to which validators run; the retirement itself is untouched.
