### PR TITLE
feat(providers,cli): make a tokens_per_minute throttle visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ same list.
 
 ## Unreleased
 
+### Changed
+
+- A `tokens_per_minute` rate limit that throttles a run now says so. The first
+  time a run waits on the token window the daemon logs a `warn` naming the
+  limit, and `lev doctor` (with `GET /api/doctor`) flags a `tokens_per_minute`
+  low enough to throttle almost every call. The limit was enforced for the
+  first time in an earlier release after being parsed-but-inert, so a stale or
+  placeholder value could silently serialize a run to about one call a minute,
+  indistinguishable from a slow model. The fix each surface names is the same:
+  raise it, or set `0` to disable the token window.
+
 ### Fixed
 
 - A shell heredoc no longer hides a redirect from the write fence, and no

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -394,6 +394,48 @@ fn misdirected_rate_limits(config: &Config) -> Vec<String> {
     misdirected
 }
 
+/// The floor below which a `tokens_per_minute` is almost certainly a mistake.
+///
+/// A single inference's prompt alone runs to thousands of tokens, so a limit
+/// under this throttles nearly every call to about one a minute. `tokens_per_minute`
+/// was documented as parsed-but-inert before it was enforced, so a value set
+/// then - a placeholder, or a guess at "some small number" - now silently
+/// serializes a run. The check names it; the fix is to raise it or set `0`.
+const IMPLAUSIBLE_TPM_FLOOR: u32 = 1_000;
+
+/// Configured `tokens_per_minute` values low enough to throttle almost every
+/// call, from `[rate_limits.<provider>]` and each `[model_providers.<name>]
+/// rate_limit`, each rendered as one report line.
+///
+/// A `0` is "no token limit" and is skipped. Above the floor is the user's
+/// call and left alone. Sorted, so a map's arbitrary order does not reorder
+/// the report.
+fn low_token_rate_limits(config: &Config) -> Vec<String> {
+    let mut low: Vec<String> = Vec::new();
+    let mut consider = |label: String, tpm: u32| {
+        if tpm != 0 && tpm < IMPLAUSIBLE_TPM_FLOOR {
+            low.push(format!(
+                "{label} tokens_per_minute = {tpm} is below one call's usual size, so runs \
+                 throttle to about one call a minute - raise it, or set 0 to disable the token \
+                 limit"
+            ));
+        }
+    };
+    for (name, rl) in &config.rate_limits {
+        consider(format!("rate_limits.{name}:"), rl.tokens_per_minute);
+    }
+    for (name, provider) in &config.model_providers {
+        if let Some(rl) = &provider.rate_limit {
+            consider(
+                format!("model_providers.{name}.rate_limit:"),
+                rl.tokens_per_minute,
+            );
+        }
+    }
+    low.sort_unstable();
+    low
+}
+
 /// `[model_providers.<name>]` script entries whose `.rhai` file is nowhere on
 /// disk, each rendered as one report line.
 ///
@@ -486,6 +528,10 @@ fn config_check(config: &Config, registry: &ProviderRegistry) -> Check {
     // Same posture as the unread keys, and reported beside them: the config
     // deserializes fine and one entry of it does nothing.
     let mut notes = missing_script_providers(config, crate::config::providers_dir().as_deref());
+    // A token limit low enough to throttle every call reads the same as a slow
+    // model from the outside, so it is worth naming here where the rest of the
+    // config is explained rather than left to a warn line as a run crawls.
+    notes.extend(low_token_rate_limits(config));
     if !unread.is_empty() {
         let subject = match unread.len() {
             1 => "1 key in config.toml is".to_string(),

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -578,6 +578,86 @@ fn config_check_counts_more_than_one_unread_key() {
     );
 }
 
+/// A `tokens_per_minute` below one call's usual size throttles nearly every
+/// call, which reads as a slow model from the outside. The config check names
+/// it - the value was documented inert before it was enforced, so a stale one
+/// now serializes a run silently. A `0` (no token limit) and a plausible cap
+/// stay quiet, or the note would just report every limit anyone set.
+#[test]
+fn config_check_names_an_implausibly_low_tokens_per_minute() {
+    let mut config = Config::default();
+    config.rate_limits.insert(
+        "openrouter".to_string(),
+        leviath_providers::RateLimitConfig {
+            requests_per_minute: 10,
+            tokens_per_minute: 100,
+        },
+    );
+    // A script provider's own `rate_limit` is read the same way.
+    config.model_providers.insert(
+        "groq".to_string(),
+        crate::config::ModelProviderConfig {
+            rate_limit: Some(leviath_providers::RateLimitConfig {
+                requests_per_minute: 30,
+                tokens_per_minute: 50,
+            }),
+            ..Default::default()
+        },
+    );
+    let check = checked(
+        "doctor-config_check_names_an_implausibly_low_tokens_per_minute",
+        &config,
+        &ProviderRegistry::new(),
+    );
+    assert_eq!(check.status, CheckStatus::Ok, "not broken wiring");
+    assert!(
+        check
+            .detail
+            .contains("rate_limits.openrouter: tokens_per_minute = 100")
+            && check.detail.contains("about one call a minute"),
+        "got: {}",
+        check.detail
+    );
+    assert!(
+        check
+            .detail
+            .contains("model_providers.groq.rate_limit: tokens_per_minute = 50"),
+        "got: {}",
+        check.detail
+    );
+}
+
+/// A `0` token limit means no limit, and a plausible cap is the user's call:
+/// neither is flagged.
+#[test]
+fn config_check_is_quiet_on_a_zero_or_ample_tokens_per_minute() {
+    let mut config = Config::default();
+    config.rate_limits.insert(
+        "openrouter".to_string(),
+        leviath_providers::RateLimitConfig {
+            requests_per_minute: 10,
+            tokens_per_minute: 0,
+        },
+    );
+    config.rate_limits.insert(
+        "anthropic".to_string(),
+        leviath_providers::RateLimitConfig {
+            requests_per_minute: 10,
+            tokens_per_minute: 40_000,
+        },
+    );
+    let check = checked(
+        "doctor-config_check_is_quiet_on_a_zero_or_ample_tokens_per_minute",
+        &config,
+        &ProviderRegistry::new(),
+    );
+    assert!(
+        !check.detail.contains("about one call a minute"),
+        "got: {}",
+        check.detail
+    );
+}
+
 #[test]
 fn config_check_is_quiet_when_every_rate_limit_names_a_real_provider() {
     let mut config = Config::default();

--- a/crates/leviath-providers/src/rate_limit.rs
+++ b/crates/leviath-providers/src/rate_limit.rs
@@ -43,6 +43,12 @@ enum Admission {
         wait: Duration,
         requests: u32,
         tokens: usize,
+        /// The token window is (part of) why this call is waiting, and it is
+        /// the first time this limiter has throttled on it. Surfaced once at
+        /// `warn` so a `tokens_per_minute` that was inert before it was
+        /// enforced does not slow a run invisibly; later waits stay at
+        /// `debug`.
+        first_tpm_wait: bool,
     },
 }
 
@@ -50,6 +56,8 @@ struct RateLimiterState {
     request_timestamps: VecDeque<Instant>,
     token_counts: VecDeque<(Instant, usize)>,
     consecutive_429s: u32,
+    /// Whether the one-time `tokens_per_minute` throttle notice has fired.
+    tpm_wait_announced: bool,
 }
 
 impl RateLimiter {
@@ -69,6 +77,7 @@ impl RateLimiter {
                 request_timestamps: VecDeque::new(),
                 token_counts: VecDeque::new(),
                 consecutive_429s: 0,
+                tpm_wait_announced: false,
             })),
         }
     }
@@ -87,7 +96,7 @@ impl RateLimiter {
             // The lock lives in this block and is gone before the sleep: a
             // guard still in scope across the await would make the future
             // `!Send`, even after an explicit drop.
-            let (wait, current_rpm, current_tpm) = {
+            let (wait, current_rpm, current_tpm, first_tpm_wait) = {
                 let mut state = self.state();
                 match self.admit(&mut state) {
                     Admission::Now => return Ok(()),
@@ -95,9 +104,24 @@ impl RateLimiter {
                         wait,
                         requests,
                         tokens,
-                    } => (wait, requests, tokens),
+                        first_tpm_wait,
+                    } => (wait, requests, tokens, first_tpm_wait),
                 }
             };
+            // The first time a run waits on the token window, say so at `warn`.
+            // The limit was documented as inert before it was enforced, so a
+            // stale or placeholder `tokens_per_minute` throttles silently
+            // otherwise, indistinguishable from a slow model. Once per limiter;
+            // the debug line still carries every wait.
+            if first_tpm_wait {
+                tracing::warn!(
+                    tokens_per_minute = self.tpm_limit,
+                    tokens_in_window = current_tpm,
+                    "Throttling on a configured tokens_per_minute limit: calls are waiting for the \
+                     token window to clear. This is a client-side rate limit; raise it or set \
+                     tokens_per_minute = 0 to disable it."
+                );
+            }
             tracing::debug!(
                 wait_ms = wait.as_millis(),
                 requests = current_rpm,
@@ -156,14 +180,22 @@ impl RateLimiter {
             let oldest = state.request_timestamps.front().copied().unwrap_or(now);
             until = until.max(oldest + window);
         }
+        let mut first_tpm_wait = false;
         if !tpm_ok {
             let oldest = state.token_counts.front().map(|(t, _)| *t).unwrap_or(now);
             until = until.max(oldest + window);
+            // Latch the one-time notice here, while the lock is held, so it
+            // fires exactly once however many callers are waiting at once.
+            if !state.tpm_wait_announced {
+                state.tpm_wait_announced = true;
+                first_tpm_wait = true;
+            }
         }
         Admission::Wait {
             wait: until.saturating_duration_since(now) + Duration::from_millis(50),
             requests: current_rpm,
             tokens: current_tpm,
+            first_tpm_wait,
         }
     }
 
@@ -295,6 +327,53 @@ mod tests {
         });
         // Should be able to acquire at least once
         limiter.acquire().await.unwrap();
+    }
+
+    /// The first time a call waits on the token window, the one-time notice
+    /// latches; it does not before any wait, and a second wait does not
+    /// re-arm it. The `warn!` fires under a real subscriber so its fields run.
+    #[tokio::test]
+    async fn the_first_tpm_wait_announces_once() {
+        let _guard = always_on_tracing_guard();
+        let limiter = short_window(60, 100);
+        assert!(
+            !limiter.state().tpm_wait_announced,
+            "nothing waited yet, so nothing announced"
+        );
+        limiter.record_tokens(100);
+        // First throttled acquire: waits, then announces as it goes.
+        tokio::time::timeout(Duration::from_secs(5), limiter.acquire())
+            .await
+            .expect("released once the window turned over")
+            .expect("acquire succeeds");
+        assert!(
+            limiter.state().tpm_wait_announced,
+            "the first token-window wait announced"
+        );
+        // A second throttle does not re-arm the latch.
+        limiter.record_tokens(100);
+        tokio::time::timeout(Duration::from_secs(5), limiter.acquire())
+            .await
+            .expect("released again")
+            .expect("acquire succeeds");
+        assert!(limiter.state().tpm_wait_announced, "still latched, once");
+    }
+
+    /// A wait driven only by the request window never arms the token notice:
+    /// the two limits are separate, and the notice is about the one that was
+    /// documented inert.
+    #[tokio::test]
+    async fn an_rpm_only_wait_does_not_announce_a_tpm_throttle() {
+        let limiter = short_window(1, 0);
+        limiter.acquire().await.expect("first request admitted");
+        tokio::time::timeout(Duration::from_secs(5), limiter.acquire())
+            .await
+            .expect("released once the request window turned over")
+            .expect("acquire succeeds");
+        assert!(
+            !limiter.state().tpm_wait_announced,
+            "an rpm wait is not a tpm throttle"
+        );
     }
 
     /// A limiter over a short window, so a wait is observable in real time.

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -671,6 +671,13 @@ entry to leave it. A `0` on either key means no limit on that side:
 `requests_per_minute = 0` leaves only the token window in force, and
 `tokens_per_minute = 0` only the request window.
 
+A throttle is visible, not silent. The first time a run waits on the token
+window the daemon logs a `warn` naming the limit, `lev doctor` (and
+`GET /api/doctor`) flags a `tokens_per_minute` low enough to throttle almost
+every call, and both point at the same fix: raise it, or set `0`. This matters
+because the limit was parsed but not enforced in older versions, so a value set
+back then now shapes a run for the first time.
+
 This shapes request *rate*. `[limits] max_concurrent_inferences` and
 `[limits.max_concurrent_inferences_by_provider]` bound *concurrency*. Both apply. Script providers
 configure their rate limit under `[model_providers.<name>.rate_limit]` instead; their concurrency


### PR DESCRIPTION
The audit of the 0.5.6/0.5.7 hardening flagged one item in the same "silently changed behavior" class as the rhai/token-limit/heredoc regressions: `tokens_per_minute` was parsed-but-inert in older versions and is now enforced (`83bebb11`), so a stale or placeholder value throttles a run silently — indistinguishable from a slow model, since a pre-emptive wait logged only at `debug`.

Enforcement is intended and stays unchanged. This makes the throttle **visible** on three surfaces, each pointing at the same fix (raise it, or set `0`):

- **Daemon log** — the first time a run waits on the token window, a `warn` names the limit; later waits stay at `debug`. Latched once per limiter, under the state lock so concurrent callers announce exactly once.
- **`lev doctor`** — flags a configured `tokens_per_minute` below one call's usual size (< 1000), on both `[rate_limits.<provider>]` and each `[model_providers.<name>].rate_limit`. `0` (no limit) and ample values stay quiet.
- **`GET /api/doctor`** — carries the same note for free: it runs the same `run_checks` and returns each check's `detail`, so a web console sees it without new API code.

Docs (`configuration` rate-limits section) and CHANGELOG updated. Coverage 100% on both changed crates; the throttle-announcement and both doctor branches (provider-level and top-level rate limits) are tested.
