### PR TITLE
Close the doc gaps an audit of the provider work turned up

### DIFF
--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -753,6 +753,7 @@ nothing about what gets written.
 | `--default-model <MODEL>` | Default model override |
 | `--claude-code <true\|false>` | Enable the Claude Code CLI transport. Off unless set, and the wizard does not ask about it: this flag is the way to turn it on |
 | `--claude-code-effort <LEVEL>` | `low`, `medium`, `high`, `xhigh`, or `max` |
+| `--codex <true\|false>` | Enable the Codex transport, which bills a ChatGPT subscription. Flips the switch only: interactive `lev setup` signs in from its own screen, and a non-interactive run has nobody watching a browser, so sign in with `lev auth login codex` on that path |
 | `--install-agents` | Install the bundled blueprints without asking |
 
 ```bash

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -49,7 +49,7 @@ update_check         = true          # ask whether a newer release exists
 | `default_model` | string | unset | A bare model id on `default_provider`, not `provider/model`. A leading `<default_provider>/` is dropped and named at load, so `"ollama/qwen3.8:latest"` under `default_provider = "ollama"` still works. Unset is usually the better state; over the API, `PUT /api/config` with `"default_model": null` writes it away. See [which entry a stage starts on](/docs/providers#which-entry-a-stage-starts-on) |
 | `agent_paths` | array of paths | `[]` | Searched in addition to `~/.leviath/agents` |
 | `openrouter_api_key` | string | unset | Falls back to `OPENROUTER_API_KEY` |
-| `ollama_base_url` | string | unset | Falls back to `OLLAMA_HOST`, then `http://localhost:11434` |
+| `ollama_base_url` | string | unset | Falls back to `OLLAMA_HOST`, then `http://localhost:11434`. Setting it also counts as choosing Ollama, so an install that configured it before `[providers] ollama_enabled` existed keeps working |
 | `request_timeout_secs` | integer | unset | Unset means the 15 minute ceiling. A stage's `[stages.<name>.model] request_timeout_secs` wins for that stage |
 | `taint_tracking` | bool | `false` | Turns on [taint tracking](/docs/security) for every agent. With it off, an agent can still opt in itself |
 | `batch_tool_hint` | bool | `true` | Adds a short hint telling the model it may batch independent tool calls |
@@ -99,13 +99,26 @@ openrouter_base_url = "https://gw.corp/v1"   # env fallback: OPENROUTER_BASE_URL
 claude_code_enabled = false          # opt in to the Claude Code CLI transport
 claude_code_binary  = "/usr/local/bin/claude"   # unset resolves `claude` on PATH
 claude_code_effort  = "medium"       # low | medium | high | xhigh | max
+ollama_enabled         = false      # offer Ollama; setting ollama_base_url also counts
 codex_enabled          = false      # bill inference to a ChatGPT subscription
-codex_reasoning_effort = "medium"   # none | minimal | low | medium | high | xhigh
+codex_reasoning_effort = "medium"   # low | medium | high | xhigh (see below)
 codex_verbosity        = "medium"   # low | medium | high
 codex_replay_reasoning = true       # replay each turn's reasoning on the next request
 anthropic_cache_ttl = "5m"           # 5m (default) | 1h
 fallback_order      = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-mini"]
 ```
+
+`ollama_enabled` turns Ollama on. It is opt-in like every other provider: it needs no key and
+answers on a well-known local port, which used to be reason enough to register it on every
+machine - and that made a bare model name in a blueprint resolvable against whatever happened to
+be running locally. Setting `ollama_base_url` counts as choosing it too.
+
+`codex_reasoning_effort` takes `none`, `minimal`, `low`, `medium`, `high` or `xhigh`, but **the
+route decides per model which of those it accepts**, and rejects the rest outright. `gpt-5.5`
+answers `400` to `minimal` and lists its own set as `none, low, medium, high, xhigh`; a model that
+must reason rejects `none`. `low` and above are accepted everywhere seen so far. Leviath cannot
+check this at save time - the answer differs per model and is only known by asking - so a value
+one of your models refuses shows up as a failed call rather than a rejected config.
 
 `anthropic_cache_ttl` is how long a cached prompt prefix survives. The default `5m` is free; `1h`
 costs more to write and sends the beta header it needs. It is worth the write cost for a staged

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -523,6 +523,16 @@ limit rather than guessing.
 **The model list is compiled in.** The route publishes no catalogue, so the
 context windows are this build's belief, and which models answer depends on
 your plan. `lev models list --provider codex` shows what your plan reaches.
+The compiled list is cross-checked against OpenAI's published catalogue every
+week by `cargo xtask prices`, which reports a model that looks renamed,
+withdrawn or newly served - it cannot fix the list, because what Codex serves
+is published nowhere, but it stops the table going quietly stale.
+
+**Reasoning effort is accepted per model.** `codex_reasoning_effort` takes
+`none`, `minimal`, `low`, `medium`, `high` or `xhigh`, and any given model
+takes some subset. `gpt-5.5` answers `400` to `minimal` and names its own set
+as `none, low, medium, high, xhigh`; a model that must reason rejects `none`.
+`low` and above have been accepted by everything seen so far.
 
 **Reasoning continuity is replayed by Leviath.** The route stores nothing
 server-side, so each turn's reasoning is handed back on the next request. Set

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -40,6 +40,8 @@ ollama_enabled = false
 # the grant is stored outside this file and its token renews itself.
 codex_enabled = false
 codex_originator = "leviath"
+# Accepted values differ per model: gpt-5.5 rejects "minimal", and a model
+# that must reason rejects "none". "low" and above work everywhere so far.
 codex_reasoning_effort = "medium"
 codex_verbosity = "medium"
 codex_replay_reasoning = true

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -101,6 +101,7 @@
           "type": "string"
         },
         "codex_reasoning_effort": {
+          "description": "How hard Codex thinks. Any given model accepts a subset of these and rejects the rest outright: `gpt-5.5` answers 400 to `minimal` and lists its own set as none, low, medium, high, xhigh, while a model that must reason rejects `none`. `low` and above have been accepted everywhere seen so far. Not checkable at save time - the answer differs per model and is only known by asking.",
           "enum": [
             "none",
             "minimal",


### PR DESCRIPTION
Audited every config field, CLI flag and route the Codex and Ollama work introduced against every page and schema. Mostly it was covered. Four things were not, and one was actively misleading.

| | |
|---|---|
| `--codex` | Missing from the CLI reference. `--claude-code` sat right beside it, so the omission read as "there is no such flag" |
| `ollama_enabled` | In the schema and `providers.md`, but not `configuration.md` — which is where you look up what `[providers]` takes. A reader there saw `ollama_base_url` and had no way to learn Ollama had become opt-in |
| `codex_reasoning_effort` | Documented as taking the full set, full stop — see below |
| The Codex model list | Said it was compiled in, and stopped there |

## The misleading one

`codex_reasoning_effort` was documented as `none | minimal | low | medium | high | xhigh`. Those are the values the *config* accepts. **The route decides per model which of them it will honour**, and rejects the rest with a 400.

That is exactly the trap the titling lane fell into: it asked `gpt-5.5` for `minimal`, and every run on that model came out untitled with the reason buried in `meta.json`. Anyone setting `codex_reasoning_effort = "minimal"` from the documented list would hit the same wall, on every call rather than just the title.

It now says so in all four places the setting appears — `configuration.md`, `providers.md`, the JSON schema and the example TOML — with the measured example (`gpt-5.5` names its own set as `none, low, medium, high, xhigh`; a model that must reason rejects `none`; `low` and above work everywhere seen so far) and the reason Leviath cannot catch it at save time.

## Deliberate omissions

Two things stay undocumented on purpose, so they don't read as further gaps:

- **`explicit_route_only`** is an internal trait method. What it does is already documented, as *"It never wins a bare model name"*.
- **`codex_originator`** stays in the schema alone. It is an escape hatch, the default is the measured-correct value, and listing it beside the ordinary settings would invite changing it.

Docs-only; the docs gate, full suite, structure and fmt all pass.
