### PR TITLE
chore(release): 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
-## Unreleased
+## 0.5.7 - 2026-08-31
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "leviath-core",
  "leviath-tools",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "chrono",
  "dirs",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "encoding_rs",
  "leviath-testkit",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "base64 0.23.1",
  "leviath-core",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "fs4",
  "keyring",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "tokio",
  "tracing",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -98,18 +98,18 @@ allow_attributes_without_reason = "deny"
 # to the repo while every crate that dev-depends on it still publishes.
 # No member depends on the facade; it is listed so the version-parity check
 # (`cargo xtask version --check`) sees every published crate in one table.
-leviath = { path = "crates/leviath", version = "0.5.6" }
-leviath-core = { path = "crates/leviath-core", version = "0.5.6" }
-leviath-net = { path = "crates/leviath-net", version = "0.5.6" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.6" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.6" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.5.6" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.6" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.6" }
-leviath-package = { path = "crates/leviath-package", version = "0.5.6" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.5.6" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.5.6" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.6" }
+leviath = { path = "crates/leviath", version = "0.5.7" }
+leviath-core = { path = "crates/leviath-core", version = "0.5.7" }
+leviath-net = { path = "crates/leviath-net", version = "0.5.7" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.7" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.7" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.5.7" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.7" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.7" }
+leviath-package = { path = "crates/leviath-package", version = "0.5.7" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.5.7" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.5.7" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.7" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.5.6", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.5.7", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Leviath HTTP API",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "description": "The REST and WebSocket surface `lev serve` puts in front of the shared-world daemon. Every route requires a bearer token. Paths here are checked against the router in crates/leviath-cli/src/commands/serve/mod.rs by a test in that file, so a route added without a spec entry fails the build. See https://leviath.dev/docs/api.",
     "license": {
       "name": "MIT"


### PR DESCRIPTION
Bumps the workspace from 0.5.6 to 0.5.7 via `cargo xtask version 0.5.7`, rolling the `## Unreleased` CHANGELOG section to `## 0.5.7 - 2026-08-31`. Merging this cuts the alpha release; beta and prod stay on their own schedules.

Ships the validator and `on_write` behavior changes plus the fixes from #751-#756, and the provider refusal-reason work.
