### PR TITLE
fix(cli): read a heredoc instead of refusing it for a redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ same list.
 
 ### Fixed
 
+- A shell heredoc no longer hides a redirect from the write fence, and no
+  longer has its own body mistaken for one. The fence reads a POSIX heredoc
+  as the command it is: the body is stdin data, so a `>` inside it is text,
+  while a real redirect beside the operator (`cat <<EOF > out`) keeps its
+  target and stays held to the working directory. The regression it fixes:
+  every `python3 - <<'EOF'` script of any substance held a `->` or a
+  comparison and so was refused outright for "a redirect that cannot be
+  read", even when it wrote nothing. Containment is unchanged - a heredoc
+  whose body never ends or whose unquoted body would expand a `$(...)` is
+  still refused, as is any heredoc on a shell that has none (`cmd.exe`),
+  where the body lines would really run.
 - The pre-flight refusal for a request that cannot fit the model's context
   window now names all three numbers it was computed from: the prompt count,
   the `max_output_tokens` reply budget, and the window. It used to print only

--- a/crates/leviath-cli/src/shell_keys.rs
+++ b/crates/leviath-cli/src/shell_keys.rs
@@ -371,11 +371,22 @@ pub(crate) enum WriteTargets {
 /// A line that will not tokenize is different: it is
 /// [`WriteTargets::Unreadable`] when it holds a `>` at all, and the caller
 /// refuses it rather than guessing. Leaning on the prompt instead is not
-/// containment, because under `--yolo` a prompt is a yes, and `cat <<EOF >
-/// /tmp/pwned` would write outside the tree where `write_file` on the same
-/// path is refused.
+/// containment, because under `--yolo` a prompt is a yes, and a redirect the
+/// reader cannot place would write outside the tree where `write_file` on the
+/// same path is refused. A well-formed heredoc reads as commands on a POSIX
+/// shell - its body is stdin data, and a redirect beside it (`cat <<EOF >
+/// /tmp/pwned`) is a named target held to the same confinement - so what
+/// lands here is the rest: a backtick, an unterminated quote or `$(`, a
+/// heredoc that never ends or whose unquoted body holds a substitution, and
+/// every heredoc on `cmd.exe`, which has none.
 pub(crate) fn write_targets(command: &str) -> WriteTargets {
-    let Some(segments) = tokenize(command) else {
+    write_targets_for(command, BACKSLASH_ESCAPES)
+}
+
+/// [`write_targets`] with the escape rule supplied, so both platforms'
+/// readings are testable on either.
+pub(crate) fn write_targets_for(command: &str, backslash_escapes: bool) -> WriteTargets {
+    let Some(segments) = tokenize_for(command, backslash_escapes) else {
         return match command.contains('>') {
             true => WriteTargets::Unreadable,
             false => WriteTargets::Known(Vec::new()),
@@ -438,11 +449,14 @@ pub(crate) fn is_valid_prefix(entry: &str) -> bool {
 /// Split a line into its commands, or `None` when it cannot be read as a list
 /// of commands.
 ///
-/// The four `None` cases are all "this line contains a construct whose contents
+/// The `None` cases are all "this line contains a construct whose contents
 /// decide what runs, and reading it wrong would understate the grant": an
 /// unterminated quote, an unterminated `$(`, a backtick (same idea as `$(`, but
-/// nesting is ambiguous), and a heredoc (whose body has its own delimiter
-/// grammar).
+/// nesting is ambiguous), and the heredocs whose bodies cannot be trusted as
+/// data - one that never ends, one whose unquoted body holds a substitution
+/// that would run, and any heredoc on a shell that has none (`cmd.exe`), where
+/// the "body" lines would really execute. A well-formed heredoc on a POSIX
+/// shell reads as commands, with its body consumed as the stdin data it is.
 fn tokenize(command: &str) -> Option<Vec<Segment>> {
     tokenize_for(command, BACKSLASH_ESCAPES)
 }
@@ -458,7 +472,7 @@ fn tokenize(command: &str) -> Option<Vec<Segment>> {
 /// Matched to the platform rather than to the resolved shell. `BuiltinTools`
 /// picks `$SHELL` on Unix and `cmd.exe` on Windows, and a Unix user whose
 /// `$SHELL` is not POSIX-ish is already outside what this parser models.
-const BACKSLASH_ESCAPES: bool = cfg!(not(windows));
+pub(crate) const BACKSLASH_ESCAPES: bool = cfg!(not(windows));
 
 /// [`tokenize`] with the escape rule supplied, so both readings are testable on
 /// either platform.
@@ -519,9 +533,36 @@ fn tokenize_for(command: &str, backslash_escapes: bool) -> Option<Vec<Segment>> 
                 lex.begin_word();
                 lex.take_dollar(&mut chars, escapes)?;
             }
-            // A heredoc body has its own delimiter grammar, which is more than
-            // a grant key is worth reading.
-            '<' if chars.peek() == Some(&'<') => return None,
+            // `<<WORD` opens a heredoc: its body is stdin data that starts
+            // after the next newline, not part of this command line, so a `>`
+            // inside the body is text rather than a redirect. The delimiter is
+            // read here; the body is consumed when that newline arrives. On a
+            // shell without heredocs (`cmd.exe`) the construct stays
+            // unreadable, because there the "body" lines would really run as
+            // commands, and swallowing them would hide their redirects from
+            // the fence. `<<<` falls out as unreadable too: the delimiter
+            // scan stops at the third `<` with nothing read.
+            '<' if chars.peek() == Some(&'<') => {
+                chars.next();
+                if !escapes {
+                    return None;
+                }
+                // A file descriptor written in front of the operator (`3<<`)
+                // is part of it, the same as on the other redirects.
+                if !lex.word.chars().all(|d| d.is_ascii_digit()) {
+                    lex.end_word();
+                }
+                lex.discard_word();
+                let strip_tabs = chars.peek() == Some(&'-');
+                if strip_tabs {
+                    chars.next();
+                }
+                while matches!(chars.peek(), Some(' ' | '\t')) {
+                    chars.next();
+                }
+                lex.pending_heredocs
+                    .push(take_heredoc_delimiter(&mut chars, escapes, strip_tabs)?);
+            }
             '>' | '<' => {
                 // A file descriptor written in front of the operator (`2>`) is
                 // part of it, not a word of its own.
@@ -571,6 +612,14 @@ fn tokenize_for(command: &str, backslash_escapes: bool) -> Option<Vec<Segment>> 
                 }
                 lex.end_word();
                 lex.end_segment();
+                // Heredoc bodies begin after the line's newline, however many
+                // commands sat on it, and stack in the order their operators
+                // appeared.
+                if c == '\n' {
+                    for heredoc in std::mem::take(&mut lex.pending_heredocs) {
+                        take_heredoc_body(&mut chars, &heredoc)?;
+                    }
+                }
             }
             c if c.is_whitespace() => lex.end_word(),
             _ => {
@@ -581,7 +630,126 @@ fn tokenize_for(command: &str, backslash_escapes: bool) -> Option<Vec<Segment>> 
     }
     lex.end_word();
     lex.end_segment();
+    // A heredoc still waiting for its body when the input ends never got one.
+    // The real shell would keep reading lines that are not here, so what runs
+    // is not knowable and the line stays unreadable.
+    if !lex.pending_heredocs.is_empty() {
+        return None;
+    }
     Some(lex.segments)
+}
+
+/// A heredoc a line has opened, waiting for the newline its body starts after.
+struct Heredoc {
+    /// The word that ends the body, matched against whole lines.
+    delimiter: String,
+    /// Whether the delimiter carried any quoting. A quoted delimiter makes the
+    /// body pure data; an unquoted one leaves it subject to expansion, so a
+    /// command substitution inside it would really run.
+    literal: bool,
+    /// `<<-`: the shell strips leading tabs from body and delimiter lines.
+    strip_tabs: bool,
+}
+
+/// Read the delimiter word after `<<`, with its quoting.
+///
+/// Quote concatenation applies the way it does to any word (`<<'EO'F` ends at
+/// `EOF`), and any quoted piece - or a backslash escape - marks the whole
+/// delimiter quoted. `None` for a quote that never closes, or for no word at
+/// all (`<< ;`, or the third `<` of a here-string), where the shell would be
+/// reading something this cannot.
+fn take_heredoc_delimiter(
+    chars: &mut std::iter::Peekable<std::str::Chars>,
+    escapes: bool,
+    strip_tabs: bool,
+) -> Option<Heredoc> {
+    let mut delimiter = String::new();
+    let mut literal = false;
+    loop {
+        match chars.peek() {
+            Some('\'') => {
+                chars.next();
+                literal = true;
+                loop {
+                    match chars.next()? {
+                        '\'' => break,
+                        q => delimiter.push(q),
+                    }
+                }
+            }
+            Some('"') => {
+                chars.next();
+                literal = true;
+                loop {
+                    match chars.next()? {
+                        '"' => break,
+                        q => delimiter.push(q),
+                    }
+                }
+            }
+            Some('\\') if escapes => {
+                chars.next();
+                literal = true;
+                delimiter.push(chars.next()?);
+            }
+            Some(&c)
+                if c.is_whitespace() || matches!(c, ';' | '&' | '|' | '(' | ')' | '<' | '>') =>
+            {
+                break;
+            }
+            Some(&c) => {
+                chars.next();
+                delimiter.push(c);
+            }
+            None => break,
+        }
+    }
+    match delimiter.is_empty() {
+        true => None,
+        false => Some(Heredoc {
+            delimiter,
+            literal,
+            strip_tabs,
+        }),
+    }
+}
+
+/// Consume one heredoc's body, leaving `chars` just past the delimiter line.
+///
+/// `None` in the two cases where the line has to stay unreadable: the body
+/// never ends (the shell would keep reading input that is not here), and an
+/// unquoted body holding a `` ` `` or `$(` (the shell expands such a body, so
+/// a substitution inside it really runs - and could write - which is exactly
+/// what this reader exists to not guess about). A quoted body is data whatever
+/// it contains.
+fn take_heredoc_body(
+    chars: &mut std::iter::Peekable<std::str::Chars>,
+    heredoc: &Heredoc,
+) -> Option<()> {
+    loop {
+        let mut line = String::new();
+        let mut line_ended = false;
+        for c in chars.by_ref() {
+            if c == '\n' {
+                line_ended = true;
+                break;
+            }
+            line.push(c);
+        }
+        let candidate = match heredoc.strip_tabs {
+            true => line.trim_start_matches('\t'),
+            false => line.as_str(),
+        };
+        if candidate == heredoc.delimiter {
+            return Some(());
+        }
+        if !heredoc.literal && (line.contains('`') || line.contains("$(")) {
+            return None;
+        }
+        if !line_ended {
+            return None;
+        }
+    }
 }
 
 /// The tokenizer's mutable state, gathered so the character loop reads as the
@@ -599,6 +767,10 @@ struct Lexer {
     quoted: bool,
     /// Set by a redirect operator: the next word names a file, not a program.
     swallow: Option<Swallow>,
+    /// Heredocs the current line has opened, in operator order. Their bodies
+    /// are consumed at the line's newline; input ending first makes the whole
+    /// line unreadable.
+    pending_heredocs: Vec<Heredoc>,
 }
 
 /// What the word a redirect claimed is going to be used for.

--- a/crates/leviath-cli/src/shell_keys/tests.rs
+++ b/crates/leviath-cli/src/shell_keys/tests.rs
@@ -900,21 +900,154 @@ fn a_literal_redirect_names_its_target() {
 #[test]
 fn an_unreadable_line_is_unreadable_only_when_it_redirects() {
     assert_eq!(
-        write_targets("cat <<EOF > out.txt\nx\nEOF"),
-        WriteTargets::Unreadable
-    );
-    assert_eq!(
         write_targets("echo `id` > out.txt"),
         WriteTargets::Unreadable
     );
-    assert_eq!(
-        write_targets("cat <<EOF\nx\nEOF"),
-        WriteTargets::Known(Vec::new())
-    );
-    assert!(write_target_paths("cat <<EOF > out.txt\nx\nEOF").is_empty());
+    assert_eq!(write_targets("echo `id`"), WriteTargets::Known(Vec::new()));
+    assert!(write_target_paths("echo `id` > out.txt").is_empty());
     assert_eq!(
         write_targets("echo x > out.txt"),
         WriteTargets::Known(vec!["out.txt".to_string()])
+    );
+}
+
+/// A well-formed heredoc line is grantable now that it tokenizes: the body is
+/// stdin data, so `python3 - <<'EOF'` keys the same as any other `python3 -`,
+/// and nothing in the body leaks into the key.
+#[test]
+fn a_heredoc_line_is_keyed_by_its_command_alone() {
+    let segments = tokenize_for("python3 - <<'EOF'\nprint(1 > 0)\nEOF", true).expect("readable");
+    assert_eq!(keys_from_segments(&segments), ["shell:python3"]);
+}
+
+/// A heredoc's body is stdin data, so the redirect fence reads through it: a
+/// `>` beside the operator is a named target held to confinement, and a `>`
+/// inside the body is text. Before heredocs tokenized, `cat <<EOF > out.txt`
+/// was refused outright, and `python3 - <<'EOF'` with any comparison or `->`
+/// in the script was refused with it.
+#[test]
+fn a_heredoc_redirect_names_its_target_and_the_body_is_data() {
+    assert_eq!(
+        write_targets_for("cat <<EOF > out.txt\nx\nEOF", true),
+        WriteTargets::Known(vec!["out.txt".to_string()])
+    );
+    assert_eq!(
+        write_targets_for("cat <<EOF > /tmp/pwned\nx\nEOF", true),
+        WriteTargets::Known(vec!["/tmp/pwned".to_string()])
+    );
+    assert_eq!(
+        write_targets_for(
+            "python3 - <<'EOF'\ndef f(x) -> int:\n    return x > 3\nEOF",
+            true
+        ),
+        WriteTargets::Known(Vec::new())
+    );
+}
+
+/// `cmd.exe` has no heredocs: the lines a POSIX shell would read as a body
+/// really run as commands there, so swallowing them would hide their
+/// redirects. On that reading the construct stays unreadable, exactly as
+/// before heredocs tokenized.
+#[test]
+fn on_a_shell_without_heredocs_the_construct_stays_unreadable() {
+    assert_eq!(
+        write_targets_for("cat <<EOF > out.txt\nx\nEOF", false),
+        WriteTargets::Unreadable
+    );
+    assert_eq!(
+        write_targets_for("python3 - <<'EOF'\nprint(1 > 0)\nEOF", false),
+        WriteTargets::Unreadable
+    );
+    assert_eq!(
+        write_targets_for("cat <<EOF\nx\nEOF", false),
+        WriteTargets::Known(Vec::new())
+    );
+}
+
+/// The two heredoc shapes whose bodies cannot be trusted as data keep the
+/// line unreadable: a body that never ends (the shell would keep reading
+/// input that is not here), and an unquoted body holding a substitution,
+/// which the shell expands - `$(...)` or a backtick in it really runs, and
+/// could write. Quoting the delimiter makes the same body pure data.
+#[test]
+fn a_heredoc_body_that_could_run_something_stays_unreadable() {
+    assert_eq!(
+        write_targets_for("cat <<EOF > out.txt\n$(touch /tmp/pwned)\nEOF", true),
+        WriteTargets::Unreadable
+    );
+    assert_eq!(
+        write_targets_for("cat <<EOF > out.txt\n`touch /tmp/pwned`\nEOF", true),
+        WriteTargets::Unreadable
+    );
+    assert_eq!(
+        write_targets_for("cat <<'EOF' > out.txt\n$(touch /tmp/pwned)\nEOF", true),
+        WriteTargets::Known(vec!["out.txt".to_string()])
+    );
+    // Never terminated: with a body (delimiter absent), and with none at all.
+    assert_eq!(
+        write_targets_for("cat <<EOF > out.txt\nstill going", true),
+        WriteTargets::Unreadable
+    );
+    assert_eq!(
+        write_targets_for("cat <<EOF > out.txt", true),
+        WriteTargets::Unreadable
+    );
+}
+
+/// The delimiter grammar: quote concatenation ends at the assembled word, a
+/// double-quoted or backslash-escaped delimiter is as literal as a
+/// single-quoted one, `<<-` matches the delimiter behind leading tabs, and a
+/// delimiter as the input's last line needs no trailing newline. Two heredocs
+/// on one line stack in operator order.
+#[test]
+fn heredoc_delimiters_follow_the_word_grammar() {
+    for command in [
+        "cat <<'EO'F > out.txt\nx\nEOF",
+        "cat <<\"EOF\" > out.txt\nx\nEOF",
+        "cat <<\\EOF > out.txt\nx\nEOF",
+        "cat <<-EOF > out.txt\n\tx\n\t\tEOF",
+        "cat 3<<EOF > out.txt\nx\nEOF",
+        // No space before `<<`: the word attached to it ends, the same as any
+        // other operator terminates a word.
+        "cat<<EOF > out.txt\nx\nEOF",
+        "cat <<EOF > out.txt\nx\nEOF",
+        "cat <<A <<B > out.txt\na body\nA\nb body\nB",
+    ] {
+        assert_eq!(
+            write_targets_for(command, true),
+            WriteTargets::Known(vec!["out.txt".to_string()]),
+            "{command:?}"
+        );
+    }
+    // A quoted delimiter marks the body literal even when only part of the
+    // word was quoted, so a substitution in this body is data.
+    assert_eq!(
+        write_targets_for("cat <<'EO'F\n$(true)\nEOF", true),
+        WriteTargets::Known(Vec::new())
+    );
+    // No delimiter at all: `<< ;` and the here-string's third `<`.
+    assert_eq!(
+        write_targets_for("cat << ; echo hi > out.txt", true),
+        WriteTargets::Unreadable
+    );
+    assert_eq!(
+        write_targets_for("grep x <<< data > out.txt", true),
+        WriteTargets::Unreadable
+    );
+    // A backslash as the input's final character escapes nothing, so the
+    // delimiter never completes and the line will not read.
+    assert_eq!(
+        write_targets_for("cat <<\\", true),
+        WriteTargets::Known(Vec::new())
+    );
+    // A delimiter whose quote never closes reads like any unterminated quote.
+    assert_eq!(
+        write_targets_for("cat <<'EOF > out.txt\nx\nEOF", true),
+        WriteTargets::Unreadable
+    );
+    assert_eq!(
+        write_targets_for("cat <<\"EOF > out.txt\nx\nEOF", true),
+        WriteTargets::Unreadable
     );
 }
 

--- a/crates/leviath-cli/src/shell_keys/tests.rs
+++ b/crates/leviath-cli/src/shell_keys/tests.rs
@@ -1034,6 +1034,14 @@ fn heredoc_delimiters_follow_the_word_grammar() {
         write_targets_for("grep x <<< data > out.txt", true),
         WriteTargets::Unreadable
     );
+    // A delimiter word that runs to the end of input opens a heredoc whose
+    // body never arrives, so the line will not read. Pinned with the POSIX
+    // reading explicitly, since the platform default skips heredocs entirely
+    // where `\` is not an escape.
+    assert_eq!(
+        write_targets_for("grep x <<END", true),
+        WriteTargets::Known(Vec::new())
+    );
     // A backslash as the input's final character escapes nothing, so the
     // delimiter never completes and the line will not read.
     assert_eq!(

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -368,11 +368,27 @@ pub(crate) fn escaping_write_refusal(
     arguments: &serde_json::Value,
     workdir: &std::path::Path,
 ) -> Option<String> {
+    escaping_write_refusal_for(
+        tool_name,
+        arguments,
+        workdir,
+        crate::shell_keys::BACKSLASH_ESCAPES,
+    )
+}
+
+/// [`escaping_write_refusal`] with the shell reading supplied, so both
+/// platforms' fences are testable on either.
+pub(crate) fn escaping_write_refusal_for(
+    tool_name: &str,
+    arguments: &serde_json::Value,
+    workdir: &std::path::Path,
+    backslash_escapes: bool,
+) -> Option<String> {
     if leviath_tools::canonical_tool_name(tool_name) != "shell" {
         return None;
     }
     let command = arguments.get("command").and_then(|v| v.as_str())?;
-    let targets = match crate::shell_keys::write_targets(command) {
+    let targets = match crate::shell_keys::write_targets_for(command, backslash_escapes) {
         crate::shell_keys::WriteTargets::Known(targets) => targets,
         // Refused even when the redirect would land inside the tree: "inside"
         // is a judgement about a path this could not read, and the fence is
@@ -380,9 +396,10 @@ pub(crate) fn escaping_write_refusal(
         crate::shell_keys::WriteTargets::Unreadable => {
             return Some(
                 "[denied] This shell line redirects with `>` inside a construct that cannot be \
-                 read ahead of time (a heredoc, a backtick, an unterminated quote or an \
-                 unbalanced `$(`), so where it writes cannot be checked against the working \
-                 directory. Use the `write_file` tool, or rewrite the line without that construct."
+                 read ahead of time (a backtick, an unterminated quote, an unbalanced `$(`, or \
+                 a heredoc whose body never ends or would expand a substitution), so where it \
+                 writes cannot be checked against the working directory. Use the `write_file` \
+                 tool, or rewrite the line without that construct."
                     .to_string(),
             );
         }
@@ -1006,33 +1023,99 @@ mod policy_tests {
 
     /// A redirect the tokenizer cannot read past is refused outright.
     ///
-    /// A heredoc, a backtick, an unterminated quote and an unbalanced `$(`
-    /// each stop the line being read as commands. Answering "no targets found"
-    /// there would let `cat <<EOF > /tmp/pwned` through under `--yolo` while
-    /// the same path in `write_file` is refused. Every redirect operator, under
-    /// every construct, against a path outside.
+    /// A backtick, an unterminated quote and an unbalanced `$(` each stop the
+    /// line being read as commands. Answering "no targets found" there would
+    /// let the redirect through under `--yolo` while the same path in
+    /// `write_file` is refused. Every redirect operator, under every
+    /// construct, against a path outside.
     #[test]
     fn no_unreadable_redirect_escapes_the_workdir() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let constructs: [(&str, &str); 6] = [
-            ("cat <<EOF", "\nx\nEOF"),
-            ("cat <<'EOF'", "\nx\nEOF"),
-            ("echo `id`", ""),
-            ("echo 'unterminated", ""),
-            ("echo \"unterminated", ""),
-            ("echo $(id", ""),
+        let constructs: [&str; 4] = [
+            "echo `id`",
+            "echo 'unterminated",
+            "echo \"unterminated",
+            "echo $(id",
         ];
         let mut checked = 0;
-        for (head, tail) in constructs {
+        for head in constructs {
             for op in [">", ">>", "2>", "&>", ">|", "<>"] {
-                let command = format!("{head} {op} /tmp/escaped.txt{tail}");
+                let command = format!("{head} {op} /tmp/escaped.txt");
                 let refusal = escaping_write_refusal("shell", &shell_call(&command), dir.path());
                 let refusal = refusal.unwrap_or_default();
                 assert!(refusal.contains("cannot be read"), "{command:?}: {refusal}");
                 checked += 1;
             }
         }
-        assert_eq!(checked, 36);
+        assert_eq!(checked, 24);
+    }
+
+    /// A heredoc no longer hides a redirect beside it: on a POSIX shell the
+    /// line reads as commands, the body is stdin data, and the `>` target is
+    /// named and held to the same confinement as `write_file`. On `cmd.exe`,
+    /// which has no heredocs, the construct stays unreadable and is refused
+    /// outright. Refused either way - what changed is only how precisely.
+    #[test]
+    fn a_heredoc_redirect_outside_the_workdir_is_refused_on_both_shells() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for head in ["cat <<EOF", "cat <<'EOF'"] {
+            for op in [">", ">>", "2>", "&>", ">|", "<>"] {
+                let command = format!("{head} {op} /tmp/escaped.txt\nx\nEOF");
+                let posix =
+                    escaping_write_refusal_for("shell", &shell_call(&command), dir.path(), true)
+                        .unwrap_or_default();
+                assert!(
+                    posix.contains("outside the working directory"),
+                    "{command:?}: {posix}"
+                );
+                let cmd_exe =
+                    escaping_write_refusal_for("shell", &shell_call(&command), dir.path(), false)
+                        .unwrap_or_default();
+                assert!(cmd_exe.contains("cannot be read"), "{command:?}: {cmd_exe}");
+            }
+        }
+    }
+
+    /// The fix this fence's precision buys: a heredoc that writes nowhere, or
+    /// redirects inside the tree, runs on a POSIX shell instead of being
+    /// refused for the `>` characters inside its body. Inline python is the
+    /// motivating case - any script of substance holds a `->` or a
+    /// comparison, and every one was refused. On `cmd.exe` the same lines
+    /// stay refused, since there the body lines would really run as commands.
+    #[test]
+    fn a_posix_heredoc_with_an_inside_or_no_redirect_is_allowed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for command in [
+            "python3 - <<'EOF'\ndef f(x) -> int:\n    return x > 3\nEOF",
+            "cat <<EOF > inside.txt\na > b\nEOF",
+        ] {
+            assert_eq!(
+                escaping_write_refusal_for("shell", &shell_call(command), dir.path(), true),
+                None,
+                "{command:?} stays inside and must not be refused"
+            );
+            let cmd_exe =
+                escaping_write_refusal_for("shell", &shell_call(command), dir.path(), false)
+                    .unwrap_or_default();
+            assert!(cmd_exe.contains("cannot be read"), "{command:?}: {cmd_exe}");
+        }
+    }
+
+    /// The body of an unquoted heredoc expands, so a substitution inside it
+    /// really runs and could write; with a redirect somewhere on the line, the
+    /// whole construct is refused rather than read as data.
+    #[test]
+    fn an_unquoted_heredoc_body_with_a_substitution_is_still_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for command in [
+            "cat <<EOF > inside.txt\n$(touch /tmp/pwned)\nEOF",
+            "cat <<EOF > inside.txt\n`touch /tmp/pwned`\nEOF",
+        ] {
+            let refusal =
+                escaping_write_refusal_for("shell", &shell_call(command), dir.path(), true)
+                    .unwrap_or_default();
+            assert!(refusal.contains("cannot be read"), "{command:?}: {refusal}");
+        }
     }
 
     /// The controls. A line the tokenizer cannot read but that redirects
@@ -1060,12 +1143,9 @@ mod policy_tests {
     #[test]
     fn an_unreadable_redirect_inside_the_workdir_is_refused_too() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let refusal = escaping_write_refusal(
-            "shell",
-            &shell_call("cat <<EOF > inside.txt\nx\nEOF"),
-            dir.path(),
-        )
-        .unwrap_or_default();
+        let refusal =
+            escaping_write_refusal("shell", &shell_call("echo `id` > inside.txt"), dir.path())
+                .unwrap_or_default();
         assert!(refusal.contains("cannot be read"), "{refusal}");
         assert!(refusal.contains("write_file"), "{refusal}");
     }

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -87,6 +87,20 @@ Some targets the parser cannot name at all, such as `> $OUT` or bash's `/dev/tcp
 have no path to check, so they are ungrantable: they prompt every time, and no approval makes them
 reusable.
 
+A line the parser cannot read as commands at all is different again. A backtick, an unterminated
+quote or an unbalanced `$(` could put a redirect anywhere, so a line carrying one is refused
+outright the moment it also carries a `>` - guessing where it writes is exactly what the fence
+exists not to do. Rewrite the line without the construct, or use the `write_file` tool.
+
+A **heredoc is read**, not refused: its body is standard input, so `python3 - <<'EOF' ... EOF`
+runs with the whole script on stdin, and a `>` or a `->` inside that body is text rather than a
+redirect. A real redirect beside the operator still counts - `cat <<EOF > report.md` writes
+`report.md` and is confined to the workspace like any other. The two heredoc shapes that could
+still hide a command keep the old refusal: a body that never reaches its delimiter, and an
+**unquoted** heredoc (`<<EOF`, not `<<'EOF'`) whose body contains a `$(...)` or backtick the shell
+would expand and run. Quoting the delimiter makes the body pure data. On Windows there are no
+heredocs, so the construct stays unreadable there and is refused.
+
 ### How much output comes back
 
 At most 1 MB of stdout and 1 MB of stderr per call. Past that the bytes are counted and dropped,


### PR DESCRIPTION
Fixes a regression from 0.5.6's redirect fence (`123f8749`): the shell write-fence tokenizer treats every heredoc as an unreadable line, so any heredoc carrying a `>` is refused outright with "a redirect that cannot be read". Since a `python3 - <<'EOF'` script of any substance holds a comparison or a `->` return annotation, effectively every inline-Python shell call was denied — even ones that wrote nothing. Reported by a user whose agents build tools this way.

## The fix

The tokenizer now reads POSIX heredocs as the commands they are. `<<WORD` consumes the delimiter (quoted, `<<-`, and fd-prefixed `3<<` variants included); the body is swallowed at the line's newline as the stdin data it is, so a `>` or `->` inside it is text. A real redirect beside the operator (`cat <<EOF > out`) keeps its target and the same workspace confinement as `write_file`.

## Security is unchanged

The reader only trusts a body it has proven is data. Still refused:

- A heredoc body that never reaches its delimiter (the shell would keep reading input that isn't here).
- An **unquoted** heredoc (`<<EOF`) whose body holds a `$(...)` or backtick the shell would expand and run. Quoting the delimiter (`<<'EOF'`) makes the body pure data.
- Every heredoc on a shell without them (`cmd.exe`), where the "body" lines would really execute as commands — judged by the same `backslash_escapes` platform flag the fence already used for path reading.

A backtick, unterminated quote, or unbalanced `$(` beside a `>` is still refused as before.

## Verification

- Unit tests cover the delimiter grammar, both platform readings, the body-substitution and never-terminated refusals, and the grant key. Existing tests that asserted heredocs were refused are updated to the precise behavior; one (`no_unreadable_redirect_escapes_the_workdir`) kept for the backtick/quote/`$(` constructs that stay unreadable.
- Live-verified against a real daemon (mock provider, isolated home): a workspace-internal `python3 - <<'EOF'` with `->` and `>` in the body that **0.5.7 refused** now runs and creates its file; an out-of-tree `cat <<EOF > /tmp/...` redirect is still denied with the file never created.
- `docs/tools` "Where a redirect may write" gains the heredoc rules and the unreadable-line refusal.
