### PR TITLE
Correct the gpt-5 context windows, and check them against the vendors weekly

### DIFF
--- a/crates/leviath-providers/src/codex/catalog.rs
+++ b/crates/leviath-providers/src/codex/catalog.rs
@@ -8,8 +8,19 @@
 //!
 //! Percentage region budgets resolve once at spawn against
 //! [`ModelCapabilities::max_context_tokens`], so a wrong row here silently
-//! mis-sizes every region for a whole run. The numbers are deliberately the
-//! conservative reading.
+//! mis-sizes every region for a whole run - which is exactly what happened:
+//! every model carried 400,000, a figure no vendor publishes for any of them,
+//! and a `gpt-5.5` run used 38% of the window it had for months.
+//!
+//! The windows are OpenAI's published `max_input_tokens`, cross-checked
+//! against OpenRouter's `context_length` (which is the whole window, and
+//! larger by exactly the output allowance). Whether the Codex *route* caps
+//! lower than the API is not knowable from here - it publishes no catalogue -
+//! so these assume it does not. If it turns out to, the symptom is a refused
+//! request rather than a silent one, and `[model_capabilities]` is the lever.
+//!
+//! `cargo xtask prices` re-checks these against the published figures every
+//! week and reports a row that has drifted. It never rewrites them.
 
 use crate::capabilities::{LimitsSource, Match, ModelCapabilities, Row};
 
@@ -57,14 +68,14 @@ pub(crate) const MODELS: &[Row] = &[
         matches: &[Match::Prefix("gpt-5.6")],
         temperature: false,
         tools: true,
-        context: 400_000,
+        context: 922_000,
         output: 128_000,
     },
     Row {
         matches: &[Match::Prefix("gpt-5.5")],
         temperature: false,
         tools: true,
-        context: 400_000,
+        context: 1_050_000,
         output: 128_000,
     },
     Row {
@@ -79,7 +90,7 @@ pub(crate) const MODELS: &[Row] = &[
         matches: &[Match::Prefix("gpt-5")],
         temperature: false,
         tools: true,
-        context: 400_000,
+        context: 272_000,
         output: 128_000,
     },
 ];
@@ -168,8 +179,11 @@ mod tests {
             assert!(caps.supports_tools, "{id}");
             assert!(caps.max_context_tokens >= 128_000, "{id}");
         }
-        assert_eq!(capabilities("gpt-5.6-sol").max_context_tokens, 400_000);
-        assert_eq!(capabilities("gpt-5.5").max_context_tokens, 400_000);
+        // The published `max_input_tokens`, not a round number: these were
+        // 400,000 for both, which no vendor publishes for either, and the
+        // weekly window check is what now holds them to the source.
+        assert_eq!(capabilities("gpt-5.6-sol").max_context_tokens, 922_000);
+        assert_eq!(capabilities("gpt-5.5").max_context_tokens, 1_050_000);
     }
 
     #[test]

--- a/crates/leviath-providers/src/codex/provider/tests.rs
+++ b/crates/leviath-providers/src/codex/provider/tests.rs
@@ -495,7 +495,7 @@ fn this_provider_never_wins_a_bare_model_name() {
 fn no_model_is_offered_with_a_temperature() {
     let p = provider("http://x", Static::new("t"));
     assert!(!p.capabilities("gpt-5.6-sol").supports_temperature);
-    assert_eq!(p.max_context_tokens("gpt-5.6-sol"), 400_000);
+    assert_eq!(p.max_context_tokens("gpt-5.6-sol"), 922_000);
 }
 
 #[test]

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -111,12 +111,27 @@ pub(crate) const MODELS: &[Row] = &[
         context: 1_050_000,
         output: 128_000,
     },
+    // Its own row rather than the family's: the 5.6 models carry a window
+    // more than three times the family default, and without this they fell
+    // through to it and every percentage region budget was sized for a
+    // fraction of what the run had.
+    Row {
+        matches: &[Match::Prefix("gpt-5.6")],
+        temperature: true,
+        tools: true,
+        context: 922_000,
+        output: 128_000,
+    },
     // GPT-5.x family (5.4, 5.4-mini, 5.4-nano, 5-mini).
+    //
+    // 272,000, not the 400,000 this carried: that figure matched no model
+    // anybody publishes, and being *over* is the direction that fails - a run
+    // builds a context the model then refuses.
     Row {
         matches: &[Match::Prefix("gpt-5")],
         temperature: true,
         tools: true,
-        context: 400_000,
+        context: 272_000,
         output: 128_000,
     },
     Row {
@@ -609,7 +624,7 @@ mod tests {
             crate::provider::build_http_client(None).expect("a test client builds"),
             "test-key".to_string(),
         );
-        assert_eq!(provider.max_context_tokens("gpt-5.4-mini"), 400_000);
+        assert_eq!(provider.max_context_tokens("gpt-5.4-mini"), 272_000);
     }
 
     #[test]
@@ -812,7 +827,7 @@ mod tests {
         );
         let caps = provider.builtin_capabilities("gpt-5.4-mini");
         assert!(caps.supports_temperature);
-        assert_eq!(caps.max_context_tokens, 400_000);
+        assert_eq!(caps.max_context_tokens, 272_000);
         assert_eq!(caps.max_output_tokens, 128_000);
     }
 
@@ -824,7 +839,7 @@ mod tests {
         );
         let caps = provider.builtin_capabilities("gpt-5.4-nano");
         assert!(caps.supports_temperature);
-        assert_eq!(caps.max_context_tokens, 400_000);
+        assert_eq!(caps.max_context_tokens, 272_000);
         assert_eq!(caps.max_output_tokens, 128_000);
     }
 
@@ -1082,9 +1097,12 @@ mod tests {
             crate::provider::build_http_client(None).expect("a test client builds"),
             "key".to_string(),
         );
-        // gpt-5.4, gpt-5-mini, etc. should all match gpt-5 pattern
-        assert_eq!(provider.max_context_tokens("gpt-5.4"), 400_000);
-        assert_eq!(provider.max_context_tokens("gpt-5-mini"), 400_000);
+        // gpt-5.4, gpt-5-mini, etc. should all match gpt-5 pattern.
+        // 272,000 is OpenAI's published `max_input_tokens` for the family;
+        // this asserted 400,000, which nothing publishes, and `cargo xtask
+        // prices` now reports the day it stops matching.
+        assert_eq!(provider.max_context_tokens("gpt-5.4"), 272_000);
+        assert_eq!(provider.max_context_tokens("gpt-5-mini"), 272_000);
     }
 
     #[test]

--- a/xtask/src/model_windows.rs
+++ b/xtask/src/model_windows.rs
@@ -1,0 +1,347 @@
+//! Whether the compiled context windows still match what the vendors publish.
+//!
+//! Every provider carries a `MODELS: &[Row]` table of context and output
+//! limits. Those numbers are load-bearing in a way a reader would not guess:
+//! percentage region budgets resolve once at spawn against
+//! `max_context_tokens`, so a row that is too small silently sizes every
+//! region for a fraction of the window the run actually has, for the whole
+//! run, with nothing failing and nothing said.
+//!
+//! That is exactly how it went wrong. `gpt-5.5` sat at 400,000 on the Codex
+//! route against a published 1,050,000, and `gpt-5.6` had no OpenAI row at all
+//! so it fell through to the `gpt-5` family's 400,000 against a published
+//! 922,000. Both were found by hand, months after the models shipped.
+//!
+//! So this rides along on the fetch `prices` already makes. It reports and
+//! never writes: these live in Rust source, and a tool that rewrites source
+//! is a much larger promise than one that rewrites a TOML table.
+//!
+//! ## Which number belongs in the field
+//!
+//! `ModelCapabilities::max_context_tokens` is documented as the maximum
+//! *input* tokens, so LiteLLM's `max_input_tokens` is the like-for-like
+//! figure. OpenRouter's `context_length` is the whole window and is larger by
+//! exactly the output allowance - 922,000 + 128,000 = 1,050,000 for the
+//! gpt-5.6 family - which is the arithmetic that says the two sources agree
+//! rather than disagreeing.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+
+/// What a vendor publishes for one model: input window, output cap.
+pub type Windows = BTreeMap<String, (u64, u64)>;
+
+/// One `Row` from a provider's compiled table.
+#[derive(Debug, PartialEq)]
+pub struct Row {
+    /// The model-name prefixes this row answers for.
+    pub prefixes: Vec<String>,
+    /// `max_context_tokens`: the input window.
+    pub context: u64,
+    /// `max_output_tokens`.
+    pub output: u64,
+}
+
+/// The windows LiteLLM publishes for OpenAI's chat models.
+///
+/// Only OpenAI: the other vendors' tables are checked the same way when
+/// somebody wires them up, and reporting on a vendor nobody compares against
+/// would be noise.
+pub fn parse_litellm_windows(body: &str) -> Result<Windows> {
+    let doc: serde_json::Value = serde_json::from_str(body).context("LiteLLM: not JSON")?;
+    let entries = doc.as_object().context("LiteLLM: not an object")?;
+    let mut out = Windows::new();
+    for (key, entry) in entries {
+        if entry
+            .get("litellm_provider")
+            .and_then(serde_json::Value::as_str)
+            != Some("openai")
+            || entry.get("mode").and_then(serde_json::Value::as_str) != Some("chat")
+            || key.contains(':')
+        {
+            continue;
+        }
+        let id = match key.split_once('/') {
+            None => key.as_str(),
+            Some((_, rest)) if !rest.contains('/') => rest,
+            Some(_) => continue,
+        };
+        let field = |name: &str| entry.get(name).and_then(serde_json::Value::as_u64);
+        if let (Some(input), Some(output)) = (field("max_input_tokens"), field("max_output_tokens"))
+        {
+            out.insert(id.to_string(), (input, output));
+        }
+    }
+    Ok(out)
+}
+
+/// The `Row` literals in a provider's source.
+///
+/// Read from the text rather than linked, for the reason `codex_catalog`
+/// gives: `xtask` is the tool that checks the crates and depends on none of
+/// them.
+pub fn parse_rows(source: &str) -> Result<Vec<Row>> {
+    let (_, rest) = source
+        .split_once("MODELS: &[Row] = &[")
+        .context("no MODELS table")?;
+    // Terminated by a line that is just `];`, found line-wise rather than as
+    // `"\n];"`: the real tables sit at column zero and a fixture does not, and
+    // a parser that only reads one of those is a parser that passes its tests
+    // and misses the file.
+    let end = rest
+        .lines()
+        .scan(0usize, |at, line| {
+            let start = *at;
+            *at += line.len() + 1;
+            Some((start, line))
+        })
+        .find(|(_, line)| line.trim() == "];")
+        .map(|(at, _)| at)
+        .context("MODELS is not terminated")?;
+    let body = rest.get(..end).unwrap_or_default();
+
+    let mut rows = Vec::new();
+    for chunk in body.split("Row {").skip(1) {
+        let prefixes: Vec<String> = chunk
+            .split("Match::Prefix(\"")
+            .skip(1)
+            .filter_map(|rest| rest.split_once('"').map(|(name, _)| name.to_string()))
+            .collect();
+        let (Some(context), Some(output)) = (number(chunk, "context:"), number(chunk, "output:"))
+        else {
+            continue;
+        };
+        if prefixes.is_empty() {
+            // A row matched some other way - `Contains`, an exact id. Nothing
+            // to look up by, so nothing to compare.
+            continue;
+        }
+        rows.push(Row {
+            prefixes,
+            context,
+            output,
+        });
+    }
+    if rows.is_empty() {
+        anyhow::bail!("MODELS parsed as empty");
+    }
+    Ok(rows)
+}
+
+/// The number after `field` in `chunk`, with the `1_000` spelling allowed.
+fn number(chunk: &str, field: &str) -> Option<u64> {
+    let (_, rest) = chunk.split_once(field)?;
+    let digits: String = rest
+        .trim_start()
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '_')
+        .filter(|c| *c != '_')
+        .collect();
+    digits.parse().ok()
+}
+
+/// Where `rows` disagrees with what the vendor publishes.
+///
+/// A row is judged against the *most specific* published model it answers
+/// for - the shortest id starting with one of its prefixes - because that is
+/// the model a blueprint naming the prefix will actually reach. A prefix
+/// nothing published matches is skipped rather than reported: this build's
+/// table legitimately carries models the sources have not caught up with, and
+/// the model-list check is the one that speaks to absence.
+pub fn drift(label: &str, rows: &[Row], published: &Windows) -> Vec<String> {
+    let mut report = Vec::new();
+    for row in rows {
+        for prefix in &row.prefixes {
+            let Some((id, (context, output))) = published
+                .iter()
+                .filter(|(id, _)| id.starts_with(prefix.as_str()))
+                .min_by_key(|(id, _)| id.len())
+            else {
+                continue;
+            };
+            if row.context != *context {
+                report.push(format!(
+                    "{label}: '{prefix}' has context {} and {id} publishes {context}",
+                    row.context
+                ));
+            }
+            if row.output != *output {
+                report.push(format!(
+                    "{label}: '{prefix}' has output {} and {id} publishes {output}",
+                    row.output
+                ));
+            }
+        }
+    }
+    report.sort();
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn published(entries: &[(&str, u64, u64)]) -> Windows {
+        entries
+            .iter()
+            .map(|(id, c, o)| ((*id).to_string(), (*c, *o)))
+            .collect()
+    }
+
+    const SOURCE: &str = r#"
+        pub(crate) const MODELS: &[Row] = &[
+            Row {
+                matches: &[Match::Prefix("gpt-5.6")],
+                temperature: false,
+                tools: true,
+                context: 922_000,
+                output: 128_000,
+            },
+            Row {
+                matches: &[Match::Prefix("o3"), Match::Prefix("o4")],
+                temperature: false,
+                tools: true,
+                context: 200_000,
+                output: 100_000,
+            },
+        ];
+    "#;
+
+    /// The prefixes and both numbers, with the `1_000` spelling read.
+    #[test]
+    fn the_rows_parse_with_their_prefixes_and_numbers() {
+        let rows = parse_rows(SOURCE).expect("parses");
+        assert_eq!(
+            rows,
+            vec![
+                Row {
+                    prefixes: vec!["gpt-5.6".to_string()],
+                    context: 922_000,
+                    output: 128_000,
+                },
+                Row {
+                    prefixes: vec!["o3".to_string(), "o4".to_string()],
+                    context: 200_000,
+                    output: 100_000,
+                },
+            ]
+        );
+    }
+
+    /// A file that does not hold what this expects fails loudly rather than
+    /// reporting a clean table it never read.
+    #[test]
+    fn a_table_it_cannot_read_is_an_error() {
+        for source in [
+            "nothing here",
+            "MODELS: &[Row] = &[",
+            "MODELS: &[Row] = &[\n];",
+        ] {
+            assert!(parse_rows(source).is_err(), "{source}");
+        }
+    }
+
+    /// A row matched some way other than a prefix has nothing to look up by,
+    /// so it is skipped rather than guessed at.
+    #[test]
+    fn a_row_with_no_prefix_is_skipped() {
+        let source = r#"
+            pub(crate) const MODELS: &[Row] = &[
+                Row {
+                    matches: &[Match::Contains("codex-spark")],
+                    context: 128_000,
+                    output: 32_000,
+                },
+                Row {
+                    matches: &[Match::Prefix("gpt-5.6")],
+                    context: 922_000,
+                    output: 128_000,
+                },
+            ];
+        "#;
+        let rows = parse_rows(source).expect("parses");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].prefixes, ["gpt-5.6"]);
+    }
+
+    /// A table that matches what is published says nothing.
+    #[test]
+    fn a_current_table_reports_nothing() {
+        let rows = parse_rows(SOURCE).expect("parses");
+        let published = published(&[("gpt-5.6", 922_000, 128_000), ("o3", 200_000, 100_000)]);
+        assert!(drift("openai", &rows, &published).is_empty());
+    }
+
+    /// The bug this exists for: a window smaller than the model's, which
+    /// nothing fails on and which sizes every region for a fraction of the
+    /// run's real budget.
+    #[test]
+    fn a_window_smaller_than_the_published_one_is_reported() {
+        let rows = vec![Row {
+            prefixes: vec!["gpt-5.6".to_string()],
+            context: 400_000,
+            output: 128_000,
+        }];
+        let report = drift(
+            "codex",
+            &rows,
+            &published(&[("gpt-5.6-sol", 922_000, 128_000)]),
+        );
+        assert_eq!(report.len(), 1, "{report:?}");
+        assert!(report[0].contains("context 400000"), "{report:?}");
+        assert!(report[0].contains("922000"), "{report:?}");
+    }
+
+    /// The output cap is checked too, and separately: the two are different
+    /// numbers with different consequences.
+    #[test]
+    fn a_wrong_output_cap_is_reported_on_its_own() {
+        let rows = vec![Row {
+            prefixes: vec!["gpt-5.6".to_string()],
+            context: 922_000,
+            output: 32_000,
+        }];
+        let report = drift("codex", &rows, &published(&[("gpt-5.6", 922_000, 128_000)]));
+        assert_eq!(report.len(), 1, "{report:?}");
+        assert!(report[0].contains("output 32000"), "{report:?}");
+    }
+
+    /// Judged against the *most specific* published id the prefix reaches,
+    /// because that is the model a blueprint naming it lands on.
+    #[test]
+    fn the_shortest_published_match_is_the_one_compared() {
+        let rows = vec![Row {
+            prefixes: vec!["gpt-5.6".to_string()],
+            context: 922_000,
+            output: 128_000,
+        }];
+        // `gpt-5.6` itself is the shortest, so the odd variant beside it does
+        // not drag the comparison.
+        let published = published(&[
+            ("gpt-5.6", 922_000, 128_000),
+            ("gpt-5.6-cyber", 400_000, 128_000),
+        ]);
+        assert!(drift("openai", &rows, &published).is_empty());
+    }
+
+    /// A prefix nothing published matches is silence, not a finding. This
+    /// build carries models the sources have not caught up with, and absence
+    /// is the model-list check's question rather than this one's.
+    #[test]
+    fn a_prefix_nothing_publishes_is_not_reported() {
+        let rows = vec![Row {
+            prefixes: vec!["gpt-6".to_string()],
+            context: 1,
+            output: 1,
+        }];
+        assert!(
+            drift(
+                "openai",
+                &rows,
+                &published(&[("gpt-5.6", 922_000, 128_000)])
+            )
+            .is_empty()
+        );
+    }
+}

--- a/xtask/src/prices.rs
+++ b/xtask/src/prices.rs
@@ -629,7 +629,10 @@ pub fn run_with(mode: PricesMode, fetch: Fetch, path: &Path, today: &str) -> Res
         std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     let existing = parse_table(&text)?;
     let openrouter = parse_openrouter(&fetch(OPENROUTER_URL)?)?;
-    let litellm = parse_litellm(&fetch(LITELLM_URL)?)?;
+    // Fetched once and read twice: the prices below and the windows further
+    // down come out of the same document.
+    let litellm_body = fetch(LITELLM_URL)?;
+    let litellm = parse_litellm(&litellm_body)?;
     let merged = merge(&existing, &openrouter, &litellm, today)?;
 
     for change in &merged.changes {
@@ -646,6 +649,15 @@ pub fn run_with(mode: PricesMode, fetch: Fetch, path: &Path, today: &str) -> Res
     // job that fails on a question is a weekly job somebody turns off.
     for line in codex_catalog::drift(&codex_ids()?, &openrouter) {
         println!("? {line}");
+    }
+    // And the context windows, which rot the same way and more quietly: a row
+    // that is too small fails nothing, it just sizes every region for a
+    // fraction of the window the run has.
+    let windows = model_windows::parse_litellm_windows(&litellm_body)?;
+    for (label, source) in WINDOW_TABLES {
+        for line in model_windows::drift(label, &model_windows::parse_rows(source)?, &windows) {
+            println!("? {line}");
+        }
     }
     let added = merged
         .changes
@@ -689,6 +701,22 @@ pub fn run_with(mode: PricesMode, fetch: Fetch, path: &Path, today: &str) -> Res
     }
 }
 
+/// The provider tables whose windows are checked, as (label, source).
+///
+/// The two that carry OpenAI's models. Another vendor's table is checked the
+/// same way the day somebody adds its published windows to the comparison;
+/// reporting on a vendor nothing is compared against would be noise.
+const WINDOW_TABLES: &[(&str, &str)] = &[
+    (
+        "openai",
+        include_str!("../../crates/leviath-providers/src/openai.rs"),
+    ),
+    (
+        "codex",
+        include_str!("../../crates/leviath-providers/src/codex/catalog.rs"),
+    ),
+];
+
 /// The Codex catalog's model ids, read from the shipped source.
 fn codex_ids() -> Result<Vec<String>> {
     codex_catalog::catalog_ids(include_str!(
@@ -731,6 +759,10 @@ pub fn run(mode: PricesMode) -> Result<()> {
 /// business changing the binary's entrypoint.
 #[path = "codex_catalog.rs"]
 pub mod codex_catalog;
+
+/// The context-window check, fed by the same fetch again.
+#[path = "model_windows.rs"]
+pub mod model_windows;
 
 #[cfg(test)]
 #[path = "prices_tests.rs"]


### PR DESCRIPTION
You were right. Every Codex model carried a **400,000**-token context window, and no vendor publishes that figure for any of them.

| model | published `max_input_tokens` | was |
|---|---|---|
| `gpt-5.5` | **1,050,000** | 400,000 |
| `gpt-5.6-sol` / `-terra` / `-luna` | **922,000** | 400,000 |
| `gpt-5` family | **272,000** | 400,000 |

Output caps were right throughout at 128,000 — it is only the context window.

## Two bugs, opposite directions

`max_context_tokens` is what percentage region budgets resolve against, **once, at spawn**. So a `gpt-5.5` run on the subscription had been sizing every region for **38% of the window it was paying for**, with nothing failing and nothing said. That is the quiet one, and it did the damage.

The `gpt-5` family row goes the other way — claiming 400,000 where the model publishes 272,000, which fails at the far end of a long stage rather than at its start.

The OpenAI provider had the same hole from the other side: **no `gpt-5.6` row at all**, so those models fell through to the family row and got 400,000 too. It has its own row now.

## Which number belongs in the field

`ModelCapabilities::max_context_tokens` is documented as the maximum *input* tokens, so LiteLLM's `max_input_tokens` is the like-for-like figure. OpenRouter's `context_length` is the whole window and is larger by exactly the output allowance — **922,000 + 128,000 = 1,050,000** — which is the arithmetic showing the two sources agree rather than disagreeing.

## The durable half

`cargo xtask prices` already fetches that catalogue every Monday, so it now checks the compiled tables against it and reports a row that has drifted.

It **reports and never writes**. These live in Rust source, and a tool that rewrites source is a much larger promise than one that rewrites a TOML table — so it cannot clobber a hand-corrected number, only notice one that has gone stale. Against the tables before this commit it reports all four rows above; after it, nothing.

Getting the signal usable needed the same care as the model-list check: a row is judged against the *shortest* published id its prefix reaches (the model a blueprint naming it actually lands on), and a prefix nothing publishes is silence rather than a finding, since this build legitimately carries models the sources have not caught up with.

## One honest limit

Whether the Codex *route* caps lower than the API is not knowable from here — it publishes no catalogue, and the only probe is a request over 400,000 tokens against a metered subscription, which I did not think worth your quota. These assume it does not. If it turns out to, the symptom is a refused request rather than a silent one, and `[model_capabilities]` is the lever.

All 13 packages at 100% coverage, clippy clean under `-D warnings`, docs/structure/fmt gates pass, full suite green.
