### PR TITLE
feat(outputs): a validator error rejects the submission by default

### DIFF
--- a/crates/leviath-cli/src/commands/agent_client/session.rs
+++ b/crates/leviath-cli/src/commands/agent_client/session.rs
@@ -87,6 +87,7 @@ pub(super) fn spawn_args(
                 example: None,
                 schema: None,
                 validator: None,
+                on_validator_error: None,
             }),
         },
     }

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -178,6 +178,7 @@ pub fn output_request(
         example: None,
         schema,
         validator: None,
+        on_validator_error: None,
     }))
 }
 

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -41,6 +41,7 @@ fn output_request(body: &SpawnAgentReq) -> Option<leviath_core::output::OutputSp
         example: None,
         schema: body.output_schema.clone(),
         validator: None,
+        on_validator_error: None,
     })
 }
 

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -152,6 +152,7 @@ async fn spawn(h: &SubAgentHandle, args: &serde_json::Value) -> String {
                 example: None,
                 schema: None,
                 validator: None,
+                on_validator_error: None,
             }),
         }
     };

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -114,7 +114,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     // Parse the agent's default output shape: [agent.output]. A per-stage
     // block narrows it, and whoever starts the run overrides both.
     if let Some(output_table) = table_of(agent, "output") {
-        blueprint.output = Some(parse_output_spec(output_table));
+        blueprint.output = Some(parse_output_spec("[agent.output]", output_table)?);
     }
 
     // Parse agent-level sandbox config: [sandbox]

--- a/crates/leviath-core/src/manifest/sections.rs
+++ b/crates/leviath-core/src/manifest/sections.rs
@@ -137,14 +137,34 @@ pub(super) fn parse_repetition_detection(
 ///
 /// `schema` is taken as arbitrary TOML and converted to JSON, so an author can
 /// write the schema inline as a TOML table rather than embedding a JSON string.
-pub(super) fn parse_output_spec(table: &toml::value::Table) -> crate::output::OutputSpec {
+///
+/// `on_validator_error` is the one enum-ish field, and a value it does not
+/// recognise is a hard error rather than a silent fallback: a misspelled
+/// policy would otherwise load as the default and change what happens to a
+/// run's answer. `where_` names the table an error came from.
+pub(super) fn parse_output_spec(
+    where_: &str,
+    table: &toml::value::Table,
+) -> Result<crate::output::OutputSpec> {
     let string_field = |key: &str| {
         table
             .get(key)
             .and_then(|v| v.as_str())
             .map(|s| s.trim().to_string())
     };
-    crate::output::OutputSpec {
+    let on_validator_error = match table.get("on_validator_error") {
+        None => None,
+        Some(value) => match value.as_str().map(str::trim) {
+            Some("reject") => Some(crate::output::OnValidatorError::Reject),
+            Some("accept") => Some(crate::output::OnValidatorError::Accept),
+            _ => {
+                return Err(Error::Other(format!(
+                    "{where_}: on_validator_error must be \"reject\" or \"accept\", got: {value}"
+                )));
+            }
+        },
+    };
+    Ok(crate::output::OutputSpec {
         format: string_field("format"),
         instructions: string_field("instructions"),
         example: string_field("example"),
@@ -156,8 +176,22 @@ pub(super) fn parse_output_spec(table: &toml::value::Table) -> crate::output::Ou
             .get("schema")
             .and_then(|v| serde_json::to_value(v).ok()),
         validator: string_field("validator"),
-    }
+        on_validator_error,
+    })
 }
+
+/// Every key [`parse_output_spec`] reads off an output table, for the schema
+/// guard in `tests.rs`. Like `REGION_KEYS`, a list and not a check: the parser
+/// ignores a key it does not know.
+#[cfg(test)]
+pub(super) const OUTPUT_KEYS: &[&str] = &[
+    "example",
+    "format",
+    "instructions",
+    "on_validator_error",
+    "schema",
+    "validator",
+];
 
 pub(super) fn parse_security_config(security_table: &toml::value::Table) -> crate::SecurityConfig {
     let mut sc = crate::SecurityConfig::default();

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -492,7 +492,10 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     // Parse the stage's declared output shape: [stages.<name>.output].
     // Narrows [agent.output]; whoever starts the run overrides both.
     if let Some(output_table) = table_of(stage_value, "output") {
-        stage.output = Some(parse_output_spec(output_table));
+        stage.output = Some(parse_output_spec(
+            &format!("stage '{stage_name}': output"),
+            output_table,
+        )?);
     }
 
     // Parse accepts_messages flag: whether mid-run user messages are

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -3040,6 +3040,77 @@ type = "object"
     );
 }
 
+/// The validator-error policy is read at both levels, and only the two spelled
+/// values load.
+#[test]
+fn on_validator_error_parses_at_agent_and_stage_level() {
+    let toml = r#"
+[agent]
+name = "policy-test"
+
+[agent.output]
+format = "a2ui"
+validator = "v.rhai"
+on_validator_error = "accept"
+
+[stages.summary]
+mode = "output"
+
+[stages.summary.output]
+on_validator_error = "reject"
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    assert_eq!(
+        bp.output.as_ref().and_then(|s| s.on_validator_error),
+        Some(crate::output::OnValidatorError::Accept)
+    );
+    assert_eq!(
+        bp.find_stage("summary")
+            .expect("the stage exists")
+            .output
+            .as_ref()
+            .and_then(|s| s.on_validator_error),
+        Some(crate::output::OnValidatorError::Reject)
+    );
+}
+
+/// A policy this parser does not recognise is a load error, not a silent
+/// fallback: `"sometimes"` would otherwise load as the default and change what
+/// happens to the run's answer.
+#[test]
+fn an_unknown_validator_error_policy_is_refused_at_load() {
+    let toml = r#"
+[agent]
+name = "policy-test"
+
+[agent.output]
+on_validator_error = "sometimes"
+"#;
+    let err = parse_manifest(toml).expect_err("refused").to_string();
+    assert!(err.contains("[agent.output]"), "{err}");
+    assert!(err.contains("\"reject\" or \"accept\""), "{err}");
+    assert!(err.contains("sometimes"), "{err}");
+}
+
+/// The wrong type is refused with the same error, naming the stage whose table
+/// carried it. Reading only `as_str` would silently ignore a non-string value.
+#[test]
+fn a_non_string_validator_error_policy_is_refused_at_load() {
+    let toml = r#"
+[agent]
+name = "policy-test"
+
+[stages.summary]
+mode = "output"
+
+[stages.summary.output]
+on_validator_error = 3
+"#;
+    let err = parse_manifest(toml).expect_err("refused").to_string();
+    assert!(err.contains("stage 'summary': output"), "{err}");
+    assert!(err.contains("got: 3"), "{err}");
+}
+
 #[test]
 fn parse_manifest_with_stage_system_prompt() {
     let toml = r#"
@@ -5574,6 +5645,11 @@ fn the_published_schema_and_the_parser_agree_on_every_key() {
             "region",
             &["$defs", "region"][..],
             super::regions::REGION_KEYS,
+        ),
+        (
+            "output",
+            &["$defs", "outputSpec"][..],
+            super::sections::OUTPUT_KEYS,
         ),
         (
             "interaction point",

--- a/crates/leviath-core/src/output.rs
+++ b/crates/leviath-core/src/output.rs
@@ -40,6 +40,28 @@ use serde::{Deserialize, Serialize};
 /// file and say where it is.
 pub const MAX_FINAL_OUTPUT_BYTES: usize = 256 * 1024;
 
+/// What happens to a submission when its Rhai validator cannot run: the script
+/// threw, exhausted its operation budget, or returned something that is neither
+/// `()` nor a string.
+///
+/// Distinct from the validator *rejecting* the answer, which always refuses the
+/// submission back to the model. This knob is only about the script itself
+/// failing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OnValidatorError {
+    /// Refuse the submission, sending the script's error text to the model as
+    /// retry feedback. The default: an answer nothing checked must not ship as
+    /// if it passed, and a `parse_json` throw on malformed output is something
+    /// the model can act on.
+    #[default]
+    Reject,
+    /// Record the submission unchecked, as if no validator were declared. For
+    /// blueprints that would rather have an unchecked answer than a failed run.
+    /// The broken script is still flagged on the run either way.
+    Accept,
+}
+
 /// What shape an agent should return.
 ///
 /// Declared by a blueprint (`[agent.output]`), narrowed by a stage
@@ -93,6 +115,13 @@ pub struct OutputSpec {
     /// format retires it along with the schema.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validator: Option<String>,
+
+    /// What to do when the validator itself cannot run. `None` means the
+    /// default, [`OnValidatorError::Reject`]. Travels with the validator: a
+    /// caller who retires the validator by overriding the format retires this
+    /// setting along with it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_validator_error: Option<OnValidatorError>,
 }
 
 impl OutputSpec {
@@ -104,6 +133,7 @@ impl OutputSpec {
             && self.example.is_none()
             && self.schema.is_none()
             && self.validator.is_none()
+            && self.on_validator_error.is_none()
     }
 }
 
@@ -274,6 +304,12 @@ pub fn resolve_output_spec(
         true => request.and_then(|r| r.validator.clone()),
         false => field(agent, stage, request, |s| s.validator.clone()),
     };
+    // The error policy accompanies the validator it is about, so it follows the
+    // validator's cascade: retired with it on a reshape, inherited otherwise.
+    let on_validator_error = match reshaped {
+        true => request.and_then(|r| r.on_validator_error),
+        false => field(agent, stage, request, |s| s.on_validator_error),
+    };
 
     Some(OutputSpec {
         format: field(agent, stage, request, |s| s.format.clone()),
@@ -281,6 +317,7 @@ pub fn resolve_output_spec(
         example: field(agent, stage, request, |s| s.example.clone()),
         schema: shape_field(|s| s.schema.clone()),
         validator,
+        on_validator_error,
     })
 }
 
@@ -538,6 +575,13 @@ mod tests {
             }
             .is_empty()
         );
+        assert!(
+            !OutputSpec {
+                on_validator_error: Some(OnValidatorError::Accept),
+                ..OutputSpec::default()
+            }
+            .is_empty()
+        );
     }
 
     #[test]
@@ -553,6 +597,7 @@ mod tests {
             example: Some("agent example".to_string()),
             schema: None,
             validator: None,
+            on_validator_error: None,
         };
         let stage = OutputSpec {
             instructions: Some("stage guidance".to_string()),
@@ -593,12 +638,14 @@ mod tests {
     }
 
     /// A Rhai validator is written for one format, so it retires with the schema
-    /// when a caller asks for a different one.
+    /// when a caller asks for a different one - and its error policy, which is
+    /// about that validator, retires with it.
     #[test]
     fn reshaping_retires_the_validator_too() {
         let agent = OutputSpec {
             format: Some("a2ui".to_string()),
             validator: Some("a2ui.rhai".to_string()),
+            on_validator_error: Some(OnValidatorError::Accept),
             ..OutputSpec::default()
         };
         let request = spec(Some("xml"), None);
@@ -606,6 +653,52 @@ mod tests {
             .expect("the agent asked for one");
         assert_eq!(resolved.format.as_deref(), Some("xml"));
         assert_eq!(resolved.validator, None);
+        assert_eq!(resolved.on_validator_error, None);
+    }
+
+    /// The error policy cascades the way the validator does: a stage's setting
+    /// beats the agent's.
+    #[test]
+    fn the_stage_error_policy_overrides_the_agents() {
+        let agent = OutputSpec {
+            format: Some("a2ui".to_string()),
+            validator: Some("a2ui.rhai".to_string()),
+            on_validator_error: Some(OnValidatorError::Reject),
+            ..OutputSpec::default()
+        };
+        let stage = OutputSpec {
+            on_validator_error: Some(OnValidatorError::Accept),
+            ..OutputSpec::default()
+        };
+        let resolved =
+            resolve_output_spec(Some(&agent), Some(&stage), None).expect("the agent asked for one");
+        assert_eq!(resolved.on_validator_error, Some(OnValidatorError::Accept));
+        assert_eq!(
+            resolved.validator.as_deref(),
+            Some("a2ui.rhai"),
+            "the validator itself still falls through from the agent"
+        );
+    }
+
+    /// A caller who reshapes and brings their own validator can bring their own
+    /// error policy with it.
+    #[test]
+    fn a_reshaping_caller_can_supply_their_own_error_policy() {
+        let agent = OutputSpec {
+            format: Some("a2ui".to_string()),
+            validator: Some("a2ui.rhai".to_string()),
+            ..OutputSpec::default()
+        };
+        let request = OutputSpec {
+            format: Some("xml".to_string()),
+            validator: Some("xml.rhai".to_string()),
+            on_validator_error: Some(OnValidatorError::Accept),
+            ..OutputSpec::default()
+        };
+        let resolved = resolve_output_spec(Some(&agent), None, Some(&request))
+            .expect("the agent asked for one");
+        assert_eq!(resolved.validator.as_deref(), Some("xml.rhai"));
+        assert_eq!(resolved.on_validator_error, Some(OnValidatorError::Accept));
     }
 
     /// A caller that brings its own checks keeps them.
@@ -910,6 +1003,7 @@ mod tests {
             example: Some("{\"root\": {}}".to_string()),
             schema: Some(json!({"type": "object"})),
             validator: None,
+            on_validator_error: None,
         });
         assert!(described.contains("Return it in this format: a2ui."));
         assert!(described.contains("One card per finding."));
@@ -967,6 +1061,25 @@ mod tests {
         assert_eq!(back, original);
         // Unset fields stay off the wire rather than serializing as nulls.
         assert!(!text.contains("instructions"));
+        assert!(!text.contains("on_validator_error"));
+    }
+
+    /// The wire spelling is the manifest spelling: `accept` and `reject`,
+    /// nothing else. A request naming a third policy is refused rather than
+    /// quietly mapped to either behaviour.
+    #[test]
+    fn the_error_policy_uses_the_manifest_spelling_on_the_wire() {
+        let original = OutputSpec {
+            on_validator_error: Some(OnValidatorError::Accept),
+            ..OutputSpec::default()
+        };
+        let text = serde_json::to_string(&original).expect("a spec serializes");
+        assert!(text.contains(r#""on_validator_error":"accept""#), "{text}");
+        let back: OutputSpec = serde_json::from_str(&text).expect("and deserializes");
+        assert_eq!(back, original);
+
+        let rejected = serde_json::from_str::<OutputSpec>(r#"{"on_validator_error":"sometimes"}"#);
+        assert!(rejected.is_err(), "an unknown policy must not deserialize");
     }
 
     #[test]

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -104,6 +104,7 @@ impl SpawnSpec {
             example: None,
             schema: None,
             validator: None,
+            on_validator_error: None,
         });
         self
     }

--- a/crates/leviath-runtime/src/output_tool.rs
+++ b/crates/leviath-runtime/src/output_tool.rs
@@ -178,9 +178,13 @@ pub(crate) fn handle_output_tool(
     }
 
     // An agent's own validator, for a format nothing here can parse and a shape
-    // no JSON Schema can describe. A broken script is reported as broken rather
-    // than treated as a rejection: reading it as "the answer is wrong" would
-    // burn the retry budget on a script bug and end the run with nothing.
+    // no JSON Schema can describe. A validator that cannot run follows the
+    // spec's `on_validator_error` policy: by default the submission is refused
+    // with the script's own error as the reason, because an answer nothing
+    // checked must not ship as if it passed, and a `parse_json` throw on
+    // malformed output is feedback the model can act on. `accept` records the
+    // submission unchecked instead, for blueprints that would rather have an
+    // answer than a failed run. The script is flagged on the run either way.
     if let Some(script) = spec.and_then(|s| s.validator.as_deref())
         && let Some(held) = validators
         && let Some(validator) = held.compiled.get(script)
@@ -193,6 +197,7 @@ pub(crate) fn handle_output_tool(
                 );
             }
             leviath_scripting::output_validator::Verdict::Unusable(reason) => {
+                let policy = spec.and_then(|s| s.on_validator_error).unwrap_or_default();
                 // Once per script, not once per retry: a validator that throws
                 // throws every time, and the same stage submitting again would
                 // otherwise repeat the same line.
@@ -201,8 +206,14 @@ pub(crate) fn handle_output_tool(
                         stage = %stage,
                         script = %script,
                         error = %reason,
-                        "output validator failed to run; recording the submission \
-                         unchecked and flagging the script on this run"
+                        policy = ?policy,
+                        "output validator failed to run; flagging the script on this run"
+                    );
+                }
+                if policy == leviath_core::output::OnValidatorError::Reject {
+                    return (
+                        format!("[error] the final output was rejected: {reason}"),
+                        None,
                     );
                 }
             }

--- a/crates/leviath-runtime/src/output_tool/tests.rs
+++ b/crates/leviath-runtime/src/output_tool/tests.rs
@@ -631,6 +631,13 @@ fn spec_with_validator(format: &str) -> OutputSpec {
     }
 }
 
+fn spec_with_lenient_validator(format: &str) -> OutputSpec {
+    OutputSpec {
+        on_validator_error: Some(leviath_core::output::OnValidatorError::Accept),
+        ..spec_with_validator(format)
+    }
+}
+
 /// The point of the seam: a format nothing in this codebase can parse, checked
 /// by the person whose format it is.
 #[test]
@@ -688,14 +695,16 @@ fn an_agent_supplied_validator_accepts_a_good_answer() {
     assert!(output.is_some());
 }
 
-/// A broken validator must not read as "every answer is wrong". That would burn
-/// the retry budget on a script bug and end the run with nothing at all.
+/// The default is fail closed: a validator that cannot run rejects the
+/// submission, and the script's own error goes back to the model. A
+/// `parse_json` throw on malformed output is feedback the model can act on;
+/// silently accepting the answer would ship it unchecked.
 #[test]
-fn a_broken_validator_records_the_submission_unchecked() {
+fn a_throwing_validator_rejects_the_submission_by_default() {
     let vals = validators_with(r#"fn validate(content) { throw "the script is broken" }"#);
     let mut w = win();
-    let (_, output) = handle_output_tool(
-        &json!({"content": "the agent's perfectly good answer"}),
+    let (message, output) = handle_output_tool(
+        &json!({"content": "an answer nothing checked"}),
         &OutputContext {
             spec: Some(&spec_with_validator("a2ui")),
             validators: Some(&vals),
@@ -706,27 +715,60 @@ fn a_broken_validator_records_the_submission_unchecked() {
         0,
         &mut w,
     );
+    assert!(output.is_none(), "nothing recorded");
+    assert!(message.starts_with("[error]"), "{message}");
     assert!(
-        output.is_some(),
-        "a script bug must not cost the agent its answer"
+        message.contains("the script is broken"),
+        "the model must see the script's own error: {message}"
     );
     assert_eq!(
         vals.broken_names(),
         vec!["v.rhai".to_string()],
-        "and the run records which script it could not use, so the failure is \
-         not only a line in the daemon log"
+        "the diagnostic flag is kept in both modes"
+    );
+}
+
+/// `on_validator_error = "accept"` is the opt-out: a blueprint that would
+/// rather have an unchecked answer than a failed run records the submission as
+/// if no validator were declared.
+#[test]
+fn an_accept_policy_records_the_submission_unchecked() {
+    let vals = validators_with(r#"fn validate(content) { throw "the script is broken" }"#);
+    let mut w = win();
+    let (_, output) = handle_output_tool(
+        &json!({"content": "the agent's perfectly good answer"}),
+        &OutputContext {
+            spec: Some(&spec_with_lenient_validator("a2ui")),
+            validators: Some(&vals),
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
+        0,
+        &mut w,
+    );
+    assert!(
+        output.is_some(),
+        "accept means the script bug does not cost the agent its answer"
+    );
+    assert_eq!(
+        vals.broken_names(),
+        vec!["v.rhai".to_string()],
+        "and the run still records which script it could not use, so the \
+         failure is not only a line in the daemon log"
     );
 }
 
 /// Once per script, not once per retry. A validator that throws throws every
 /// time, so a stage that submits three corrections would otherwise report the
-/// same broken script three times.
+/// same broken script three times. The rejection itself does repeat: the model
+/// is told every time, the operator once.
 #[test]
 fn a_broken_validator_is_recorded_once_however_often_it_is_hit() {
     let vals = validators_with(r#"fn validate(content) { throw "still broken" }"#);
     let mut w = win();
     for _ in 0..3 {
-        handle_output_tool(
+        let (message, output) = handle_output_tool(
             &json!({"content": "an answer"}),
             &OutputContext {
                 spec: Some(&spec_with_validator("a2ui")),
@@ -738,6 +780,8 @@ fn a_broken_validator_is_recorded_once_however_often_it_is_hit() {
             0,
             &mut w,
         );
+        assert!(output.is_none(), "the default policy rejects every retry");
+        assert!(message.contains("still broken"), "{message}");
     }
     assert_eq!(vals.broken_names(), vec!["v.rhai".to_string()]);
 }

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -1939,6 +1939,7 @@ mod tests {
                 example: Some("{\"root\": {}}".to_string()),
                 schema: None,
                 validator: None,
+                on_validator_error: None,
             }),
         );
         let resolved = resolve_one(&bp, None);

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -13641,6 +13641,7 @@ fn stage_setup_from_folds_a_required_output_into_the_system_prompt() {
         example: Some("{\"root\": {}}".to_string()),
         schema: None,
         validator: None,
+        on_validator_error: None,
     };
     let mut s = stage_named("summary", None, false, None);
     s.require_output = true;

--- a/crates/leviath-scripting/src/output_validator.rs
+++ b/crates/leviath-scripting/src/output_validator.rs
@@ -27,8 +27,10 @@
 //!
 //! Execution runs on a fresh hardened engine per call: no filesystem, no
 //! network, no `eval`, operation-bounded. A validator that throws, loops, or
-//! returns something that is neither `()` nor a string is an authoring error,
-//! reported as such rather than being allowed to fail every submission.
+//! returns something that is neither `()` nor a string is reported as broken
+//! rather than folded into "the answer is wrong"; what happens to the
+//! submission then is the consumer's policy (`on_validator_error` on the
+//! output spec), not this module's.
 
 use rhai::{AST, Dynamic, Engine, Scope};
 
@@ -95,11 +97,15 @@ pub enum Verdict {
     /// The answer is not, for this reason. Goes back to the agent verbatim.
     Invalid(String),
     /// The validator itself is broken: it threw, ran out of operations, or
-    /// returned something that is neither `()` nor a string.
+    /// returned something that is neither `()` nor a string. Carries the error
+    /// text, script path included, so a consumer that refuses the submission
+    /// can hand the model something actionable.
     ///
-    /// Kept apart from [`Invalid`](Self::Invalid) on purpose. A broken validator
-    /// must not read as "every answer is wrong", which would burn the agent's
-    /// whole retry budget on a script bug and end the run with nothing.
+    /// Kept apart from [`Invalid`](Self::Invalid) on purpose: a broken script
+    /// is flagged on the run as an authoring problem, where a rejection is the
+    /// answer's problem. Whether the submission is then refused or recorded
+    /// unchecked is the consumer's `on_validator_error` policy, decided where
+    /// the verdict is applied rather than here.
     Unusable(String),
 }
 

--- a/crates/leviath-scripting/src/output_validator/tests.rs
+++ b/crates/leviath-scripting/src/output_validator/tests.rs
@@ -50,8 +50,10 @@ fn a_validator_can_inspect_the_content_it_is_given() {
     );
 }
 
-/// A broken validator must not read as "every answer is wrong". That would burn
-/// the agent's whole retry budget on a script bug and end the run with nothing.
+/// A throw is its own verdict, not folded into `Invalid`: the consumer decides
+/// what happens to the submission, and either way the run flags the script as
+/// broken. The error text travels with the verdict so a refusal can hand the
+/// model something actionable.
 #[test]
 fn a_validator_that_throws_is_unusable_rather_than_a_rejection() {
     let v = compiled(r#"fn validate(content) { throw "boom" }"#);

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -101,7 +101,9 @@ format's parser.
 **Does it have the shape you wanted?** That is a schema, and only happens if you write one.
 
 For JSON, use a JSON Schema. For anything else, ship a [Rhai validator](/docs/rhai-validators) with
-your agent.
+your agent. A validator that cannot run rejects the submission by default, sending the script's
+error back to the model as feedback; set `on_validator_error = "accept"` on the output block if you
+would rather record the answer unchecked.
 
 ## Asking for a shape at launch
 

--- a/docs/content/rhai-validators.md
+++ b/docs/content/rhai-validators.md
@@ -62,14 +62,34 @@ The same hardened engine every Leviath script gets. No filesystem, no network, n
 operation budget so a runaway script stops instead of hanging the run. You get the
 [standard helpers](/docs/scripting), including `parse_json`.
 
-A validator that throws, loops forever, or returns something that is neither `()` nor a string is
-treated as **broken, not as a rejection**. The submission is recorded, and the run says so.
+## When the validator itself fails
 
-That distinction matters. If a script bug read as "this answer is wrong", the agent would retry
-against a validator that can never pass. It would burn its whole budget and end with no answer at
-all. A bug in your validator should cost you a warning, not the agent's work.
+A validator can also fail to run at all: it throws, runs past its operation budget, or returns
+something that is neither `()` nor a string.
 
-Where the run says so:
+By default the submission is **rejected**, and the script's own error goes back to the agent as the
+reason. A throw is often the check working: a validator that calls `parse_json` on malformed output
+throws, and "malformed JSON" is something the agent can fix on its next try. The alternative, and
+the old behaviour, was to accept the answer unchecked, which shipped exactly the submissions the
+validator existed to catch.
+
+If you would rather end the run with an unchecked answer than risk ending it with none, say so:
+
+```toml
+[stages.present.output]
+format = "a2ui"
+validator = "validators/a2ui.rhai"
+on_validator_error = "accept"
+```
+
+With `accept`, a validator that cannot run records the submission as if no validator were declared.
+Choose it when any answer beats no answer, and be aware of what you are trading: a genuine script
+bug under the default reads as "this answer is wrong" on every retry, so the agent can burn its
+whole budget against a check that can never pass. The setting works at both levels, `[agent.output]`
+and `[stages.<name>.output]`, and the stage's value wins. Anything other than `reject` or `accept`
+refuses to load.
+
+In both modes the run flags the script:
 
 | Surface | What you see |
 |---|---|
@@ -80,8 +100,8 @@ Where the run says so:
 Named rather than counted, because the useful question is which one. Recorded once per script
 however many times the stage submits - a validator that throws throws every time.
 
-The failure would otherwise be invisible: the run completes, reports success, and the only trace is
-a line in the daemon log. An answer nobody checked looks exactly like an answer that passed.
+Under `accept` the flag is the only trace: the run completes, reports success, and an answer nobody
+checked looks exactly like an answer that passed. Check it before trusting those runs.
 
 `lev validate` compiles the machine's global tools and script providers as well as the blueprint's
 own, so a script that will not load is something you can find before a run needs it.

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -256,6 +256,13 @@
         "validator": {
           "type": "string",
           "description": "A .rhai script deciding whether an answer is valid, as a path relative to the blueprint directory. For a format the engine cannot parse and a shape a JSON Schema cannot describe. Defines fn validate(content), returning () when fine or a string saying what is wrong. Compiled at spawn, so a broken script fails fast."
+        },
+        "on_validator_error": {
+          "enum": [
+            "reject",
+            "accept"
+          ],
+          "description": "What happens to a submission when the validator itself cannot run: it threw, ran out of operations, or returned the wrong type. reject (the default) refuses the submission and sends the script's error back to the model as retry feedback; accept records the answer unchecked. The broken script is flagged on the run either way."
         }
       }
     },


### PR DESCRIPTION
## Behavior change, called out up front

**A Rhai output validator that cannot run now rejects the submission by default.** Before this PR, a validator that threw, ran past its operation budget, or returned the wrong type produced `Verdict::Unusable` and the submission was accepted unchecked, with only a broken-script flag recorded. Any blueprint relying on that fail-open behaviour needs `on_validator_error = "accept"` after this merges.

## The decision and the tradeoff

Fail open ships exactly the answers the validator existed to catch: a validator whose first line is `parse_json(content)` throws on malformed output, and that throw used to wave the malformed answer through. Fail closed treats the throw as a rejection whose reason is the script's own error text, sent back to the model as retry feedback the model can act on.

The cost is real: a genuine script bug now reads as "this answer is wrong" on every retry, so the agent can burn its budget against a check that can never pass and end the run with nothing. That is why the knob exists rather than a hard switch.

## The knob

```toml
[stages.present.output]
format = "a2ui"
validator = "validators/a2ui.rhai"
on_validator_error = "accept"   # default: "reject"
```

- Parses at `[agent.output]` and `[stages.<name>.output]`; the stage's value wins, the same cascade as the validator itself.
- Travels with the validator: a caller who retires the validator by overriding the format retires the policy with it; a caller who reshapes and brings their own validator can bring their own policy.
- `on_validator_error = "sometimes"` (or a non-string value) is a load error naming the table, consistent with the other enum-ish manifest fields.
- The broken-script flag (`flags.broken_scripts`, `lev ps` `(broken script)`, dashboard header) is recorded in both modes, once per script per run.
- `Verdict::Unusable` already carried the error text with the script path, so the runtime hands the model `[error] the final output was rejected: v.rhai: validate: ...` with no scripting-layer change; the scripting crate only got its fail-open doc comments rewritten.
- The published `docs/schema/blueprint.schema.json` lists the key, and `outputSpec` joined the schema-vs-parser drift guard via a new `OUTPUT_KEYS` list.

## Noted follow-up (unchanged here)

The analogous fail-open path for a JSON Schema that will not compile (`output_tool.rs`, `ArgValidation::SchemaUnusable` skips the check and records the submission unchecked) is deliberately left as-is in this PR.

## Fail-first evidence

The headline test was written and run against the unfixed code first:

```
test output_tool::tests::a_throwing_validator_rejects_the_submission_by_default ... FAILED
panicked at crates/leviath-runtime/src/output_tool/tests.rs:711:5: nothing recorded
```

i.e. the throwing validator's submission was accepted. It passes after the change, along with the flipped suite: the old `a_broken_validator_records_the_submission_unchecked` is now `an_accept_policy_records_the_submission_unchecked`, the once-per-run flag test asserts the rejection repeats while the flag does not, and new core tests cover the cascade, reshaping retirement, wire spelling, unknown-value refusal, and load errors at both manifest levels.

## Gates

- `cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo xtask structure`, `cargo xtask docs`: clean
- Coverage at 100% (fresh `llvm-cov-target` each): leviath-core, leviath-scripting, leviath-runtime, leviath-cli
- Pre-commit full suite passed

Docs: `docs/content/rhai-validators.md` rewritten around the new default (new "When the validator itself fails" section documents both modes and when to choose `accept`; the fail-early section still holds), plus a pointer in `docs/content/outputs.md`.
