### PR TITLE
docs: list Codex OAuth, and lift the critical onboarding pages into Get started

### DIFF
--- a/docs/content/agent-catalog.md
+++ b/docs/content/agent-catalog.md
@@ -3,7 +3,7 @@ title: Agent catalog
 description: The seven pre-built agents Leviath ships, what each is for, how to install them, and the lev run command for each.
 group: Get started
 group_order: 1
-order: 2
+order: 4
 ---
 
 # Agent catalog

--- a/docs/content/comparison.md
+++ b/docs/content/comparison.md
@@ -3,7 +3,7 @@ title: Where Leviath sits
 description: Where Leviath sits among other agent tools, and which are worth running alongside it rather than instead of it.
 group: Get started
 group_order: 1
-order: 3
+order: 2
 ---
 
 # Where Leviath sits
@@ -19,7 +19,7 @@ runtime. So this page is about layers, not scores, and several of the tools belo
 
 ```mermaid
 flowchart TD
-  ORCH["Orchestrators<br/>Gas Town / Gas City"]
+  ORCH["Orchestrators<br/>Gas Town / Gas City / OpenClaw / Hermes"]
   ORCH --> AGENTS["Agent layer"]
   subgraph AGENTS["Agent layer: pick one"]
     CC["Coding agents<br/>Claude Code, Codex, OpenHands"]

--- a/docs/content/first-agent.md
+++ b/docs/content/first-agent.md
@@ -1,9 +1,9 @@
 ---
 title: Build your first agent
 description: Build a release-notes agent from an empty directory: stages, models, context regions, an error edge, and a structured answer.
-group: Concepts
-group_order: 2
-order: 2
+group: Get started
+group_order: 1
+order: 5
 ---
 
 # Build your first agent

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -233,5 +233,5 @@ scratch, a stage at a time, and is the natural next thing to read.
   a page starts using a word you have not met.
 - [Where Leviath sits](/docs/comparison) is for deciding whether you want Leviath at all, and what
   to run alongside it.
-- [Where Leviath fits](/docs/integrations) covers driving Leviath from a tool you already use, like
-  an orchestrator or a CI job.
+- [How Leviath integrates](/docs/integrations) covers driving Leviath from a tool you already use,
+  like an orchestrator or a CI job.

--- a/docs/content/integrations.md
+++ b/docs/content/integrations.md
@@ -1,5 +1,5 @@
 ---
-title: Where Leviath fits
+title: How Leviath integrates
 description: The four ways to drive Leviath from a tool you already use, and how to choose between them.
 group: Integrations
 group_order: 5

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -1,9 +1,9 @@
 ---
 title: MCP tool servers
 description: Connect Leviath to Model Context Protocol servers over stdio or HTTP, giving agents tools beyond the built-ins.
-group: Reference
-group_order: 3
-order: 5
+group: Get started
+group_order: 1
+order: 7
 ---
 
 # MCP tool servers

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -1,9 +1,9 @@
 ---
 title: Providers
-description: Configure Anthropic, OpenAI, Google, OpenRouter, Ollama, or Claude Code from a key or an env var, and pick which model each stage uses.
-group: Reference
-group_order: 3
-order: 6
+description: Configure Anthropic, OpenAI, OpenAI Codex, Google, OpenRouter, Ollama, or Claude Code from a key or a browser sign-in, and pick each stage's model.
+group: Get started
+group_order: 1
+order: 3
 ---
 
 # Providers
@@ -18,6 +18,7 @@ writes it into `~/.leviath/config.toml` for you, interactively or with
 |---|---|---|
 | Anthropic | `ANTHROPIC_API_KEY` | [console.anthropic.com](https://console.anthropic.com/settings/keys) |
 | OpenAI | `OPENAI_API_KEY` | [platform.openai.com](https://platform.openai.com/api-keys) |
+| OpenAI Codex | none (ChatGPT subscription; browser sign-in) | [see below](#openai-codex-chatgpt-subscription) |
 | Google (Gemini) | `GOOGLE_API_KEY` | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | OpenRouter | `OPENROUTER_API_KEY` | [openrouter.ai/keys](https://openrouter.ai/keys) |
 | Ollama | `OLLAMA_HOST` (optional, local) | [ollama.com/download](https://ollama.com/download) |
@@ -41,14 +42,17 @@ provider verbatim, so it has to be spelled the way the provider spells it:
 |---|---|---|
 | Anthropic | the bare model name | `claude-sonnet-5` |
 | OpenAI | the bare model name | `gpt-5.4-mini` |
+| OpenAI Codex | `codex/model` (prefix required) | `codex/gpt-5.5` |
 | Google | the bare model name | `gemini-2.5-pro` |
 | OpenRouter | `vendor/model` | `deepseek/deepseek-v4-flash` |
 | Ollama | `model:tag` | `qwen3.5:9b` |
 
 OpenRouter is the one that trips people up: its identifiers carry a vendor prefix, and the prefix is
 part of the name. `deepseek-v4-flash` is not a valid OpenRouter model; `deepseek/deepseek-v4-flash`
-is. Browse the full catalog at [openrouter.ai/models](https://openrouter.ai/models), or ask your
-install:
+is. OpenAI Codex carries a prefix for a different reason: `gpt-5.5` is the model, and the `codex/`
+in front of it names the provider, required because a bare model name never routes to Codex on its
+own (see [OpenAI Codex](#openai-codex-chatgpt-subscription)). Browse the full OpenRouter catalog at
+[openrouter.ai/models](https://openrouter.ai/models), or ask your install:
 
 ```bash
 lev models list --provider openrouter        # live from the gateway, with dates and prices

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -1,9 +1,9 @@
 ---
 title: Built-in tools
 description: The built-in tool catalog every agent can advertise, and how a stage decides which ones the model may call.
-group: Reference
-group_order: 3
-order: 4
+group: Get started
+group_order: 1
+order: 6
 ---
 
 # Built-in tools


### PR DESCRIPTION
Docs-only. No code change; version stays 0.5.8.

**Codex OAuth in the tables.** The providers table and the model-identifier table both omitted OpenAI Codex (the ChatGPT-subscription transport), even though the page already has a full `## OpenAI Codex` section. Added to both, with the `codex/` prefix explained — it's the provider selector, required because a bare model name never routes to Codex on its own (distinct from OpenRouter's slash, which is part of the model id).

**Critical pages lifted into Get started.** Moved Providers, Build your first agent, Built-in tools, and MCP tool servers into the Get started group, so the sidebar reads as an onboarding arc: Getting Started → Where Leviath sits → Providers → Agent catalog → Build your first agent → Built-in tools → MCP tool servers. Orders are unique within the group; the gaps left in Concepts/Reference are harmless (the renderer sorts by order) and no URLs changed (they're filename-based), so no cross-links broke.

**Diagram + rename.** Added OpenClaw and Hermes beside Gas Town and Gas City in the "Where Leviath sits" orchestrators diagram, matching the integrations page. Renamed the integrations page's sidebar title from "Where Leviath fits" to "How Leviath integrates" (it read almost identically to "Where Leviath sits"), and updated the one cross-reference.

After merge, docs are republished to alpha and beta via `publish-docs.yml` (no release re-cut needed).
