### PR TITLE
docs: close the gaps the hook and validator batch left behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,66 @@ same list.
 
 ## Unreleased
 
+### Breaking
+
+- A Rhai output validator that cannot run - it threw, ran past its operation
+  budget, or returned something that is neither `()` nor a string - now
+  rejects the submission by default, with the script's own error sent back to
+  the model as retry feedback. It used to accept the answer unchecked, which
+  shipped exactly the submissions the validator existed to catch: a validator
+  whose first line is `parse_json(content)` throws on malformed output, and
+  that throw waved the malformed answer through. Set
+  `on_validator_error = "accept"` on the output block to restore the old
+  acceptance, for blueprints that would rather end with an unchecked answer
+  than risk ending with none - the tradeoff being that under the default a
+  genuine script bug reads as "this answer is wrong" on every retry. The
+  broken script is flagged on the run (`flags.broken_scripts`) in both modes.
+  A declared JSON `schema` that fails to compile still skips its check and
+  records the submission unchecked, deliberately (#756).
+- `false` from a custom region's `on_write` hook is a surfaced rejection now,
+  not a silent drop that reported success. A write from the model
+  (`context_write`, `context_append`, a routed tool result) gets a real tool
+  error carrying the refusal and its reason, and nothing is stored; a
+  framework write (an assistant turn, a delivered message, a nudge) is stored
+  unchanged with a warning, so a script can no longer silently delete the
+  conversation record. A script that relied on `false` to filter framework
+  writes should do that filtering in `render` or `on_overflow` instead. The
+  hook also gained an upsert story: `ctx.entry` carries the write's `key`, an
+  accept map may override it (`#{ content: "...", key: "..." }`), and `render`
+  sees a last-wins view per key while shadowed entries stay in the store until
+  eviction releases them (#754).
+
+### Fixed
+
+- Passing an `output_format` that differs from what the blueprint declares
+  still retires its Rhai validator and JSON schema - a check written for one
+  shape cannot judge another - but no longer does so silently: `lev run` warns
+  on stderr, the REST spawn response carries an additive `warnings` array
+  naming each retired check, and the daemon logs a line for every spawn path,
+  sub-agent and ACP spawns included (#755).
+- A script provider's reported usage goes through the same normalization the
+  native parsers apply: `prompt_tokens` is read as the whole prompt with the
+  cache counts inside it, so an OpenAI-shaped usage object forwarded verbatim
+  is no longer double-counted, and a missing `total_tokens` is derived from
+  the parts instead of being recorded as zero. Rows a script's `list_models`
+  answers now also count as a real provider listing in `lev models list`
+  (`"learned": true` under `--json`) instead of being mislabeled as rows from
+  this build's table (#752).
+
 ### Added
 
+- A `blueprint:` prefix on a seed path reads from the blueprint's own
+  directory instead of the run's workdir
+  (`seed = { files = ["blueprint:config/style.md"] }`, and the `glob` and
+  `rhai` forms the same way), so an agent can ship the files it seeds from.
+  The prefix is fenced inside that directory with no `[read_paths]` escape,
+  because a blueprint does not ship files outside itself (#751).
+- `lev validate` and `lev test` compile output validators and stage hook
+  scripts beside the region scripts they already checked, so a script that
+  would fail the spawn fails the command first. `lev validate` and
+  `lev doctor` also name config keys nothing reads and `[model_providers.*]`
+  script entries whose `.rhai` file is not on disk, along with the path that
+  was looked for (#753).
 - `GET /api/config` reports `default_model`, the model every stage runs on
   while it is set, and reports it as `null` rather than dropping the key when
   nothing is pinned. A console could read `default_provider` and not this, so

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -719,11 +719,12 @@ pub struct RunFlags {
     ///
     /// A script that will not compile, or that throws where the runtime has to
     /// carry on regardless, is skipped rather than fatal - which is the right
-    /// call and was also completely silent. An output validator that throws is
-    /// the case that prompted this: the submission is recorded *unchecked*,
-    /// because reading a script bug as "the answer is wrong" would burn the
-    /// retry budget on it and end the run with nothing. So the run finishes,
-    /// looks successful, and the only trace is a line in the daemon log.
+    /// call and used to be completely silent; this list is the trace. An
+    /// output validator that cannot run is the exception: by default the
+    /// submission is rejected and the script's own error goes back to the
+    /// model as retry feedback, while `on_validator_error = "accept"` records
+    /// the submission unchecked and leaves this list as the only trace of an
+    /// answer nothing checked. The script is named here in both modes.
     ///
     /// Named rather than counted, because the useful question is which one -
     /// the answer tells you which file to open.

--- a/docs/content/agent-client-protocol.md
+++ b/docs/content/agent-client-protocol.md
@@ -70,7 +70,7 @@ Flags (run `lev agent-client --help` for the authoritative list):
 | `--allow <tool>` | Allow a tool outright. Repeatable. |
 | `--max-depth <n>` | Override the blueprint's max sub-agent tree depth. |
 | `--no-seed-commands` | Refuse the blueprint's `seed = { command = "..." }` regions, which run at spawn before any approval prompt. |
-| `--output-format <label>` | Ask for the [final output](/docs/outputs) in this shape. Any label works. |
+| `--output-format <label>` | Ask for the [final output](/docs/outputs) in this shape. Any label works. One that differs from the blueprint's retires its declared validator and schema. |
 | `--output-instructions <text>` | Extra guidance about that shape. |
 
 ## The agent's answer

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -264,6 +264,17 @@ errors. `tail` is a byte budget for how much of the end you get back.
 > in one shared world, so there is no process per run. If you are tracking slots from outside, read
 > [reconciling an external work queue](/docs/work-queues) first.
 
+### What a run flags about itself
+
+A run object carries a `flags` object: post-hoc diagnostics that tell an empty or degraded run
+from a healthy one without parsing its logs. Counters like `modified_file_count`, `searches_run`
+beside `searches_empty`, and `gates_forced` say whether the run actually did anything, and
+`empty_output` sums up the verdict. `flags.broken_scripts` names each Rhai script the run needed
+but could not use - an [output validator](/docs/rhai-validators#when-the-validator-itself-fails)
+that threw, say - and is the same list `lev ps` renders as `(broken script)`; the key is omitted
+while the list is empty. The flags live in the run's `meta.json`, so they come back wherever a
+run object does.
+
 ### How long a run has taken
 
 Three spans, and they answer different questions. A run paused overnight is hours old and spent

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -44,7 +44,7 @@ Spawn an agent into the daemon. `PATH` is an installed agent name, a blueprint d
 | `--no-seed-commands` | Refuse the blueprint's `seed = { command = "..." }` regions for this run |
 | `--count <N>` | Start this many runs of the same agent and task, each under its own run id, from one invocation |
 | `--json` | Print the spawned run as JSON rather than a sentence. See below |
-| `--output-format <LABEL>` | Ask for the final output in this shape. See [Final outputs](/docs/outputs) |
+| `--output-format <LABEL>` | Ask for the final output in this shape. A label that differs from what the blueprint declares retires its Rhai validator and JSON schema, with a warning on stderr. See [Final outputs](/docs/outputs) |
 | `--output-instructions <TEXT>` | Extra guidance about that shape |
 | `--output-schema <JSON\|@FILE>` | A JSON Schema the final output must satisfy |
 | `--<region> <TEXT\|@FILE>` | Seed a named context region. See below |
@@ -205,6 +205,14 @@ in three levels: an **error** exits non-zero, a **warning** does not, and a **no
 Parsing itself refuses a few things outright, before any finding is reported: a negative count
 anywhere in the file (`max_items = -1`), an unknown key under `[sandbox]`, and an unknown key in a
 stage table. Each of those errors names the key.
+
+The blueprint's scripts are compiled too, exactly as a spawn would compile them: a custom region
+script, an output validator, or a stage hook script that is missing or will not load fails the
+command, since it would fail the run. And because a clean verdict against a config the daemon
+would grumble about is worth less than it looks, the command reads your `config.toml` on the way
+past: keys nothing reads are named as warnings (usually a typo'd setting), and a
+`[model_providers.*]` script entry whose `.rhai` file is not on disk is named along with the path
+that was looked for.
 
 | Level | Code | What it means |
 |---|---|---|
@@ -367,6 +375,10 @@ asserted on, never performed, so a case can expect `write_file` without a file a
 A `tests/*.rhai` file is run instead as a script through the scripting engine, and fails the run if
 it returns `false`.
 
+Before any case runs, the blueprint's own scripts are compiled the way a spawn would compile them:
+custom region scripts, output validators, and stage hook scripts all have to load. `--dry-run`
+includes those checks, so a broken script is caught without spending anything.
+
 ### `lev models`
 
 | Command | Flags |
@@ -385,7 +397,9 @@ prints the table alone. `-r/--remote` is still accepted for older scripts and ch
 
 `--provider` naming a [Rhai script provider](/docs/rhai-providers) loads that script and calls its
 `list_models`: a script names its own catalog at run time, so there is no built-in table to read it
-from. A `--provider` that names nothing at all - no configured
+from. What it answers counts as a real provider listing, toward the trailing line and as
+`"learned": true` in `--json`. A `serves = [...]` or `[model_capabilities]` claim in your config
+never becomes a listing row at all: those feed validation, not this table. A `--provider` that names nothing at all - no configured
 provider, no row in the built-in table, no script of that name that loads - **exits non-zero**
 rather than printing an empty table, since there is nothing an empty table could be reporting.
 A provider the built-in table knows but this install has no credential for is still an empty table
@@ -402,7 +416,7 @@ Serve an agent over the [Agent Client Protocol](/docs/agent-client-protocol) as 
 | `--allow <TOOL>` | Allow one tool outright. Repeatable |
 | `--max-depth <N>` | Override the maximum sub-agent tree depth |
 | `--no-seed-commands` | Refuse the blueprint's command seeds |
-| `--output-format <LABEL>` | Ask the agent for its [final output](/docs/outputs) in this format |
+| `--output-format <LABEL>` | Ask the agent for its [final output](/docs/outputs) in this format. A differing label retires the blueprint's declared validator and schema |
 | `--output-instructions <TEXT>` | Extra instructions for that final output |
 
 ## Blueprints and packaging
@@ -686,7 +700,7 @@ rest, and the one that fails is the diagnosis.
 
 | Check | What it proves | A failure means |
 |---|---|---|
-| `config` | `config.toml` parses and a provider registry can be built | The config file is malformed |
+| `config` | `config.toml` parses and a provider registry can be built. The OK line also carries notes for a file that loads with problems in it: keys nothing reads, and `[model_providers.*]` script entries whose `.rhai` file is not on disk | The config file is malformed |
 | `resolve` | Your defaults pick a provider that is actually registered | A key is missing or misspelled |
 | `inference` | One real call reaches the model | A bad key, an unknown model id, or a billing problem |
 | `daemon` | A one-stage agent spawns over the control socket, runs, and finishes | The handoff is broken even though the credentials are fine |

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -75,6 +75,10 @@ history      = { kind = "compact_history", budget = "15%", source_region = "code
 | `checklist` | A task list whose entries carry state. Written through `todo_add` / `todo_done` / `todo_note`, never evicted, and rendered open-items-first. |
 | `custom` | Behavior defined by a Rhai script (see [Rhai regions](/docs/rhai-regions)). |
 
+A `custom` region gets keyed writes too: entries written under one key render last-wins, like
+`hashmap`, though the shadowed entries keep holding budget until something evicts them. [Rhai
+regions](/docs/rhai-regions#keyed-writes-render-as-an-upsert) has the details.
+
 An unrecognized `kind` is a hard parse error, not a silently ignored region. So is an
 unrecognized `strategy`: `strategy = "per-item"` with a hyphen is refused, rather than leaving the
 region to evict one entry at a time as if the line had not been written.

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -218,6 +218,11 @@ until one passes, so a bad correction never replaces a good answer.
 A submission is checked for well-formedness first, so "this is not even JSON" comes back before a
 list of missing properties. That is the more useful thing to hear.
 
+One asymmetry to know about: a schema that itself will not compile skips the check and records the
+submission unchecked, where a [Rhai validator](/docs/rhai-validators) that cannot run rejects by
+default. A bad schema refusing every submission would leave the run unable to finish, so it fails
+open, deliberately.
+
 ## Requiring one
 
 `require_output` makes a stage produce an answer before it moves on. `mode = "output"` sets it for

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -394,7 +394,11 @@ The three optional functions each carry their own shape. `stream(state, request,
 `{ delta, tool_calls: [{index, id, name, arguments_delta}], tokens: {...}, finish_reason }`.
 `count_tokens(state, text, model)` returns an int (Leviath falls back to a local heuristic without
 it). `list_models(state)` returns an array of
-`{ id, display_name, max_context_tokens, max_output_tokens }`.
+`{ id, display_name, max_context_tokens, max_output_tokens }`. What it answers is treated as a
+real provider listing: `lev models list` counts the rows toward its "from the providers' own
+listings" line and marks them `"learned": true` under `--json`, exactly as it does a native
+provider's catalog. A `serves = [...]` or `[model_capabilities]` claim in the config is not - those
+feed validation and never become listing rows.
 
 ### Counting tokens remotely
 

--- a/docs/content/rhai-regions.md
+++ b/docs/content/rhai-regions.md
@@ -111,7 +111,18 @@ one). Return:
 | `#{ action: "reject", reason: "..." }` | Reject, and tell the writer why |
 | `#{ content: "...", key: "..." }` | Accept; both fields optional (`action: "accept"` implied). `content` replaces the text, `key` stores the entry under a different key than the write named |
 
-The map forms use the same vocabulary as [stage hooks](/docs/rhai-hooks), on purpose.
+The map vocabulary here is `accept` and `reject`, nothing else. It is deliberately narrower than
+the [stage hook](/docs/rhai-hooks) one: a region hook has no `allow`, `retry`, `cancel`, or
+`modify`, and an unknown action is a malformed map, which **accepts the entry unchanged** with a
+warning. So `#{ action: "cancel" }` does not refuse anything; write `#{ action: "reject" }` when
+you mean no.
+
+> [!IMPORTANT]
+> `false` changed meaning. Earlier releases treated it as a silent drop that still reported
+> success to the writer. Now a write from the model gets a tool error carrying the refusal, and a
+> framework write (an assistant turn, a delivered message, a nudge) is stored unchanged with a
+> warning. A script that used `false` to filter framework writes out of the region should do that
+> filtering in `render` or `on_overflow` instead.
 
 What a rejection does depends on who is writing. When the model writes through `context_write` or
 `context_append`, or a tool result is routed into the region, the tool result reports the refusal

--- a/docs/content/rhai-validators.md
+++ b/docs/content/rhai-validators.md
@@ -89,6 +89,10 @@ whole budget against a check that can never pass. The setting works at both leve
 and `[stages.<name>.output]`, and the stage's value wins. Anything other than `reject` or `accept`
 refuses to load.
 
+The setting governs validators only. A declared JSON `schema` that fails to compile keeps its old
+fail-open behaviour: the check is skipped and the submission recorded unchecked, so one bad schema
+cannot make a run unable to finish.
+
 In both modes the run flags the script:
 
 | Surface | What you see |
@@ -111,8 +115,10 @@ own, so a script that will not load is something you can find before a run needs
 Only when the format it was written for is the one in effect.
 
 A validator describes one format. If a caller overrides the format at launch, your validator is
-retired along with any JSON Schema, because neither describes what is now being produced. The caller
-can supply their own checks with their own format.
+retired along with any JSON Schema, because neither describes what is now being produced. The
+caller can bring a JSON Schema of their own (`--output-schema`, or `output_schema` on the API); a
+replacement validator is the one check no request can supply, so a reshaped run keeps only whatever
+schema came with it.
 
 ```mermaid
 flowchart TB

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -192,8 +192,13 @@ The rules that keep this safe:
   into the workdir when the pattern is compiled.
 - **Taint rises.** When a grant is active, the read tools are classified `Private` for that
   agent, so taint tracking treats out-of-workdir content with more suspicion, not less.
-- Rhai script tools have their own `read_file` and it stays workdir-confined; `[read_paths]`
-  applies to the built-in file tools only.
+- **Seeds answer to the same fence.** A `seed = { files = [...] }`, `glob` or `rhai` path that
+  resolves outside the workdir is refused at spawn unless a declared and granted `[read_paths]`
+  entry covers it, on the same reasoning as `read_file`: the blueprint chose that path, not you.
+  A `blueprint:`-prefixed seed reads only from the blueprint's own directory, and no grant can
+  let it out - a blueprint does not ship files outside itself.
+- Rhai script tools have their own `read_file` and it stays workdir-confined; among the tools,
+  `[read_paths]` applies to the built-in file tools only.
 
 Pick the run's workdir itself with `lev run <agent> --workdir <dir>` (defaults to the directory
 you ran the command from).

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -59,7 +59,9 @@ child of the capacity it needs to finish.
 
 `seed_context` injects starting material into the child's first pinned region, and
 `output_format` / `output_instructions` ask it for a particular shape of answer, overriding its
-blueprint's.
+blueprint's. Override with care: an `output_format` that differs from what the child's blueprint
+declares retires any Rhai validator and JSON schema it declared, since a check written for one
+shape cannot judge another, and the only warning goes to the daemon log.
 
 ## Fan-out
 

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -195,7 +195,8 @@ model but executed by the engine's tool registry, since they act on the shared a
 
 A child reports whatever it submitted through [`submit_output`](/docs/outputs). A child that
 submitted nothing says so, rather than returning an empty result. `output_format` asks the child for
-a particular shape, overriding what its blueprint declares.
+a particular shape, overriding what its blueprint declares. A label that differs retires the
+child's declared validator and schema, and the warning appears only in the daemon log.
 
 ## Environment
 

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -251,7 +251,7 @@
         },
         "schema": {
           "type": "object",
-          "description": "A JSON Schema describing the answer's shape. Separate from format, which asks only whether the answer parses. A failing submission is refused back to the model to correct."
+          "description": "A JSON Schema describing the answer's shape. Separate from format, which asks only whether the answer parses. A failing submission is refused back to the model to correct. A schema that itself will not compile skips the check and records the submission unchecked, unlike a validator, whose failures follow on_validator_error."
         },
         "validator": {
           "type": "string",
@@ -262,6 +262,7 @@
             "reject",
             "accept"
           ],
+          "default": "reject",
           "description": "What happens to a submission when the validator itself cannot run: it threw, ran out of operations, or returned the wrong type. reject (the default) refuses the submission and sends the script's error back to the model as retry feedback; accept records the answer unchecked. The broken script is flagged on the run either way."
         }
       }
@@ -700,11 +701,11 @@
           "properties": {
             "glob": {
               "type": "string",
-              "description": "Concatenated contents of the workdir files matching this pattern."
+              "description": "Concatenated contents of the files matching this pattern, expanded against the workdir, or against the blueprint's own directory with a blueprint: prefix. Neither base can be escaped: each match is fenced inside it, with [read_paths] as the only way out for the workdir form and no way out at all for the prefixed one."
             },
             "files": {
               "type": "array",
-              "description": "Concatenated contents of these workdir-relative paths.",
+              "description": "Concatenated contents of these paths, resolved against the workdir, or against the blueprint's own directory with a blueprint: prefix. Neither base can be escaped: a path outside it is refused at spawn, with [read_paths] as the only way out for the workdir form and no way out at all for the prefixed one.",
               "items": {
                 "type": "string"
               }
@@ -715,7 +716,7 @@
             },
             "rhai": {
               "type": "string",
-              "description": "A Rhai script in the workdir whose returned String fills the region."
+              "description": "A Rhai script whose returned String fills the region, resolved against the workdir, or against the blueprint's own directory with a blueprint: prefix. Neither base can be escaped: a path outside it is refused at spawn, with [read_paths] as the only way out for the workdir form and no way out at all for the prefixed one."
             },
             "command": {
               "type": "string",


### PR DESCRIPTION
A docs audit against the just-merged #751-#756 batch found the pages that had not caught up. Docs and CHANGELOG only; the one schema file touched is `docs/schema/blueprint.schema.json` (descriptions plus one `"default"` keyword), and the key drift test still passes. Every claim below was re-verified against the code before writing.

## Must-fixes

- **rhai-regions.md no longer claims the `on_write` map forms share the stage-hook vocabulary.** Regions accept only `accept`/`reject` (`custom_region.rs`), stage hooks accept `allow`/`retry`/`cancel`/`modify` (`stage_hook.rs`), and an unknown action in a region hook warns and accepts the entry unchanged - so `#{ action: "cancel" }` refused nothing while the page implied it would. The page now states the region vocabulary and contrasts it with the stage-hook one.
- **blueprint.schema.json seed descriptions** for `glob`, `files` and `rhai` said workdir-only; all three accept the `blueprint:` prefix since #751. Each now names both bases and the no-escape rule.
- **cli.md's `lev validate` section** documents what #753 added: output validators and stage hook scripts are compiled (missing/uncompilable is a hard failure), stale config keys are named, and a `[model_providers.*]` script entry with no `.rhai` on disk is named with the path looked for.
- **CHANGELOG Unreleased** gains entries for #751-#756, with the two behavior changes under `### Breaking`: #756 (a validator that cannot run now rejects by default; `on_validator_error = "accept"` restores the old acceptance) and #754 (`false` from `on_write` is a surfaced rejection, not a silent drop reported as success; framework writes accept with a warning).
- **The schema/validator asymmetry is now documented**: a declared JSON `schema` that fails to compile still skips its check and records the submission unchecked (`output_tool.rs`, deliberate), unlike a broken validator. Stated in outputs.md's schema section, beside the `on_validator_error` text in rhai-validators.md, and in the schema key's description in blueprint.schema.json.

## Smaller fixes

- security.md: fixed the "read_paths applies to the built-in file tools only" contradiction and added the seed containment story - non-prefixed seeds outside the workdir need a `[read_paths]` grant, `blueprint:` seeds have no escape at all.
- rhai-regions.md: the false-now-rejects migration note is promoted to a callout beside the return-vocabulary table instead of one row deep in the failure table.
- cli.md: `lev doctor`'s config check now mentions stale keys and missing script-provider files; `lev test` mentions the compiled validators and hook scripts.
- Check retirement on a differing `output_format` is now mentioned where callers set it: sub-agents.md and tools.md (parent-spawned children, warning goes only to the daemon log), agent-client-protocol.md, and both cli.md flag rows.
- api.md defines the run `flags` object, `flags.broken_scripts` included, which rhai-validators.md referenced but api.md never described. openapi.json untouched: no run-flags schema exists there to extend.
- blueprint.schema.json: `on_validator_error` carries `"default": "reject"`.
- rhai-validators.md no longer says a caller "can supply their own checks": only a JSON Schema can travel with a request, never a replacement validator.
- Learned listings documented in rhai-providers.md and cli.md: a script's `list_models` counts as a real provider listing (`"learned": true` in `--json`); config `serves`/`[model_capabilities]` claims never become listing rows.
- context.md's region-kind table points keyed custom-region writes at rhai-regions.md's upsert section, with the shadowed-entries-hold-budget caveat.

## Gates

`cargo xtask docs` (40 pages, 3 schemas, no problems), `cargo xtask structure`, the `leviath-core` manifest suite including `the_published_schema_and_the_parser_agree_on_every_key` (224 passed), and the pre-commit checks all pass. No production code, no `main.rs`, no version pins.
