### PR TITLE
ci(beta): give the weekly beta release a second chance to fire

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     # Every Monday at 9am PST (4pm UTC)
     - cron: '0 16 * * 1'
+    # Backstop, four hours later, mirroring prod.yml. GitHub does not guarantee
+    # a scheduled event is ever delivered, and on 2026-08-31 it dropped the
+    # 16:00 dispatch outright, as it had for prod the Thursday before. The
+    # `Get alpha release info` gate already refuses to ship a version beta
+    # carries, so a redundant run is a fifteen-second no-op, and the
+    # beta-promote concurrency group queues the two slots if both ever arrive.
+    - cron: '0 20 * * 1'
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
Mirrors prod's `ab079e06` backstop onto beta: a second cron slot at 20:00 UTC Monday, four hours after the intended one.

On 2026-08-31 GitHub never delivered the Monday 16:00 UTC scheduled event (no run object was created at all), the same dropped-event failure that hit prod on 2026-08-27, and 0.5.7-beta had to ship by manual dispatch. A weekly cron with no second chance turns one dropped event into a week with no beta.

The `Get alpha release info` gate already skips when beta carries the alpha version, so a redundant run is a fifteen-second no-op, and the existing `beta-promote` queued concurrency group serializes the two slots if both ever arrive.
