### PR TITLE
Fix Codex titling, filter models by provider, and watch the catalog for drift

### DIFF
--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -1,6 +1,6 @@
 //! Config and models endpoints.
 
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::Json;
 
@@ -389,8 +389,16 @@ pub(super) async fn validate_config_key(Json(req): Json<ValidateKeyReq>) -> Json
 /// that admits which numbers are guesses.
 const MODELS_PRIME_TIMEOUT_SECS: u64 = 5;
 
-pub(super) async fn get_models(State(state): State<AppState>) -> Json<Vec<ModelEntry>> {
-    models_with(&state, &leviath_providers::provider::build_http_client).await
+pub(super) async fn get_models(
+    State(state): State<AppState>,
+    Query(query): Query<ModelsQuery>,
+) -> Json<Vec<ModelEntry>> {
+    models_with(
+        &state,
+        &leviath_providers::provider::build_http_client,
+        &query,
+    )
+    .await
 }
 
 /// [`get_models`], with client construction injected so the "no usable HTTPS
@@ -398,8 +406,18 @@ pub(super) async fn get_models(State(state): State<AppState>) -> Json<Vec<ModelE
 pub(super) async fn models_with(
     state: &AppState,
     build_client: leviath_providers::provider::HttpClientFactory<'_>,
+    query: &ModelsQuery,
 ) -> Json<Vec<ModelEntry>> {
-    Json(list_models_from_config(&state.current_config(), build_client).await)
+    let mut models = list_models_from_config(&state.current_config(), build_client).await;
+    // Filtered here rather than left to the caller because the interesting
+    // case is two providers serving the *same* model ids: `openai` and
+    // `codex` both answer to `gpt-5.5`, and they bill to different places.
+    // A client that wants one of them should be able to ask for it rather
+    // than fetch both and match on a string it had to know.
+    if let Some(provider) = query.provider.as_deref() {
+        models.retain(|m| m.provider == provider);
+    }
+    Json(models)
 }
 
 /// Every model every configured provider reports, as `provider/id`: what the
@@ -573,6 +591,92 @@ mod tests {
             providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         }
+    }
+
+    /// `?provider=` narrows the listing, which is what makes two providers
+    /// serving the same model id tellable apart.
+    ///
+    /// That is the real case, not a hypothetical one: `openai` and `codex`
+    /// both answer to `gpt-5.5` and bill to entirely different places. This
+    /// stands two gateways up at dead ports with the same model in each, so
+    /// the ids collide exactly the way those two do - a client keying on `id`
+    /// alone would collapse them into one row and whichever it kept would
+    /// decide what the user pays.
+    #[tokio::test]
+    async fn the_model_listing_can_be_narrowed_to_one_provider() {
+        use crate::config::{ModelProviderConfig, ModelProviderKind};
+
+        let mut config = Config::default();
+        for name in ["alpha", "zeta"] {
+            config.model_providers.insert(
+                name.to_string(),
+                ModelProviderConfig {
+                    kind: Some(ModelProviderKind::OpenaiCompatible),
+                    // Nothing listens, so each falls back to the models its
+                    // entry names rather than asking a server.
+                    base_url: Some("http://127.0.0.1:1/v1".to_string()),
+                    models: Some(vec!["shared-model".to_string()]),
+                    ..Default::default()
+                },
+            );
+        }
+        let (tx, _) = broadcast::channel::<ServerEvent>(64);
+        let state = AppState {
+            update_check: Default::default(),
+            update_jobs: Default::default(),
+            config: crate::commands::serve::testutil::fixed_config(config),
+            event_tx: tx,
+            control: crate::commands::serve::testutil::no_daemon_client(),
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            providers: crate::commands::serve::providers::ProviderAdmin::default(),
+            limits: Default::default(),
+        };
+        let build = leviath_providers::provider::build_http_client;
+
+        // Unfiltered: the same id under both providers.
+        let Json(all) = super::models_with(&state, &build, &Default::default()).await;
+        // Sorted: the registry's iteration order is not the contract here,
+        // the pair of entries under one id is.
+        let mut shared: Vec<&str> = all
+            .iter()
+            .filter(|m| m.id == "shared-model")
+            .map(|m| m.provider.as_str())
+            .collect();
+        shared.sort_unstable();
+        let listed: Vec<String> = all
+            .iter()
+            .map(|m| format!("{}/{}", m.provider, m.id))
+            .collect();
+        assert_eq!(shared, ["alpha", "zeta"], "{listed:?}");
+
+        // Filtered: one of them, and the id is still there.
+        let Json(narrowed) = super::models_with(
+            &state,
+            &build,
+            &super::ModelsQuery {
+                provider: Some("zeta".to_string()),
+            },
+        )
+        .await;
+        let got: Vec<String> = narrowed
+            .iter()
+            .map(|m| format!("{}/{}", m.provider, m.id))
+            .collect();
+        assert_eq!(narrowed.len(), 1, "{got:?}");
+        assert_eq!(narrowed[0].provider, "zeta");
+        assert_eq!(narrowed[0].id, "shared-model");
+
+        // A provider this machine does not have lists nothing, rather than
+        // erroring: "no models" is the honest answer.
+        let Json(none) = super::models_with(
+            &state,
+            &build,
+            &super::ModelsQuery {
+                provider: Some("not-a-provider".to_string()),
+            },
+        )
+        .await;
+        assert!(none.is_empty());
     }
 
     fn test_state() -> AppState {
@@ -1994,9 +2098,11 @@ mod tests {
             providers: crate::commands::serve::providers::ProviderAdmin::default(),
             limits: Default::default(),
         };
-        let Json(models) = super::models_with(&state, &|_t| {
-            Err(leviath_providers::provider::malformed_url_error())
-        })
+        let Json(models) = super::models_with(
+            &state,
+            &|_t| Err(leviath_providers::provider::malformed_url_error()),
+            &Default::default(),
+        )
         .await;
         assert!(models.is_empty());
     }

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -381,6 +381,17 @@ impl ApiLimits {
     }
 }
 
+/// Query parameters for `GET /api/models`.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct ModelsQuery {
+    /// Only models this provider serves. Absent lists every provider's.
+    ///
+    /// A name nothing serves lists nothing, rather than 404ing: the set of
+    /// providers is whatever this machine has configured, so "no models" is
+    /// the honest answer to asking about one it has not.
+    pub(super) provider: Option<String>,
+}
+
 /// Body of `PUT /api/config` (admin-only). Every field is optional; a present
 /// field is written, an absent one is left untouched. Mirrors what `lev setup`
 /// writes, so a newcomer can configure providers entirely from the browser.

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -289,10 +289,18 @@ fn no_thinking_extra(provider: &str) -> serde_json::Value {
         "openrouter" => serde_json::json!({ "reasoning": { "enabled": false } }),
         // Every model on the Codex route is a reasoning model, so a title
         // call left alone spends its whole 256-token budget thinking and
-        // returns nothing. The route rejects `effort: "none"` for a model
-        // that has reasoning, so this asks for the least of it instead.
+        // returns nothing. This asks for the least of it instead.
+        //
+        // `"low"`, not `"minimal"` and not `"none"`: the accepted set is per
+        // model, and both ends of it are unportable. `gpt-5.5` refuses
+        // `minimal` and names its set - "Supported values are: 'none', 'low',
+        // 'medium', 'high', and 'xhigh'" - while a model that must reason
+        // refuses `none`. `low` is in every set this route has shown us, and
+        // a title that arrives beats a cheaper one that 400s. This shipped as
+        // `minimal`, and every `codex/gpt-5.5` run came out untitled with the
+        // reason visible only in `meta.json`'s `title_error`.
         "codex" => serde_json::json!({
-            "reasoning": { "effort": "minimal" },
+            "reasoning": { "effort": "low" },
             "text": { "verbosity": "low" }
         }),
         _ => serde_json::Value::Null,
@@ -1790,13 +1798,23 @@ mod tests {
         );
         // Every model on the Codex route reasons, so left alone a title call
         // spends its whole 256-token budget thinking and returns nothing.
-        assert_eq!(
-            title_request("t", "codex", "gpt-5.6-sol").extra,
-            serde_json::json!({
-                "reasoning": { "effort": "minimal" },
-                "text": { "verbosity": "low" }
-            })
-        );
+        //
+        // The effort is the same for every model on the route, and it is
+        // `low` rather than the cheaper `minimal`: `gpt-5.5` answers 400 to
+        // `minimal` and names its set, which has `low` in it. Sending a value
+        // one model refuses costs the title outright, so the portable value
+        // wins over the cheap one - and asserting it for both models is what
+        // says that out loud.
+        for model in ["gpt-5.6-sol", "gpt-5.5"] {
+            assert_eq!(
+                title_request("t", "codex", model).extra,
+                serde_json::json!({
+                    "reasoning": { "effort": "low" },
+                    "text": { "verbosity": "low" }
+                }),
+                "{model}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -218,7 +218,7 @@ handle that on all of them rather than on a few. The body is a line of plain tex
 | `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question. See [below](#answering-a-question) |
 | `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation. The listing is paginated and takes `q`; the detail carries the manifest, the regions and the [fan-out limits](#fan-out-limits) |
 | `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key. A `PUT` that changes a provider key, a gateway, `default_provider` or [`default_model`](#the-default-model) applies to the next run spawned, with no daemon restart |
-| `GET /api/models` | Enumerate models, with each one's token limits and where they came from. An OpenAI-compatible gateway's detected models are listed under the gateway's name |
+| `GET /api/models?provider=` | Enumerate models, with each one's token limits and where they came from. An OpenAI-compatible gateway's detected models are listed under the gateway's name. `provider` narrows the listing to one - see [below](#two-providers-one-model-id) |
 | `POST /api/models/probe` *(admin)* | Ask an OpenAI-compatible server what it serves before writing a gateway for it: `{"base_url", "api_key"?, "headers"?}` → `{"models": [ids]}`, or 502 carrying the server's own error text. See [below](#gateways) |
 | `GET /api/providers` · `POST …/{name}/login` *(admin)* · `/logout` *(admin)* · `/check` *(admin)* | The providers that sign in with a browser instead of taking a key, and the sign-in itself. See [below](#signing-in-to-a-subscription-provider) |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
@@ -937,6 +937,42 @@ without an `agent`, since the answer is the same either way.
 
 Each listed provider carries a `provider` object with what its leading `// @` comments declare:
 `description`, `default_model`, `max_context_tokens`, `max_output_tokens` and `supports_streaming`.
+
+## Two providers, one model id
+
+`GET /api/models` returns a flat list, and each entry carries the `provider`
+that serves it. That matters more than it looks: **`openai` and `codex` serve
+the same model ids.** Both answer to `gpt-5.5`, and they bill to entirely
+different places - one to an API balance, one to a ChatGPT subscription.
+
+So `id` is not a key. `provider` + `id` is:
+
+```json
+[
+  { "id": "gpt-5.5", "provider": "openai", "pricing": { "input": 1.25, "output": 10.0 } },
+  { "id": "gpt-5.5", "provider": "codex",  "pricing": { "input": 0.0,  "output": 0.0  } }
+]
+```
+
+A client keying a picker on `id` alone silently collapses those two into one
+row, and whichever it kept decides what the user pays. Build the key the way a
+blueprint names a model - `provider/id`, the same `codex/gpt-5.5` that goes in
+`models = [...]`.
+
+`?provider=` asks the server instead:
+
+```
+GET /api/models?provider=codex     only the subscription's models
+GET /api/models?provider=openai    only the keyed ones
+```
+
+A provider this machine has not configured lists nothing rather than 404ing:
+the set of providers is whatever the config has, so "no models" is the honest
+answer to asking about one it does not have.
+
+The `pricing` on a Codex entry is a real zero rather than an absent one - the
+marginal cost of a subscription call is nothing, and `null` there would mean
+"unknown", which is a different thing a console should draw differently.
 
 ## Signing in to a subscription provider
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2021,6 +2021,17 @@
     },
     "/api/models": {
       "get": {
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Only models this provider serves. `openai` and `codex` serve the same model ids and bill to different places, so `provider` and `id` together are the key, not `id` alone. A provider this machine has not configured lists nothing rather than 404ing."
+          }
+        ],
         "tags": [
           "config"
         ],

--- a/xtask/src/codex_catalog.rs
+++ b/xtask/src/codex_catalog.rs
@@ -1,0 +1,253 @@
+//! Whether the compiled Codex model catalog still matches what OpenAI ships.
+//!
+//! The Codex route has no `/models` endpoint, so
+//! `crates/leviath-providers/src/codex/catalog.rs` carries the list as a
+//! compiled table. A table nobody checks is a table that rots, and the two
+//! ways it rots are both quiet: a model withdrawn or renamed stays offered
+//! and fails at the first call, and a model newly served stays unreachable -
+//! `serves_model` refuses it locally, so somebody pays for a subscription
+//! that includes a model Leviath will not route to.
+//!
+//! There is no authoritative source to fix that from. Which models Codex
+//! serves is a product decision published nowhere, and only an authenticated
+//! ChatGPT session can enumerate them. So this does not rewrite the table; it
+//! reads the same OpenRouter catalogue `prices` already fetched and reports
+//! what looks wrong, every Monday, where somebody will see it.
+//!
+//! Two directions, and they are not equally trustworthy:
+//!
+//! * a catalog id no price source knows is probably renamed or withdrawn, and
+//!   is worth acting on. Codex-only models are exempt: `gpt-5.3-codex-spark`
+//!   is real and OpenRouter will never list it;
+//! * an OpenAI model in the same family that the catalog lacks *may* be newly
+//!   served, or may be a model Codex does not offer at all. OpenRouter lists
+//!   every OpenAI model, most of which Codex has never served, so this half is
+//!   a prompt to check rather than a finding.
+
+use anyhow::{Context, Result};
+
+use super::Prices;
+
+/// The family the Codex route serves. Narrower than "every OpenAI model",
+/// which would report dozens of irrelevant ids every week.
+const FAMILY: &str = "gpt-5.";
+
+/// A model whose name says it is Codex's own, and so will never appear in a
+/// public price catalogue.
+fn is_codex_only(id: &str) -> bool {
+    id.contains("codex")
+}
+
+/// The `gpt-5.N` generation of an id, as `N`.
+///
+/// `None` for anything outside the family, which is most of what OpenAI
+/// publishes.
+fn generation(id: &str) -> Option<u32> {
+    let rest = id.strip_prefix(FAMILY)?;
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+/// The model ids in `catalog.rs`, read from the source rather than linked.
+///
+/// `xtask` deliberately depends on no Leviath crate - it is the tool that
+/// checks them, and every `cargo xtask docs` would otherwise rebuild the
+/// provider crate first. The shape parsed here is the one the file declares:
+/// `("id", "Display Name"),` rows between the `CATALOG` binding and its `];`.
+pub fn catalog_ids(source: &str) -> Result<Vec<String>> {
+    let (_, rest) = source
+        .split_once("CATALOG: &[(&str, &str)] = &[")
+        .context("codex catalog: no CATALOG binding")?;
+    let (body, _) = rest
+        .split_once("];")
+        .context("codex catalog: CATALOG is not terminated")?;
+    let mut ids = Vec::new();
+    for row in body.split("(\"").skip(1) {
+        let Some((id, _)) = row.split_once('"') else {
+            continue;
+        };
+        ids.push(id.to_string());
+    }
+    if ids.is_empty() {
+        anyhow::bail!("codex catalog: CATALOG parsed as empty");
+    }
+    Ok(ids)
+}
+
+/// What looks stale about `ids`, given what the price sources list.
+///
+/// Reported, never written: see the module note on why there is nothing to
+/// write from.
+pub fn drift(ids: &[String], openrouter: &Prices) -> Vec<String> {
+    let openai: Vec<&str> = openrouter
+        .keys()
+        .filter(|(vendor, _)| vendor == "openai")
+        .map(|(_, id)| id.as_str())
+        .collect();
+
+    // Only this generation and later are worth asking about. OpenAI still
+    // publishes prices for every `gpt-5.1`, `5.2` and `5.4` variant it ever
+    // shipped, and Codex serves none of them: without a floor this reported
+    // a dozen models a week, which is a report nobody reads. The floor moves
+    // on its own as the catalog does.
+    let floor = ids.iter().filter_map(|id| generation(id)).max();
+
+    let mut report = Vec::new();
+    for id in ids {
+        // Covered by a *prefix*, not only by an exact match, because that is
+        // how the price table is read: `gpt-5.6` prices `gpt-5.6-sol`, and a
+        // vendor that publishes the family without the variant should not
+        // have every variant reported as withdrawn, every week, for ever.
+        let known = openai
+            .iter()
+            .any(|listed| id == listed || id.starts_with(listed));
+        if is_codex_only(id) || known {
+            continue;
+        }
+        report.push(format!(
+            "codex: '{id}' is in the catalog and no price source lists it - renamed or withdrawn?"
+        ));
+    }
+    for id in &openai {
+        // Symmetric to the rule above: the family name itself is covered when
+        // the catalog serves variants of it. OpenRouter prices `gpt-5.6`, the
+        // catalog serves `gpt-5.6-sol` and friends, and asking every Monday
+        // whether Codex serves `gpt-5.6` is the same noise in the other
+        // direction.
+        let covered = ids
+            .iter()
+            .any(|known| known == id || known.starts_with(*id));
+        let current = match (generation(id), floor) {
+            (Some(generation), Some(floor)) => generation >= floor,
+            // No floor means an empty catalog, which `catalog_ids` refuses,
+            // and no generation means the id is outside the family.
+            _ => false,
+        };
+        if !current || covered {
+            continue;
+        }
+        report.push(format!(
+            "codex: '{id}' is listed by OpenAI and not in the catalog - does Codex serve it?"
+        ));
+    }
+    report.sort();
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Rate;
+    use super::*;
+
+    fn priced(ids: &[&str]) -> Prices {
+        ids.iter()
+            .map(|id| {
+                (
+                    ("openai".to_string(), (*id).to_string()),
+                    Rate {
+                        input: 1.0,
+                        cache_read: None,
+                        cache_write: None,
+                        output: 2.0,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// The parser reads the ids and not the display names beside them.
+    #[test]
+    fn the_catalog_parses_to_its_ids() {
+        let source = r#"
+            pub(crate) const CATALOG: &[(&str, &str)] = &[
+                ("gpt-5.6-sol", "GPT-5.6 Sol"),
+                ("gpt-5.5", "GPT-5.5"),
+            ];
+        "#;
+        assert_eq!(catalog_ids(source).unwrap(), ["gpt-5.6-sol", "gpt-5.5"]);
+    }
+
+    /// A file that does not hold what this expects fails loudly. A silent
+    /// empty answer would report every model as newly served, every week.
+    #[test]
+    fn a_catalog_it_cannot_read_is_an_error() {
+        for source in [
+            "nothing like a catalog here",
+            "pub(crate) const CATALOG: &[(&str, &str)] = &[",
+            "pub(crate) const CATALOG: &[(&str, &str)] = &[];",
+        ] {
+            assert!(catalog_ids(source).is_err(), "{source}");
+        }
+    }
+
+    /// The real catalog parses. Compiled in, so this fails the day the shape
+    /// of that file changes rather than the Monday after.
+    #[test]
+    fn the_shipped_catalog_parses() {
+        let source = include_str!("../../crates/leviath-providers/src/codex/catalog.rs");
+        let ids = catalog_ids(source).expect("the shipped catalog parses");
+        assert!(ids.iter().any(|id| id.starts_with("gpt-5")), "{ids:?}");
+    }
+
+    /// A variant the sources price under the family name is not missing.
+    ///
+    /// This is the noise the check would otherwise generate for ever:
+    /// OpenRouter prices `gpt-5.6`, Codex serves `gpt-5.6-sol`, and an exact
+    /// comparison calls that withdrawn every Monday.
+    #[test]
+    fn a_variant_covered_by_its_family_is_not_reported() {
+        let ids = vec!["gpt-5.6-sol".to_string(), "gpt-5.6-terra".to_string()];
+        assert!(drift(&ids, &priced(&["gpt-5.6"])).is_empty());
+    }
+
+    /// A catalog id nothing lists is worth saying; a Codex-only one is not.
+    #[test]
+    fn an_id_no_source_knows_is_reported_unless_it_is_codexs_own() {
+        let ids = vec![
+            "gpt-5.5".to_string(),
+            "gpt-5.9-withdrawn".to_string(),
+            "gpt-5.3-codex-spark".to_string(),
+        ];
+        let report = drift(&ids, &priced(&["gpt-5.5"]));
+        assert_eq!(report.len(), 1, "{report:?}");
+        assert!(report[0].contains("gpt-5.9-withdrawn"), "{report:?}");
+        assert!(report[0].contains("renamed or withdrawn"));
+    }
+
+    /// A new model in the family is a question, and one outside it is not
+    /// even that: OpenRouter lists every OpenAI model.
+    #[test]
+    fn a_new_family_member_is_asked_about_and_an_outsider_is_not() {
+        let ids = vec!["gpt-5.5".to_string()];
+        let report = drift(&ids, &priced(&["gpt-5.5", "gpt-5.6-cyber", "gpt-4o", "o3"]));
+        assert_eq!(report.len(), 1, "{report:?}");
+        assert!(report[0].contains("gpt-5.6-cyber"), "{report:?}");
+        assert!(report[0].contains("does Codex serve it"));
+    }
+
+    /// A model from a generation the catalog has moved past is not a
+    /// question. OpenAI still prices every variant it ever shipped, and
+    /// without this the check reported a dozen of them a week.
+    #[test]
+    fn an_older_generation_is_not_asked_about() {
+        let ids = vec!["gpt-5.6-sol".to_string()];
+        // `gpt-5.6` covers the catalog's own id; the rest are generations it
+        // has moved past.
+        let sources = priced(&["gpt-5.6", "gpt-5.2-pro", "gpt-5.4-nano"]);
+        let report = drift(&ids, &sources);
+        assert!(report.is_empty(), "{report:?}");
+
+        // The floor is the catalog's own newest, so the same sources against
+        // an older catalog do produce questions.
+        let older_catalog = vec!["gpt-5.2-pro".to_string()];
+        let report = drift(&older_catalog, &sources);
+        assert_eq!(report.len(), 2, "{report:?}");
+    }
+
+    /// A catalog that matches its sources says nothing at all.
+    #[test]
+    fn a_current_catalog_reports_nothing() {
+        let ids = vec!["gpt-5.5".to_string(), "gpt-5.3-codex-spark".to_string()];
+        assert!(drift(&ids, &priced(&["gpt-5.5"])).is_empty());
+    }
+}

--- a/xtask/src/prices.rs
+++ b/xtask/src/prices.rs
@@ -638,6 +638,15 @@ pub fn run_with(mode: PricesMode, fetch: Fetch, path: &Path, today: &str) -> Res
     for d in &merged.disagreements {
         println!("? {d} (not written)");
     }
+    // The Codex model catalog rides along on this fetch. It is a compiled
+    // table with no endpoint behind it, so nothing here can rewrite it - but
+    // the catalogue already in hand is enough to say when it looks stale, and
+    // this is the job that runs every week. Reported, never fatal: the second
+    // half of the report is a question rather than a finding, and a weekly
+    // job that fails on a question is a weekly job somebody turns off.
+    for line in codex_catalog::drift(&codex_ids()?, &openrouter) {
+        println!("? {line}");
+    }
     let added = merged
         .changes
         .iter()
@@ -680,6 +689,13 @@ pub fn run_with(mode: PricesMode, fetch: Fetch, path: &Path, today: &str) -> Res
     }
 }
 
+/// The Codex catalog's model ids, read from the shipped source.
+fn codex_ids() -> Result<Vec<String>> {
+    codex_catalog::catalog_ids(include_str!(
+        "../../crates/leviath-providers/src/codex/catalog.rs"
+    ))
+}
+
 /// The workspace root, from this crate's manifest directory.
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -708,6 +724,13 @@ pub fn run(mode: PricesMode) -> Result<()> {
         Err(err) => Err(err),
     }
 }
+
+/// The Codex model catalog check, fed by the same fetch as the prices above.
+/// Declared here rather than in `main.rs`, which is coverage-excluded and
+/// guarded in CI for that reason - a module belonging to this task has no
+/// business changing the binary's entrypoint.
+#[path = "codex_catalog.rs"]
+pub mod codex_catalog;
 
 #[cfg(test)]
 #[path = "prices_tests.rs"]


### PR DESCRIPTION
Three things, all from checking that run `McQueen-1788154098-7381590bc0bd` actually worked. It did — and it exposed a bug.

## The run

`codex/gpt-5.5`, status `complete`, 484 prompt / 36 completion tokens, one tool call, three seconds, `cost_usd: 0.0`. Real inference billed to the subscription, and the joke came back.

But the run has **no title**, and `meta.json` said why:

```
codex/gpt-5.5 failed: API error: HTTP 400: Unsupported value: 'minimal' is not
supported with the 'gpt-5.5' model. Supported values are: 'none', 'low',
'medium', 'high', and 'xhigh'.
```

The titling extra asked for `effort: "minimal"`. The reasoning behind it was right — every model on this route thinks, and a title call left alone spends its whole 256-token budget doing it — but the accepted set is **per model**, and both ends are unportable: `gpt-5.5` refuses `minimal`, and a model that must reason refuses `none`. `low` is in every set the route has shown us, and a title that arrives beats a cheaper one that 400s. The test now asserts it for two models rather than one.

## Filtering openai from codex

They serve **the same model ids**. Both answer to `gpt-5.5`, and they bill to entirely different places. A flat `GET /api/models` handed a console two `gpt-5.5` rows, so anything keying on `id` alone collapsed them — and whichever it kept decided what the user paid.

`?provider=` asks the server instead:

```
GET /api/models?provider=codex     only the subscription's models
GET /api/models?provider=openai    only the keyed ones
```

A provider this machine has not configured lists nothing rather than 404ing. The entries always carried `provider`, so the key was available — the docs now say so outright, with the collision spelled out, because two `gpt-5.5` rows do not look like a trap until they are one.

## Keeping the Codex catalog honest

The route has no `/models` endpoint, so the model list is a compiled table, and both ways it rots are quiet: a withdrawn model stays offered and fails at the first call, and a newly-served one stays unreachable because `serves_model` refuses it locally.

Nothing can rewrite that automatically — which models Codex serves is published nowhere, and only an authenticated session can enumerate them. But `cargo xtask prices` already fetches OpenAI's public catalogue **every Monday**, so the check rides along on that fetch. It reports; it never writes and never fails the job.

Getting the signal usable took two rules, both of which started as noise:

- **Prefix matching, both directions.** OpenRouter prices `gpt-5.6` while Codex serves `gpt-5.6-sol`, which read as "withdrawn" every week.
- **A generation floor** at the catalog's own newest. OpenAI still prices every `gpt-5.1`, `5.2` and `5.4` variant it ever shipped — twelve questions a week.

With both, measured against the committed price table, it leaves exactly two lines:

```
? codex: 'gpt-5.6-cyber' is listed by OpenAI and not in the catalog - does Codex serve it?
? codex: 'gpt-5.6-sol-pro' is listed by OpenAI and not in the catalog - does Codex serve it?
```

Those are real questions I cannot answer from here: only the account knows. They are not added to the catalog on a guess.

`xtask` still depends on no Leviath crate — it is the tool that checks them, and linking one would make every `cargo xtask docs` build the provider crate first — so the catalog is read from its source, with a test that parses the shipped file so a shape change fails at once rather than the Monday after.

## Verification

All 13 packages at 100% region coverage, clippy clean, structure/docs gates pass, full suite green. `main.rs` untouched, so no label needed.
