### PR TITLE
Put the Ollama switch on the API, and correct a pricing claim the live test disproved

### DIFF
--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -62,6 +62,9 @@ fn redact(
         has_google_key: c.providers.google_api_key.is_some(),
         has_openrouter_key: c.openrouter_api_key.is_some(),
         ollama_base_url: c.ollama_base_url.clone(),
+        // The switch or the address: either is a choice, and a console
+        // drawing "Ollama is on" should not have to know which one was used.
+        ollama_enabled: c.providers.ollama_enabled || c.ollama_base_url.is_some(),
         codex_enabled: c.providers.codex_enabled,
         codex_reasoning_effort: c.providers.codex_reasoning_effort.clone(),
         codex_verbosity: c.providers.codex_verbosity.clone(),
@@ -181,6 +184,9 @@ pub(super) async fn put_config(
         "reasoning effort",
     )?;
     let verbosity = validated(req.codex_verbosity, CODEX_VERBOSITIES, "verbosity")?;
+    config.providers.ollama_enabled = req
+        .ollama_enabled
+        .unwrap_or(config.providers.ollama_enabled);
     config.providers.codex_enabled = req.codex_enabled.unwrap_or(config.providers.codex_enabled);
     config.providers.codex_replay_reasoning = req
         .codex_replay_reasoning
@@ -1096,6 +1102,7 @@ mod tests {
             has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: None,
+            ollama_enabled: false,
             codex_enabled: false,
             codex_reasoning_effort: None,
             codex_verbosity: None,
@@ -1127,6 +1134,7 @@ mod tests {
             has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: Some("http://localhost:11434".to_string()),
+            ollama_enabled: false,
             codex_enabled: false,
             codex_reasoning_effort: None,
             codex_verbosity: None,
@@ -1296,6 +1304,61 @@ mod tests {
             .body(Body::from(body.to_string()))
             .unwrap();
         app.oneshot(req).await.unwrap()
+    }
+
+    /// Ollama is writable and readable, so a console can turn it on.
+    ///
+    /// Found by driving the live API rather than by reading the code: the
+    /// Codex switch was on `GET`/`PUT` and this one was not, so a settings
+    /// page could see `ollama_base_url` and had no way to learn - or say -
+    /// whether Ollama was on at all.
+    #[tokio::test]
+    async fn put_config_writes_the_ollama_switch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+
+        let body = serde_json::json!({ "ollama_enabled": true }).to_string();
+        let resp = put_config_request(state_with_config_path(path.clone()), &body).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let rc: RedactedConfig = serde_json::from_slice(&bytes).unwrap();
+        assert!(rc.ollama_enabled);
+        assert!(
+            Config::load_from_path_public(&path)
+                .unwrap()
+                .providers
+                .ollama_enabled
+        );
+    }
+
+    /// An address counts as having chosen it, so the switch reads true for a
+    /// config that predates the switch. A console asking "is Ollama on" wants
+    /// one answer, not two fields to reconcile.
+    #[tokio::test]
+    async fn an_ollama_address_reads_as_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+
+        // The *watching* state, built first and then edited underneath it:
+        // `state_with_config_path` serves a fixed config, and the reloader is
+        // mtime-checked, so the edit has to land after construction and look
+        // newer. This is the dance every other test of this reloader does.
+        let state = state_watching_config_path(path.clone());
+        Config {
+            ollama_base_url: Some("http://elsewhere:11434".to_string()),
+            ..Config::default()
+        }
+        .save_to_path_public(&path)
+        .unwrap();
+        bump_mtime(&path);
+
+        let json = get_config_request(state).await;
+        assert_eq!(json["ollama_enabled"], true, "{json}");
     }
 
     /// The Codex switch and its two tuning knobs are writable, so a console

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -48,6 +48,14 @@ pub(super) struct RedactedConfig {
     pub(super) has_google_key: bool,
     pub(super) has_openrouter_key: bool,
     pub(super) ollama_base_url: Option<String>,
+    /// Whether Ollama is on.
+    ///
+    /// Beside `ollama_base_url` rather than folded into it, because the two
+    /// say different things: this is "I chose Ollama", the URL is "and it is
+    /// not at the default address". A config that names a URL counts as
+    /// having chosen it, so this reads `true` for one of those too - what a
+    /// console wants to draw is whether it is on, not which field said so.
+    pub(super) ollama_enabled: bool,
     /// Whether the Codex transport is on. Whether it is *signed in* is a
     /// separate question with a separate route: see `GET /api/providers`.
     pub(super) codex_enabled: bool,
@@ -423,6 +431,13 @@ pub(super) struct WriteConfigReq {
     /// sign-in, taken through `POST /api/providers/codex/login`. Writing this
     /// alone leaves a provider that is enabled and cannot answer, which is why
     /// `GET /api/providers` reports the two separately.
+    /// Turn Ollama on or off.
+    ///
+    /// Off, no run registers it. It needs no key and answers on a well-known
+    /// local port, so it used to be registered on every machine whether or
+    /// not anybody asked - which made a bare model name resolvable against
+    /// whatever happened to be running there.
+    pub(super) ollama_enabled: Option<bool>,
     pub(super) codex_enabled: Option<bool>,
     /// How hard Codex thinks: `none`, `minimal`, `low`, `medium`, `high` or
     /// `xhigh`. Validated before anything is written.

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -1294,6 +1294,7 @@ mod tests {
             has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: None,
+            ollama_enabled: false,
             codex_enabled: false,
             codex_reasoning_effort: None,
             codex_verbosity: None,

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -960,10 +960,13 @@ So `id` is not a key. `provider` + `id` is:
 
 ```json
 [
-  { "id": "gpt-5.5", "provider": "openai", "pricing": { "input": 1.25, "output": 10.0 } },
-  { "id": "gpt-5.5", "provider": "codex",  "pricing": { "input": 0.0,  "output": 0.0  } }
+  { "id": "gpt-5.5", "provider": "openai", "max_context_tokens": 400000 },
+  { "id": "gpt-5.5", "provider": "codex",  "max_context_tokens": 400000 }
 ]
 ```
+
+Measured against a live daemon signed in to both, that is four ids each served
+twice: `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra` and `gpt-5.6-luna`.
 
 A client keying a picker on `id` alone silently collapses those two into one
 row, and whichever it kept decides what the user pays. Build the key the way a
@@ -981,9 +984,13 @@ A provider this machine has not configured lists nothing rather than 404ing:
 the set of providers is whatever the config has, so "no models" is the honest
 answer to asking about one it does not have.
 
-The `pricing` on a Codex entry is a real zero rather than an absent one - the
-marginal cost of a subscription call is nothing, and `null` there would mean
-"unknown", which is a different thing a console should draw differently.
+`pricing` is `null` on a Codex entry, and on any other model whose provider
+did not quote a rate in its listing. It reports what the *listing* said, not
+what a run would be billed at, so a console should not read `null` as free.
+For Codex it happens to be free - a subscription has no per-call price, and a
+run on it reports `cost_usd: 0` - but the two facts arrive by different routes.
+See [where a run's cost went](#where-a-runs-cost-went) for the figure that is
+actually charged.
 
 ## Signing in to a subscription provider
 
@@ -1119,6 +1126,12 @@ signing out is not the same as turning the provider off. `PUT /api/config` carri
 `codex_verbosity` takes `low`, `medium` or `high`. Both are validated before anything is written,
 because the provider silently ignores a value it does not recognise - a typo would otherwise be
 saved, read back by `GET /api/config`, and quietly do nothing.
+
+`ollama_enabled` turns Ollama on, and `GET /api/config` reports it. It is
+opt-in like everything else: off, no run registers it. Setting
+`ollama_base_url` counts as choosing it too, and the `GET` reports `true` for
+either - a console asking "is Ollama on" wants one answer, not two fields to
+reconcile.
 
 `codex_replay_reasoning` is on by default and worth leaving on. It is writable so it can be
 turned off from a console the day the route stops accepting a replayed reasoning blob, without


### PR DESCRIPTION
Two gaps found by driving the live API against a real Codex sign-in, rather than by reading the code — neither was visible from the source.

## `ollama_enabled` was not on the API

`GET /api/config` reported `ollama_base_url` and nothing else about Ollama, so a settings page could see the address and had no way to learn — or say — whether Ollama was on at all. The Codex switch had been on `GET` and `PUT` since it was added; this one was not, because the field is newer than the route.

It reads and writes like the Codex one now. The read answers `true` for a config that names an address too: setting `ollama_base_url` counts as choosing Ollama, and a console asking "is it on" wants one answer rather than two fields to reconcile.

## The docs claimed a price that isn't there

`api.md` said the `pricing` on a Codex entry was "a real zero rather than an absent one". It is `null`. `ModelEntry.pricing` reports what the provider's *listing* carried, and `Provider::pricing()` — which is what a run is actually costed by, and which does return zero for Codex — is never consulted when building that listing.

I wrote that sentence on an assumption and did not verify it. Corrected to say what the field actually is, with a pointer to the figure that is really charged.

There is a real improvement hiding behind it — falling back to `provider.pricing(&id)` would make the listing agree with what a run gets billed, for every provider, not just Codex. That changes the output of `GET /api/models` across the board, so it is worth doing deliberately rather than folding in here.

## What the live test confirmed

Against the installed build, signed in to Codex on a Plus plan:

- `codex_enabled = true` and `default_provider = "codex"` persisted — the wizard bug is fixed
- A run on `codex/gpt-5.5` completed **with a title** (`title_error: None`) — the titling bug is fixed
- `lev models list --provider codex` shows 4 models, with `gpt-5.3-codex-spark` correctly withheld on Plus
- `GET /api/providers` reports the account, plan and expiry, and no token
- `POST /api/providers/codex/check` answers `200` with the 4 models the plan reaches
- `?provider=` filters correctly: 4 codex rows, 81 openai, 0 for an unknown name
- **The collision is real**: `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra` and `gpt-5.6-luna` are each served by *both* `openai` and `codex`, which is exactly why `id` alone is not a key. Now stated in the docs with the measured list.

All 13 packages at 100% coverage, clippy clean, docs/structure/fmt gates pass, full suite green.
