### PR TITLE
docs: correct provider-enumeration and Ollama claims for Codex and opt-in

### DIFF
--- a/docs/content/comparison.md
+++ b/docs/content/comparison.md
@@ -77,7 +77,8 @@ language against an SDK, that model is not here. Other languages drive Leviath t
 yourself. [`lev serve`](/docs/api) and [The Lair](https://leviath.dev/lair) reach it from anywhere,
 but there is no hosted service and no multi-machine scheduling.
 
-You also need a model provider either way: an API key or a local Ollama.
+You also need a model provider either way: an API key, a ChatGPT or Claude subscription you sign in
+to, or a local Ollama.
 
 One current limit worth knowing before you choose. Every agent has its own state, workdir fence,
 tool policy, and panic boundary, so one agent's crash stays its own. The opt-in

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -740,8 +740,10 @@ This is a warning, not an error. Every command reads `config.toml`, so one stale
 the CLI down. A blueprint is different: it is authored and validated deliberately, and it fails on
 an unknown key.
 
-The one place unrecognized keys are *kept*: `[model_providers.<name>]` forwards anything it does not
-recognize to the Rhai script, so those are read and never reported.
+The one place unrecognized keys are *kept*: a **script** `[model_providers.<name>]` entry forwards
+anything it does not recognize to the Rhai script, so those are read and never reported. An
+`openai-compatible` endpoint entry has no script to forward to, so it refuses an unknown key
+instead (see [OpenAI-compatible endpoints](#openai-compatible-endpoints)).
 
 <a id="model_capabilitiesmodel_id"></a>
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -115,8 +115,9 @@ To embed the runtime in your own application instead of running the CLI, add the
 
 ## Configure a provider
 
-One provider is all you need: an API key from Anthropic, OpenAI, Google AI, or OpenRouter,
-or a local [Ollama](https://ollama.com) with no key at all.
+One provider is all you need: an API key from Anthropic, OpenAI, Google AI, or OpenRouter; a
+ChatGPT subscription you sign in to (OpenAI Codex, no key); or a local [Ollama](https://ollama.com)
+with no key at all.
 
 ```bash
 lev setup
@@ -126,8 +127,9 @@ The wizard detects keys already in your environment, sets a default model, and i
 pre-built agents.
 
 > [!TIP]
-> No API key handy? Point Leviath at a local [Ollama](https://ollama.com) install and run
-> entirely offline. `lev setup` will detect it. See [Providers](/docs/providers) for the full list.
+> No API key handy? Two paths need none: sign in to a ChatGPT or Claude subscription, or point
+> Leviath at a local [Ollama](https://ollama.com) install and run entirely offline. `lev setup`
+> sets up either. See [Providers](/docs/providers) for the full list.
 
 <details>
 <summary>Script the setup instead</summary>

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -354,8 +354,8 @@ that collapses to one model everywhere, with the blueprint's own choice printed 
 substitution it is.
 
 > [!WARNING]
-> Ollama needs no key, so it is registered whether or not a server is running. Leave
-> `default_model` unset on a machine with no Ollama and every stage that lists it starts against
+> Once Ollama is enabled, it is registered whether or not a server is running. Leave `default_model`
+> unset on such a machine with no Ollama server up and every stage that lists it starts against
 > `http://localhost:11434`. The run moves on to its next candidate rather than dying there, but
 > it still spends the attempts finding out. This is why the bundled agents pin their Ollama entry
 > explicitly and put it last.

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -68,8 +68,9 @@ would succeed anonymously), and retry.
 
 ## No provider configured
 
-An agent needs at least one [provider](/docs/providers). Run `lev setup`, or point Leviath at a
-local [Ollama](https://ollama.com) for a no-key start.
+An agent needs at least one [provider](/docs/providers). Run `lev setup`: an API key, a ChatGPT or
+Claude subscription you sign in to, or a local [Ollama](https://ollama.com) all count, and the last
+two need no key.
 
 `lev doctor` says which provider your defaults actually resolve to, and which ones it tried to get
 there. That matters because a stage naming no model of its own falls back to `anthropic`. So a
@@ -117,13 +118,16 @@ one run, and copying the blueprint does it per stage. See
 
 ## My run went to Ollama and I never asked for it
 
-Ollama needs no key, so it is registered whether or not a server is running, and every bundled agent
-lists it last. With nothing else configured that is the first entry that matches, and the run starts
-against `http://localhost:11434`.
+If a run started on Ollama when you did not mean it to, Ollama is enabled in your config: either
+`[providers] ollama_enabled = true` or an `ollama_base_url` is set. One of them may have carried
+over from before Ollama became opt-in, since an address that used to configure it still does. Once
+it is on, every bundled agent lists it last, so on a stage that names no model of its own it is the
+first entry that matches, and the run starts against `http://localhost:11434`.
 
-Set `default_model` alongside your `default_provider`. Without a model to send, `default_provider`
-is never consulted and Ollama wins by default. `lev doctor` says so in its `resolve` line when your
-configured provider is being passed over.
+Two ways to stop it. Turn Ollama off if you did not mean to enable it. Or set `default_model`
+alongside your `default_provider`: without a model to send, `default_provider` is never consulted
+and Ollama wins by default. `lev doctor` says so in its `resolve` line when your configured provider
+is being passed over.
 
 A run that starts on a dead Ollama does not die there. An unreachable provider is treated the
 same as one out of credits, so the stage moves to its next candidate. You will see the swap in the


### PR DESCRIPTION
Docs-only accuracy sweep. No code change; version stays 0.5.8.

A whole-docs audit for statements the recent Codex and Ollama-opt-in changes made stale. Findings and fixes:

**Provider enumerations missing the subscription path**
- `getting-started` "Configure a provider" and its TIP, and `troubleshooting` "No provider configured", listed the ways to get a provider without naming the ChatGPT/Claude subscription sign-in — Ollama read as the only keyless option.
- `comparison` ("Where Leviath sits") said a provider is "an API key or a local Ollama"; now "an API key, a ChatGPT or Claude subscription you sign in to, or a local Ollama."

**Stale Ollama auto-registration (opt-in since 0.5.6)**
- `troubleshooting` "My run went to Ollama and I never asked for it" and the same warning on `providers` described the old always-registered behavior. Ollama is opt-in now (`[providers] ollama_enabled` or an `ollama_base_url`), verified at `run/session.rs:102` — a run only lands there when it is enabled (possibly carried over from before the switch). Reframed around that, with how to stop it.

**Endpoint unknown-key refusal**
- `configuration`'s note that `[model_providers]` "forwards anything" now distinguishes a script entry (forwards to the Rhai script) from an `openai-compatible` endpoint (refuses unknown keys).

The audit also confirmed the other 0.5.6–0.5.8 behavior-change docs are already accurate: validator reject-by-default, `on_write` honest rejection, heredoc read-not-refuse, the three-number token-limit message, `tokens_per_minute` enforcement + doctor flag, and `exact_token_counting` correctly removed from all docs.

After merge, docs are republished to alpha and beta via `publish-docs.yml`.
