### PR TITLE
fix(providers): name all three numbers in the token-limit refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## Unreleased
+
+### Fixed
+
+- The pre-flight refusal for a request that cannot fit the model's context
+  window now names all three numbers it was computed from: the prompt count,
+  the `max_output_tokens` reply budget, and the window. It used to print only
+  the prompt against the window ("Token limit exceeded: 430 > 8192"), which
+  read as false whenever the reply budget was what tipped the sum - the
+  common case on a Rhai provider script left on its 8192-token
+  `@max_context_tokens` default, where any stage asking for an 8192-token
+  reply was refused with a message pointing at the wrong number. The docs now
+  carry the script annotation table with its defaults and call the trap out.
+
 ## 0.5.7 - 2026-08-31
 
 ### Breaking

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -335,6 +335,7 @@ impl OllamaProvider {
         }
         ProviderError::TokenLimitExceeded {
             used: estimated_request_tokens(request),
+            reply_budget: request.max_tokens,
             max: self.max_context_tokens(&request.model),
         }
     }
@@ -2530,6 +2531,7 @@ mod tests {
         assert!(
             !ProviderError::TokenLimitExceeded {
                 used: 33_000,
+                reply_budget: 0,
                 max: 32_768
             }
             .is_transient(),

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -191,12 +191,24 @@ pub enum ProviderError {
     #[error("Invalid response: {0}")]
     InvalidResponse(String),
 
-    /// Token limit exceeded
-    #[error("Token limit exceeded: {used} > {max}")]
+    /// The prompt plus the reply budget cannot fit the model's context window.
+    ///
+    /// `used` is the prompt alone: the pre-flight guard refuses when
+    /// `used + reply_budget` overflows `max`, so the message names all three
+    /// numbers. A refusal that printed only the prompt against the window
+    /// read as false ("430 > 8192") whenever the reply budget was what
+    /// tipped the sum.
+    #[error(
+        "Token limit exceeded: the prompt's {used} tokens plus the \
+         {reply_budget}-token reply budget (max_output_tokens) exceed the \
+         model's {max}-token context window"
+    )]
     TokenLimitExceeded {
-        /// Tokens the request would have sent.
+        /// Prompt tokens the request would have sent, without the reply budget.
         used: usize,
-        /// The model's context limit.
+        /// The reply budget the request asked for (`max_tokens`).
+        reply_budget: usize,
+        /// The model's context window.
         max: usize,
     },
 
@@ -1259,7 +1271,14 @@ mod tests {
         assert!(!ProviderError::ApiError("401 unauthorized".into()).is_transient());
         assert!(!ProviderError::ApiError("400 bad request".into()).is_transient());
         assert!(!ProviderError::InvalidResponse("garbage".into()).is_transient());
-        assert!(!ProviderError::TokenLimitExceeded { used: 9, max: 8 }.is_transient());
+        assert!(
+            !ProviderError::TokenLimitExceeded {
+                used: 9,
+                reply_budget: 0,
+                max: 8
+            }
+            .is_transient()
+        );
         assert!(!ProviderError::Other("mystery".into()).is_transient());
         // An unusable provider is permanent: retrying just burns the job
         // timeout against an account that has no money in it.
@@ -1294,7 +1313,11 @@ mod tests {
             ProviderError::ApiError("HTTP 502 Bad Gateway".into()),
             ProviderError::RequestFailed("connection reset".into()),
             ProviderError::Other("mystery".into()),
-            ProviderError::TokenLimitExceeded { used: 9, max: 8 },
+            ProviderError::TokenLimitExceeded {
+                used: 9,
+                reply_budget: 0,
+                max: 8,
+            },
         ] {
             assert!(!err.retry_advice().capacity, "{err}");
         }
@@ -1659,7 +1682,11 @@ mod tests {
         // Everything that is genuinely about the request stays put.
         for err in [
             ProviderError::InvalidResponse("garbage".into()),
-            ProviderError::TokenLimitExceeded { used: 9, max: 8 },
+            ProviderError::TokenLimitExceeded {
+                used: 9,
+                reply_budget: 0,
+                max: 8,
+            },
             ProviderError::RateLimitExceeded {
                 retry_after_secs: Some(5),
             },
@@ -1741,13 +1768,22 @@ mod tests {
         assert_eq!(err.to_string(), "Invalid response: missing field");
     }
 
+    /// The message names all three numbers the refusal was computed from. An
+    /// earlier shape printed only the prompt against the window, which read as
+    /// false ("430 > 8192") whenever the reply budget tipped the sum.
     #[test]
     fn provider_error_token_limit_display() {
         let err = ProviderError::TokenLimitExceeded {
-            used: 500,
-            max: 100,
+            used: 430,
+            reply_budget: 8192,
+            max: 8192,
         };
-        assert_eq!(err.to_string(), "Token limit exceeded: 500 > 100");
+        assert_eq!(
+            err.to_string(),
+            "Token limit exceeded: the prompt's 430 tokens plus the 8192-token \
+             reply budget (max_output_tokens) exceed the model's 8192-token \
+             context window"
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/src/compaction_bridge.rs
+++ b/crates/leviath-runtime/src/compaction_bridge.rs
@@ -408,7 +408,12 @@ mod tests {
 
         let outcome = rx.try_recv().unwrap();
         let err = outcome.result.expect_err("950 + 100 does not fit in 1,000");
-        assert_eq!(err.to_string(), "Token limit exceeded: 950 > 1000");
+        assert_eq!(
+            err.to_string(),
+            "Token limit exceeded: the prompt's 950 tokens plus the 100-token \
+             reply budget (max_output_tokens) exceed the model's 1000-token \
+             context window"
+        );
         assert!(
             !provider.inferred.load(std::sync::atomic::Ordering::SeqCst),
             "refused before the call, not after it"

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -235,7 +235,11 @@ pub async fn guard_context_window(
     }
     let used = provider.count_tokens(&text, &request.model).await;
     if used.saturating_add(request.max_tokens) > max {
-        return Err(ProviderError::TokenLimitExceeded { used, max });
+        return Err(ProviderError::TokenLimitExceeded {
+            used,
+            reply_budget: request.max_tokens,
+            max,
+        });
     }
     tracing::debug!(
         model = %request.model,
@@ -900,7 +904,12 @@ mod tests {
         let err = outcome.result.expect_err("should be rejected");
         // Assert on the Display string (branch-free) rather than `matches!`,
         // whose non-matching arm would be an uncovered region.
-        assert_eq!(err.to_string(), "Token limit exceeded: 950 > 1000");
+        assert_eq!(
+            err.to_string(),
+            "Token limit exceeded: the prompt's 950 tokens plus the 100-token \
+             reply budget (max_output_tokens) exceed the model's 1000-token \
+             context window"
+        );
     }
 
     /// A refusal is a fact about the request, not the network: it is reported
@@ -1408,7 +1417,11 @@ mod tests {
         assert_eq!(
             backoff_after(
                 &RetryPolicy::default(),
-                &ProviderError::TokenLimitExceeded { used: 9, max: 8 },
+                &ProviderError::TokenLimitExceeded {
+                    used: 9,
+                    reply_budget: 0,
+                    max: 8
+                },
                 1,
                 Duration::ZERO
             ),

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -2113,6 +2113,7 @@ fn collect_learns_from_a_refused_request_too() {
         entity: e,
         result: Err(leviath_providers::ProviderError::TokenLimitExceeded {
             used: 1_300,
+            reply_budget: 100,
             max: 1_350,
         }),
         pricing: None,

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -1338,7 +1338,12 @@ mod tests {
         .await;
         let outcome = rx.recv().await.expect("an outcome is always reported");
         let err = outcome.result.expect_err("600 + 512 does not fit in 1,000");
-        assert_eq!(err.to_string(), "Token limit exceeded: 600 > 1000");
+        assert_eq!(
+            err.to_string(),
+            "Token limit exceeded: the prompt's 600 tokens plus the 512-token \
+             reply budget (max_output_tokens) exceed the model's 1000-token \
+             context window"
+        );
         assert!(
             !provider.inferred.load(std::sync::atomic::Ordering::SeqCst),
             "refused before the call, not after it"

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -736,6 +736,8 @@ an unknown key.
 The one place unrecognized keys are *kept*: `[model_providers.<name>]` forwards anything it does not
 recognize to the Rhai script, so those are read and never reported.
 
+<a id="model_capabilitiesmodel_id"></a>
+
 ## `[model_capabilities.<model_id>]`
 
 Per-model corrections to the provider's built-in capability table. Useful for a local or

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -657,9 +657,18 @@ So a request that could be near the window is measured before it goes out. When 
 estimate plus the reply budget reaches half the model's window, the runtime asks the provider's own
 tokenizer what the request costs (`/messages/count_tokens` on Anthropic, `:countTokens` on Gemini,
 tiktoken locally on OpenAI, a script's `count_tokens` on a [Rhai provider](/docs/rhai-providers))
-and refuses to send one that would not fit, naming the count and the window in the error. A request
-under that line is sent as it is, so a short turn pays nothing. Every lane is guarded the same
-way: the stage's own call, the routing call at a stage boundary, compaction and titling.
+and refuses to send one that would not fit. The refusal names all three numbers it was computed
+from - the prompt count, the `max_output_tokens` reply budget, and the window - because the reply
+budget is usually the one that tipped the sum, and an error that only showed the prompt against the
+window pointed at the wrong number. A request under that line is sent as it is, so a short turn
+pays nothing. Every lane is guarded the same way: the stage's own call, the routing call at a
+stage boundary, compaction and titling.
+
+The window in that refusal is whatever the provider declares for the model, and a declared window
+that is too small refuses everything a real one would have carried. The common case is a
+[Rhai provider](/docs/rhai-providers#the-script-contract) left on its 8192-token
+`@max_context_tokens` default: a stage asking for an 8192-token reply can then never send anything,
+and the fix is the script's annotation (or a `[model_capabilities]` entry), not the stage.
 
 The count is also fed back into the correction, so a refused request tightens the estimate for the
 retry rather than being rediscovered by it.

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -80,6 +80,29 @@ A provider defines `initialize` and `inference` (required) and may add `stream`,
 checked when the script loads, so one that is missing or takes the wrong number of parameters is
 skipped with a warning, the same as a syntax error, rather than failing part-way into a run.
 
+The metadata directives, all optional:
+
+| directive | default | meaning |
+|---|---|---|
+| `// @provider <name>` | none | informational; activation is by config key / filename |
+| `// @description <text>` | empty | one line shown in listings |
+| `// @default_model <id>` | none | fills a stage that names no model |
+| `// @max_context_tokens <int>` | 8192 | the model's whole context window |
+| `// @max_output_tokens <int>` | 4096 | the largest reply the model can produce |
+| `// @supports_streaming <bool>` | false | advisory; real streaming needs a `stream` function |
+
+> [!IMPORTANT]
+> `@max_context_tokens` is the window the
+> [pre-flight guard](/docs/context#requests-are-measured-before-they-are-sent) holds every request
+> against: one whose prompt plus its `max_tokens` reply budget would overflow it is refused before
+> it is sent. Left at the 8192 default, a stage that asks for an 8192-token reply can never run,
+> whatever its prompt - the refusal reads
+> `Token limit exceeded: the prompt's N tokens plus the 8192-token reply budget (max_output_tokens)
+> exceed the model's 8192-token context window`, and the number to fix is this annotation, not the
+> stage's `max_output_tokens`. Declare the backing model's real window here, or override it
+> per model with a [`[model_capabilities]`](/docs/configuration#model_capabilitiesmodel_id) entry;
+> a `list_models` answer is a listing, and does not feed the guard.
+
 `initialize(config)` runs once when the provider loads. It runs **offline**, so no HTTP host
 functions are available here. Return a state map that is persisted and passed to every later call.
 


### PR DESCRIPTION
A user's custom provider refused every run with `error: Token limit exceeded: 430 > 8192`, a message that is mathematically false as written and reads as an output-token cap. The real mechanics: the pre-flight guard refuses when prompt + `max_output_tokens` would overflow the model's context window, and a Rhai provider script that never declares `// @max_context_tokens` gets the 8192-token default, so any stage asking for an 8192-token reply can never send anything. The error printed the prompt against the window and omitted the reply budget that tipped the sum, so both users and agents chased the wrong number.

Changes:

- `ProviderError::TokenLimitExceeded` carries the reply budget, and the message names all three figures: `Token limit exceeded: the prompt's 430 tokens plus the 8192-token reply budget (max_output_tokens) exceed the model's 8192-token context window`. The `used` field stays prompt-only, since estimate calibration feeds on it.
- `docs/rhai-providers`: the script contract now carries the annotation table with defaults, plus a callout on the 8192 default meeting the guard and where the fix lives (the annotation or a `[model_capabilities]` entry, not the stage).
- `docs/context`: the guard section explains what the refusal names and calls out the too-small declared window as the common cause.
- `docs/configuration`: adds the `<a id>` anchor for `[model_capabilities.<model_id>]` that its own same-page cross-reference already pointed at (previously a dead link) and the new links need.
- CHANGELOG gains the `## Unreleased` section with this fix.
