### PR TITLE
Say why a plan-gated model is refused, instead of claiming it is not served

### DIFF
--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -1485,6 +1485,7 @@ mod tests {
             // bundled blueprint says about itself, not what one install happens
             // to have configured.
             provider_catalogs: std::collections::HashMap::new(),
+            provider_refusals: std::collections::HashMap::new(),
             unrouted_models: std::collections::HashSet::new(),
             model_windows: crate::commands::models::builtin_model_windows(),
         }

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -582,17 +582,29 @@ pub(super) fn lint_models(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lin
             Some(ProviderCatalog::Complete(ids)) => {
                 let key = model_key(&entry.model);
                 if !ids.iter().any(|id| model_key(id) == key) {
+                    // The provider's own reason wins. "Does not serve it" is
+                    // right for a typo and wrong for a model the route carries
+                    // and this account cannot reach, and the two send a reader
+                    // to different places.
+                    let reason = env
+                        .provider_refusals
+                        .get(&format!("{}/{}", entry.provider, entry.model));
                     findings.push(
                         LintFinding::new(
                             LintSeverity::Error,
                             "unserved-model",
-                            format!(
-                                "names {}/{}, which provider '{}' does not serve (it lists {})",
-                                entry.provider,
-                                entry.model,
-                                entry.provider,
-                                sample_catalog(ids),
-                            ),
+                            match reason {
+                                Some(reason) => {
+                                    format!("names {}/{}: {reason}", entry.provider, entry.model)
+                                }
+                                None => format!(
+                                    "names {}/{}, which provider '{}' does not serve (it lists {})",
+                                    entry.provider,
+                                    entry.model,
+                                    entry.provider,
+                                    sample_catalog(ids),
+                                ),
+                            },
                         )
                         .in_stage(&stage.name)
                         .with_fix(format!(

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -191,6 +191,15 @@ pub(crate) struct LintEnv {
     /// and its entries go unchecked. See [`ProviderCatalog`] for what the two
     /// present states mean.
     pub provider_catalogs: HashMap<String, ProviderCatalog>,
+    /// Why a provider refuses one particular `provider/model`, when it had
+    /// more to say than the absence itself - keyed the way a blueprint writes
+    /// it.
+    ///
+    /// A catalogue that depends on the *account* rather than the build makes
+    /// "does not serve it" wrong: Codex carries `gpt-5.3-codex-spark` and a
+    /// Plus plan cannot reach it, and telling somebody to check their
+    /// spelling sends them nowhere useful.
+    pub provider_refusals: HashMap<String, String>,
 
     /// Bare model names the blueprint leaves unrouted: it names the model and
     /// no provider, and nothing this install can reach claims to serve it.
@@ -250,6 +259,7 @@ impl LintEnv {
             // serve. Doing it again here would cost every agent a round of
             // priming to say something the spawn says louder a moment later.
             provider_catalogs: HashMap::new(),
+            provider_refusals: HashMap::new(),
             unrouted_models: HashSet::new(),
             model_windows: crate::commands::models::builtin_model_windows(),
         }
@@ -321,6 +331,23 @@ impl LintEnv {
                 None => continue,
             };
             self.provider_catalogs.insert(name.to_string(), catalog);
+        }
+
+        // And what each refused entry's provider says about it, asked while
+        // the provider is still in hand: the checks run over plain data.
+        //
+        // No "already asked" guard, unlike the loop above: that one is keyed
+        // by provider and its question can cost a network call, while this is
+        // keyed by the exact pair and answered from memory. A blueprint naming
+        // one pair in two stages asks twice and inserts the same string.
+        for entry in entries() {
+            let Some(provider) = registry.get(&entry.provider) else {
+                continue;
+            };
+            if let Some(reason) = provider.refusal_reason(model_key(&entry.model)) {
+                self.provider_refusals
+                    .insert(format!("{}/{}", entry.provider, entry.model), reason);
+            }
         }
 
         // The open entries, asked the way the resolver asks: does *any*

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -920,6 +920,55 @@ max_iterations = 10
     );
 }
 
+/// A provider that can say *why* it refuses says that instead.
+///
+/// "Does not serve it" is right for a typo and wrong for a model the route
+/// carries and this account cannot reach - Codex carries
+/// `gpt-5.3-codex-spark` and a Plus plan cannot reach it. The two send a
+/// reader to different places, one to check the spelling and one to change
+/// the stage or the plan, so the reason replaces the guess rather than
+/// sitting beside it.
+#[test]
+fn a_refusal_the_provider_can_explain_says_the_reason() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "groq", model = "llama-3.1-70b" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        provider_catalogs: HashMap::from([(
+            "groq".to_string(),
+            ProviderCatalog::Complete(vec!["llama-4-scout".to_string()]),
+        )]),
+        provider_refusals: HashMap::from([(
+            "groq/llama-3.1-70b".to_string(),
+            "your ChatGPT plus plan does not include it".to_string(),
+        )]),
+        ..LintEnv::default()
+    };
+
+    let findings = lint(&toml, &env);
+    assert_eq!(codes(&findings), ["unserved-model"]);
+    let message = &findings[0].message;
+    assert!(message.contains("plus plan does not include"), "{message}");
+    assert!(
+        !message.contains("does not serve"),
+        "the reason should replace the guess, not sit beside it: {message}"
+    );
+    // The fix still points at the listing, which is where the alternatives
+    // are whichever way the refusal was worded.
+    assert!(
+        findings[0]
+            .fix
+            .as_deref()
+            .is_some_and(|f| f.contains("lev models list")),
+        "{findings:?}"
+    );
+}
+
 /// A catalogue too long to print is summarised with a count, because "it lists
 /// 2" and "it lists 340" send someone to different places: the first to a typo
 /// in the script's own `list_models`, the second to a typo in the blueprint.
@@ -2650,6 +2699,41 @@ fn blueprint_open(models: &[&str]) -> leviath_core::Blueprint {
 /// `native_providers`, which is the list the resolver asks first.
 struct NativeProvider(Vec<String>);
 
+/// The same, but it publishes what it serves and can say why it refuses the
+/// rest - the shape of a provider whose catalogue depends on the account.
+struct ExplainingProvider {
+    serves: Vec<String>,
+    reason: String,
+}
+
+#[async_trait::async_trait]
+impl leviath_providers::Provider for ExplainingProvider {
+    async fn infer(
+        &self,
+        _r: &leviath_providers::InferenceRequest,
+    ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
+        Err(leviath_providers::ProviderError::Other("t".to_string()))
+    }
+    async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        1
+    }
+    fn max_context_tokens(&self, _m: &str) -> usize {
+        1000
+    }
+    fn name(&self) -> &str {
+        "explaining"
+    }
+    fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
+        leviath_providers::ModelCapabilities::default()
+    }
+    fn served_catalog(&self) -> Option<Vec<String>> {
+        Some(self.serves.clone())
+    }
+    fn refusal_reason(&self, model_key: &str) -> Option<String> {
+        (!self.serves.iter().any(|m| m == model_key)).then(|| self.reason.clone())
+    }
+}
+
 #[async_trait::async_trait]
 impl leviath_providers::Provider for NativeProvider {
     async fn infer(
@@ -2753,6 +2837,64 @@ async fn a_script_providers_catalogue_reaches_the_lint() {
             .any(|f| f.code == "unserved-model"),
         "the catalogue is what makes the model checkable"
     );
+}
+
+/// The env collects the provider's own reason for refusing an entry, so the
+/// check has it without holding a registry.
+///
+/// The lint runs over plain data, and the provider is only in hand while the
+/// env is built - so a reason not gathered here is a reason nobody can print.
+#[tokio::test]
+async fn a_providers_reason_for_refusing_reaches_the_lint() {
+    let mut registry = leviath_runtime::ProviderRegistry::new();
+    registry.register(
+        "codexish".to_string(),
+        std::sync::Arc::new(ExplainingProvider {
+            serves: vec!["gpt-5.5".to_string()],
+            reason: "your ChatGPT plus plan does not include it".to_string(),
+        }),
+    );
+    let bp = blueprint_pinning(&[("codexish", "gpt-5.3-spark")]);
+
+    let env = LintEnv::default().with_provider_catalogs(
+        &bp,
+        &crate::config::Config::default(),
+        &registry,
+    );
+
+    assert_eq!(
+        env.provider_refusals
+            .get("codexish/gpt-5.3-spark")
+            .map(String::as_str),
+        Some("your ChatGPT plus plan does not include it")
+    );
+    // And the finding carries it rather than the generic wording.
+    let message = &lint_manifest("", &bp, &env)
+        .into_iter()
+        .find(|f| f.code == "unserved-model")
+        .expect("the catalogue makes it checkable")
+        .message;
+    assert!(message.contains("plus plan does not include"), "{message}");
+}
+
+/// A provider with nothing to add contributes no entry, so the check keeps its
+/// own wording.
+#[tokio::test]
+async fn a_provider_with_no_reason_adds_none() {
+    let mut registry = leviath_runtime::ProviderRegistry::new();
+    registry.register(
+        "plain".to_string(),
+        std::sync::Arc::new(NativeProvider(vec!["gpt-5.5".to_string()])),
+    );
+    let bp = blueprint_pinning(&[("plain", "nope")]);
+
+    let env = LintEnv::default().with_provider_catalogs(
+        &bp,
+        &crate::config::Config::default(),
+        &registry,
+    );
+
+    assert!(env.provider_refusals.is_empty());
 }
 
 /// A script provider with no `list_models` is recorded as having said nothing,

--- a/crates/leviath-providers/src/codex/provider.rs
+++ b/crates/leviath-providers/src/codex/provider.rs
@@ -447,6 +447,15 @@ impl Provider for CodexProvider {
             .then(|| model_key.to_string())
     }
 
+    fn refusal_reason(&self, model_key: &str) -> Option<String> {
+        // Only for a model this route really does serve. Anything else is a
+        // name nobody here has heard of, and the caller's own "not carried"
+        // message is the better one for that.
+        let known = catalog::CATALOG.iter().any(|(id, _)| *id == model_key);
+        (known && !catalog::plan_allows(self.plan().as_deref(), model_key))
+            .then(|| catalog::gated_remedy(self.plan().as_deref(), model_key))
+    }
+
     fn served_catalog(&self) -> Option<Vec<String>> {
         // `Some` is a promise of completeness, and the lint turns a name
         // outside it into a hard error. Only answered once the plan tier is

--- a/crates/leviath-providers/src/codex/provider/tests.rs
+++ b/crates/leviath-providers/src/codex/provider/tests.rs
@@ -859,6 +859,38 @@ async fn a_check_falls_back_to_the_plan_in_the_grant() {
     );
 }
 
+/// A model the route carries and the plan cannot reach explains itself.
+///
+/// The catalog and the plan are different questions, and the answers send a
+/// reader to different places: one to check the spelling, the other to change
+/// the stage or the plan. Before this, both came out as "provider 'codex'
+/// does not serve it" - which is not true of a model Codex serves.
+#[test]
+fn a_plan_gated_model_says_which_plan_and_what_is_left() {
+    let plus = provider("http://x", Static::with_plan("t", Some("plus")));
+    let reason = plus
+        .refusal_reason("gpt-5.3-codex-spark")
+        .expect("plus does not reach it");
+    assert!(reason.contains("plus"), "{reason}");
+    assert!(reason.contains("gpt-5.3-codex-spark"), "{reason}");
+    // And what to use instead, which is the half that makes it actionable.
+    assert!(reason.contains("gpt-5.5"), "{reason}");
+
+    // A model the plan does reach has nothing to explain.
+    assert_eq!(plus.refusal_reason("gpt-5.5"), None);
+    // Nor does a name this route never carried: "not carried" is already the
+    // right message for that, and the caller has a better one.
+    assert_eq!(plus.refusal_reason("gpt-4o"), None);
+}
+
+/// An account whose tier could not be read refuses nothing, so it explains
+/// nothing. A missing claim must not read as "your plan excludes this".
+#[test]
+fn an_unknown_plan_explains_nothing() {
+    let unknown = provider("http://x", Static::with_plan("t", None));
+    assert_eq!(unknown.refusal_reason("gpt-5.3-codex-spark"), None);
+}
+
 #[test]
 fn an_empty_usage_url_leaves_the_default_alone() {
     let p = provider("http://x", Static::new("t")).with_usage_url(Some("  ".to_string()));

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -927,6 +927,22 @@ pub trait Provider: Send + Sync {
         None
     }
 
+    /// Why this provider will not serve `model_key`, when it has something
+    /// more useful to say than "it is not in my catalogue".
+    ///
+    /// `None` by default, and `None` is also the right answer for a plain
+    /// typo: the caller's own message already names the model and says how to
+    /// list what is carried.
+    ///
+    /// It exists for a provider whose catalogue depends on the *account*
+    /// rather than on the build - a subscription tier, an org allowlist. There
+    /// the honest answer is not "no such model" but "your plan does not
+    /// include it", and the two send a reader to completely different places:
+    /// one to check their spelling, the other to change the stage or the plan.
+    fn refusal_reason(&self, _model_key: &str) -> Option<String> {
+        None
+    }
+
     /// Whether this provider may only be reached by name.
     ///
     /// A blueprint entry that names a model without a provider asks every
@@ -2050,6 +2066,15 @@ mod tests {
         let provider = MinimalProvider;
         let models = provider.list_models().await.unwrap();
         assert!(models.is_empty());
+    }
+
+    /// A provider with nothing to add says nothing, and the caller keeps its
+    /// own wording. Only a catalogue that depends on the account has a better
+    /// answer than "not carried".
+    #[test]
+    fn the_default_refusal_has_no_reason_to_give() {
+        assert_eq!(MinimalProvider.refusal_reason("only-this-one"), None);
+        assert_eq!(MinimalProvider.refusal_reason("anything-else"), None);
     }
 
     /// The default credential check *is* the listing, which is the right

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -677,12 +677,23 @@ pub fn resolve_stages(
             // that published a complete catalogue can get here, so the answer
             // is evidence rather than an absence of it (`refuses_model`).
             if registry.refuses_model(&head.provider, &head.model) {
-                return Err(format!(
-                    "stage '{}' names {}/{}, which provider '{}' does not serve. \
-                     Run `lev models list --provider {}` to see what it carries, \
-                     then name one of those in the stage's models list.",
-                    stage.name, head.provider, head.model, head.provider, head.provider,
-                ));
+                // The provider gets to say *why* first. "Does not serve it"
+                // is right for a typo and wrong for a model the route carries
+                // and the account cannot reach - and those two send a reader
+                // to different places, one to check the spelling and one to
+                // change the stage or the plan.
+                return Err(match registry.refusal_reason(&head.provider, &head.model) {
+                    Some(reason) => format!(
+                        "stage '{}' names {}/{}: {reason}",
+                        stage.name, head.provider, head.model
+                    ),
+                    None => format!(
+                        "stage '{}' names {}/{}, which provider '{}' does not serve. \
+                         Run `lev models list --provider {}` to see what it carries, \
+                         then name one of those in the stage's models list.",
+                        stage.name, head.provider, head.model, head.provider, head.provider,
+                    ),
+                });
             }
             // Empty `available_tools` exposes no tools; otherwise filter the full
             // set by name (alias-resolved). A name matching nothing (a typo, or an
@@ -893,6 +904,7 @@ mod tests {
                 Arc::new(FakeProvider {
                     serves: models.iter().map(|m| (*m).to_string()).collect(),
                     catalog: None,
+                    refusal: None,
                 }),
             );
         }
@@ -908,6 +920,8 @@ mod tests {
         /// `None` is the ordinary fixture and means "will not say", which no
         /// caller may read as a refusal.
         catalog: Option<Vec<String>>,
+        /// What it says about refusing something outside that catalogue.
+        refusal: Option<String>,
     }
     #[async_trait::async_trait]
     impl leviath_providers::Provider for FakeProvider {
@@ -940,6 +954,10 @@ mod tests {
         fn served_catalog(&self) -> Option<Vec<String>> {
             self.catalog.clone()
         }
+
+        fn refusal_reason(&self, _model_key: &str) -> Option<String> {
+            self.refusal.clone()
+        }
     }
 
     /// A registry whose providers each publish a complete catalogue, for the
@@ -952,6 +970,7 @@ mod tests {
                 Arc::new(FakeProvider {
                     serves: models.iter().map(|m| (*m).to_string()).collect(),
                     catalog: Some(models.iter().map(|m| (*m).to_string()).collect()),
+                    refusal: None,
                 }),
             );
         }
@@ -1233,6 +1252,61 @@ mod tests {
         assert!(err.contains("plan"), "names the stage: {err}");
         assert!(err.contains("groq/llama-3.1-70b"), "names the pair: {err}");
         assert!(err.contains("lev models list"), "says what to do: {err}");
+    }
+
+    /// And when the provider can say *why*, the spawn error says that instead.
+    ///
+    /// "Does not serve it" is right for a typo and wrong for a model the route
+    /// carries and the account cannot reach: Codex carries
+    /// `gpt-5.3-codex-spark`, a Plus plan does not include it, and the two
+    /// send a reader to different places - one to check the spelling, the
+    /// other to change the stage or the plan. This is the message somebody
+    /// actually reads when a run will not start.
+    #[test]
+    fn resolve_stages_prefers_the_providers_own_reason() {
+        let stage = leviath_core::Stage::new(
+            "plan".to_string(),
+            model_cfg(vec![("codexish", "gpt-5.3-spark")]),
+        );
+        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
+        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
+
+        let mut registry = ProviderRegistry::new();
+        registry.register(
+            "codexish".to_string(),
+            Arc::new(FakeProvider {
+                serves: vec!["gpt-5.5".to_string()],
+                catalog: Some(vec!["gpt-5.5".to_string()]),
+                refusal: Some(
+                    "your ChatGPT plus plan does not include it. Available: gpt-5.5".to_string(),
+                ),
+            }),
+        );
+
+        let err = resolve_stages(
+            &bp,
+            None,
+            &ModelDefaults::default(),
+            &registry,
+            catalog(&[]),
+            false,
+            None,
+        )
+        .expect_err("the plan does not reach it");
+
+        assert!(err.contains("plan"), "names the stage: {err}");
+        assert!(
+            err.contains("codexish/gpt-5.3-spark"),
+            "names the pair: {err}"
+        );
+        assert!(
+            err.contains("plus plan does not include"),
+            "the reason: {err}"
+        );
+        assert!(
+            !err.contains("does not serve"),
+            "the reason replaces the guess rather than sitting beside it: {err}"
+        );
     }
 
     /// The same shape, against a provider that publishes nothing. A provider

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -275,6 +275,17 @@ impl ProviderRegistry {
             .any(|id| crate::pipeline::model_key(id) == key)
     }
 
+    /// What `provider` says about refusing `model`, when it has more to say
+    /// than the absence itself.
+    ///
+    /// Asked only after [`refuses_model`](Self::refuses_model) has already
+    /// said no, so this is about the wording of a decision rather than the
+    /// decision.
+    pub(crate) fn refusal_reason(&self, provider: &str, model: &str) -> Option<String> {
+        self.get(provider)?
+            .refusal_reason(crate::pipeline::model_key(model))
+    }
+
     /// Get all *natively-registered* provider names. Script providers are
     /// resolved on demand and so are not enumerated here - see
     /// [`resolvable_names`](Self::resolvable_names) for the set that includes
@@ -362,6 +373,8 @@ mod tests {
         /// the ordinary fixture and means "will not say", which no caller may
         /// read as a refusal.
         catalog: Option<Vec<String>>,
+        /// What it says about refusing anything outside that catalogue.
+        refusal: Option<String>,
     }
 
     impl StubProvider {
@@ -371,6 +384,7 @@ mod tests {
                 outcome,
                 warmed: Arc::new(std::sync::Mutex::new(Vec::new())),
                 catalog: None,
+                refusal: None,
             }
         }
 
@@ -379,6 +393,14 @@ mod tests {
             Self {
                 catalog: Some(models.iter().map(|m| (*m).to_string()).collect()),
                 ..Self::new(PrimeOutcome::Ok)
+            }
+        }
+
+        /// And one that explains what it will not serve.
+        fn explaining(models: &[&str], reason: &str) -> Self {
+            Self {
+                refusal: Some(reason.to_string()),
+                ..Self::publishing(models)
             }
         }
     }
@@ -438,6 +460,37 @@ mod tests {
         fn served_catalog(&self) -> Option<Vec<String>> {
             self.catalog.clone()
         }
+
+        fn refusal_reason(&self, _model_key: &str) -> Option<String> {
+            self.refusal.clone()
+        }
+    }
+
+    /// A provider gets to explain a refusal, and one with nothing to add is
+    /// silent rather than inventing a sentence.
+    #[test]
+    fn refusal_reason_comes_from_the_provider_or_not_at_all() {
+        let mut reg = ProviderRegistry::new();
+        reg.register(
+            "codexish".to_string(),
+            Arc::new(StubProvider::explaining(
+                &["gpt-5.5"],
+                "your plan does not include it",
+            )),
+        );
+        reg.register(
+            "groq".to_string(),
+            Arc::new(StubProvider::publishing(&["llama-4-scout"])),
+        );
+
+        assert_eq!(
+            reg.refusal_reason("codexish", "gpt-5.3-spark").as_deref(),
+            Some("your plan does not include it")
+        );
+        assert_eq!(reg.refusal_reason("groq", "llama-3.1-70b"), None);
+        // And a provider that is not here explains nothing rather than
+        // panicking on the lookup.
+        assert_eq!(reg.refusal_reason("absent", "anything"), None);
     }
 
     /// `refuses_model` folds three different "no" answers into `false`, because


### PR DESCRIPTION
Naming a model your ChatGPT plan does not include said this:

```
stage 'engine' names codex/gpt-5.3-codex-spark, which provider 'codex' does not
serve. Run `lev models list --provider codex` to see what it carries, then name
one of those in the stage's models list.
```

Which is not true. Codex *serves* that model; a Plus plan does not reach it. The message sends a reader to check their spelling when the answer is a plan — and the listing it points at is filtered by that same plan, so following the advice shows a set the model is simply missing from, with no hint why.

The good message already existed. `gated_remedy` names the tier and lists what the tier does reach, and **nothing could get to it**: `serves_model` filtered by plan, so the stage never resolved, so no request was made, so the 400 that would have carried it never came back.

## The seam

`Provider::refusal_reason` is asked *only after* a provider has already refused, so it is about the wording of a decision rather than the decision. `None` by default — and `None` is the right answer for a typo, where the caller's own message is better. It exists for a catalogue that depends on the **account** rather than the build: a subscription tier, an org allowlist.

Both surfaces that report a refusal now prefer it, so they cannot drift apart:

- the spawn path in `resolve_stages`
- the `unserved-model` blueprint lint

## Measured against the live account

Same command, after the change:

```
stage 'engine' names codex/gpt-5.3-codex-spark: your ChatGPT plus plan does not
include 'gpt-5.3-codex-spark'. Available on this plan: gpt-5.6-sol,
gpt-5.6-terra, gpt-5.6-luna, gpt-5.5. Change the stage's model, or upgrade the
plan.
```

## What did not change

The refusal still happens **at spawn**, not at the first inference. That half was worth keeping: a multi-stage agent that only discovered the problem on reaching that stage would have burned everything before it. Claiming the model and letting the route answer would have been the simpler change and a worse one.

Plan detection needed no work — it already exists, from the `chatgpt_plan_type` claim in the id token, with the quota route as a fallback. It is what drives `served_catalog`, the model listing, and now this message.

All 13 packages at 100% coverage, clippy clean under `-D warnings`, docs/structure/fmt gates pass, full suite green.
