### PR TITLE
chore(prices): refresh vendor list prices 2026-08-31

### DIFF
--- a/crates/leviath-providers/pricing/rates.toml
+++ b/crates/leviath-providers/pricing/rates.toml
@@ -7,7 +7,7 @@
 # `openrouter` or `litellm` when only one listed it, and `manual` for a row a
 # person wrote, which the refresh never overwrites.
 
-read_on = "2026-08-29"
+read_on = "2026-08-31"
 
 [[rate]]
 provider = "anthropic"
@@ -461,6 +461,15 @@ source = "litellm"
 
 [[rate]]
 provider = "google"
+prefix = "gemini-omni-1.1-flash"
+input = 1.5
+cache_read = 1.5
+cache_write = 1.5
+output = 9.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
 prefix = "gemini-omni-flash-preview"
 input = 1.5
 cache_read = 1.5
@@ -700,6 +709,15 @@ input = 0.4
 cache_read = 0.1
 cache_write = 0.4
 output = 1.6
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4.1-nano"
+input = 0.1
+cache_read = 0.025
+cache_write = 0.1
+output = 0.4
 source = "both"
 
 [[rate]]


### PR DESCRIPTION
Weekly refresh of `crates/leviath-providers/pricing/rates.toml`
by `cargo xtask prices`. Auto-merges once the required checks pass.

```
+ google/gemini-omni-1.1-flash: 1.5/1.5/1.5/9.0 (litellm)
+ openai/gpt-4.1-nano: 0.1/0.025/0.1/0.4 (both)
? openai/gpt-5.6-sol: openrouter 2.0/0.2/2.5/10.0 vs litellm 4.0/0.4/5.0/20.0 (not written)
? codex: 'gpt-5.6-luna-pro' is listed by OpenAI and not in the catalog - does Codex serve it?
? codex: 'gpt-5.6-terra-pro' is listed by OpenAI and not in the catalog - does Codex serve it?
prices: 118 rows, 2 added, 0 changed, 1 disagreements; openrouter 101 models, litellm 146 models
prices: wrote 2 rows to /home/runner/work/leviath/leviath/crates/leviath-providers/pricing/rates.toml (read_on 2026-08-31)
```
