### PR TITLE
feat(providers): an ordered provider preference for a bare model name

### DIFF
--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -394,6 +394,28 @@ fn misdirected_rate_limits(config: &Config) -> Vec<String> {
     misdirected
 }
 
+/// `[providers] provider_order` entries naming a provider that is not
+/// configured, each rendered as one report line.
+///
+/// The order is only a preference, so a name nothing serves is not an error -
+/// it just never wins anything, silently. A provider counts as known if it is
+/// one of the built-ins the wizard offers or a `[model_providers.<name>]`
+/// script entry, so a real custom provider does not read as a typo.
+fn misdirected_provider_order(config: &Config) -> Vec<String> {
+    let mut known: Vec<&str> = crate::commands::setup::catalog::providers()
+        .iter()
+        .map(|p| p.id)
+        .collect();
+    known.extend(config.model_providers.keys().map(String::as_str));
+    config
+        .providers
+        .provider_order
+        .iter()
+        .filter(|name| !known.contains(&name.as_str()))
+        .map(|name| format!("provider_order entry \"{name}\" names no configured provider"))
+        .collect()
+}
+
 /// The floor below which a `tokens_per_minute` is almost certainly a mistake.
 ///
 /// A single inference's prompt alone runs to thousands of tokens, so a limit
@@ -532,6 +554,9 @@ fn config_check(config: &Config, registry: &ProviderRegistry) -> Check {
     // model from the outside, so it is worth naming here where the rest of the
     // config is explained rather than left to a warn line as a run crawls.
     notes.extend(low_token_rate_limits(config));
+    // A provider_order entry that names nothing configured never wins a route
+    // and says nothing about it, the same silent kind of misconfiguration.
+    notes.extend(misdirected_provider_order(config));
     if !unread.is_empty() {
         let subject = match unread.len() {
             1 => "1 key in config.toml is".to_string(),

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -658,6 +658,41 @@ fn config_check_is_quiet_on_a_zero_or_ample_tokens_per_minute() {
     );
 }
 
+/// A `provider_order` entry naming nothing configured never wins a route and
+/// says nothing about it, so the config check names it. A real built-in and a
+/// `[model_providers]` script entry both count as configured and stay quiet.
+#[test]
+fn config_check_names_a_provider_order_entry_for_no_configured_provider() {
+    let mut config = Config::default();
+    config.providers.provider_order = vec![
+        "codex".to_string(),
+        "opennrouter".to_string(),
+        "my-gateway".to_string(),
+    ];
+    config.model_providers.insert(
+        "my-gateway".to_string(),
+        crate::config::ModelProviderConfig::default(),
+    );
+    let check = checked(
+        "doctor-config_check_names_a_provider_order_entry_for_no_configured_provider",
+        &config,
+        &ProviderRegistry::new(),
+    );
+    assert_eq!(check.status, CheckStatus::Ok, "not broken wiring");
+    assert!(
+        check
+            .detail
+            .contains("provider_order entry \"opennrouter\""),
+        "the typo is named: {}",
+        check.detail
+    );
+    assert!(
+        !check.detail.contains("\"codex\"") && !check.detail.contains("\"my-gateway\""),
+        "a built-in and a configured gateway stay quiet: {}",
+        check.detail
+    );
+}
+
 #[test]
 fn config_check_is_quiet_when_every_rate_limit_names_a_real_provider() {
     let mut config = Config::default();

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -57,6 +57,7 @@ fn redact(
         config_mtime,
         default_provider: c.default_provider.clone(),
         default_model: c.default_model.clone(),
+        provider_order: c.providers.provider_order.clone(),
         has_anthropic_key: c.providers.anthropic_api_key.is_some(),
         has_openai_key: c.providers.openai_api_key.is_some(),
         has_google_key: c.providers.google_api_key.is_some(),
@@ -140,6 +141,12 @@ pub(super) async fn put_config(
 
     if let Some(v) = req.default_provider {
         config.default_provider = v;
+    }
+    // A present list replaces the order whole; an empty one clears it back to
+    // `default_provider` alone. Absent leaves it untouched, like every other
+    // partial field here.
+    if let Some(order) = req.provider_order {
+        config.providers.provider_order = order;
     }
     // Three states rather than the two every field around it has: absent
     // leaves the pin alone, `null` removes it so each blueprint picks its own
@@ -1097,6 +1104,7 @@ mod tests {
         let config = RedactedConfig {
             default_provider: "anthropic".to_string(),
             default_model: None,
+            provider_order: Vec::new(),
             has_anthropic_key: true,
             has_openai_key: false,
             has_google_key: false,
@@ -1129,6 +1137,7 @@ mod tests {
         let config = RedactedConfig {
             default_provider: "ollama".to_string(),
             default_model: None,
+            provider_order: Vec::new(),
             has_anthropic_key: false,
             has_openai_key: false,
             has_google_key: false,
@@ -1332,6 +1341,46 @@ mod tests {
                 .unwrap()
                 .providers
                 .ollama_enabled
+        );
+    }
+
+    /// `provider_order` round-trips: a present list is written whole and
+    /// reported back, and an empty list clears it. Absent is covered by the
+    /// empty-body test that asserts nothing else moves.
+    #[tokio::test]
+    async fn put_config_writes_and_clears_the_provider_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+
+        let body =
+            serde_json::json!({ "provider_order": ["codex", "openrouter", "openai"] }).to_string();
+        let resp = put_config_request(state_with_config_path(path.clone()), &body).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let rc: RedactedConfig = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(rc.provider_order, ["codex", "openrouter", "openai"]);
+        assert_eq!(
+            Config::load_from_path_public(&path)
+                .unwrap()
+                .providers
+                .provider_order,
+            ["codex", "openrouter", "openai"]
+        );
+
+        // An empty list clears it back to default_provider alone.
+        let empty: [&str; 0] = [];
+        let body = serde_json::json!({ "provider_order": empty }).to_string();
+        let resp = put_config_request(state_with_config_path(path.clone()), &body).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        assert!(
+            Config::load_from_path_public(&path)
+                .unwrap()
+                .providers
+                .provider_order
+                .is_empty()
         );
     }
 

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -43,6 +43,12 @@ pub(super) struct RedactedConfig {
     /// "nothing is set" - without the field, a picker drew an empty box over
     /// a machine that had a model pinned.
     pub(super) default_model: Option<String>,
+    /// `[providers] provider_order`: the ordered provider preference for a bare
+    /// model name, best first. Empty when the user set none, in which case
+    /// `default_provider` alone decides. Always serialized (empty array, not
+    /// omitted) so a console can tell "no order set" from an old daemon that
+    /// cannot report it.
+    pub(super) provider_order: Vec<String>,
     pub(super) has_anthropic_key: bool,
     pub(super) has_openai_key: bool,
     pub(super) has_google_key: bool,
@@ -461,6 +467,14 @@ pub(super) struct WriteConfigReq {
     /// and reintroducing the read-modify-write hazard this endpoint avoids.
     #[serde(default)]
     pub(super) remove_gateways: Option<Vec<String>>,
+    /// The ordered provider preference for a bare model name (`[providers]
+    /// provider_order`), best first. Absent leaves it untouched; a present list
+    /// replaces it whole, and an empty list clears it back to
+    /// `default_provider` alone. A whole-list replace rather than an add/remove
+    /// pair because an order is short and a console edits it as one field, so
+    /// the read-modify-write hazard the gateway split avoids does not arise.
+    #[serde(default)]
+    pub(super) provider_order: Option<Vec<String>>,
 }
 
 /// One custom gateway as `GET /api/config` reports it.

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -1289,6 +1289,7 @@ mod tests {
         let config = RedactedConfig {
             default_provider: "anthropic".to_string(),
             default_model: Some("claude-sonnet-5".to_string()),
+            provider_order: Vec::new(),
             has_anthropic_key: true,
             has_openai_key: false,
             has_google_key: false,

--- a/crates/leviath-cli/src/config/providers.rs
+++ b/crates/leviath-cli/src/config/providers.rs
@@ -151,6 +151,25 @@ pub struct ProviderConfig {
     /// once.
     #[serde(default)]
     pub fallback_order: Vec<String>,
+
+    /// Ordered provider preference for a bare model name, best first, as plain
+    /// provider names (e.g. `["codex", "openrouter", "openai"]`).
+    ///
+    /// When a blueprint names a model with no provider and more than one
+    /// configured provider serves it, this decides which one wins. It
+    /// generalizes [`default_provider`](super::Config::default_provider) from a
+    /// single front-runner into a full ordering; leave it empty and
+    /// `default_provider` alone decides, exactly as before.
+    ///
+    /// Naming a provider here is also a deliberate choice to route bare names
+    /// through it, so a subscription transport (Codex, Claude Code) that is
+    /// otherwise reachable only by an explicit `provider/model` becomes eligible
+    /// at the priority it is listed - which is how a user who prefers their
+    /// subscription gets it used first. Bare provider names, not
+    /// `provider/model`, because this is a preference over routes, not a
+    /// failover target that needs a model to send (that is `fallback_order`).
+    #[serde(default)]
+    pub provider_order: Vec<String>,
 }
 
 /// Hand-written so the API keys can never be printed.
@@ -211,6 +230,7 @@ impl Default for ProviderConfig {
             codex_replay_reasoning: default_true(),
             anthropic_cache_ttl: None,
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         }
     }
 }

--- a/crates/leviath-cli/src/daemon/spawn/policy.rs
+++ b/crates/leviath-cli/src/daemon/spawn/policy.rs
@@ -16,6 +16,7 @@ pub(crate) fn model_defaults(config: &Config) -> ModelDefaults {
         provider: config.default_provider.clone(),
         model: config.default_model.clone(),
         fallback_order: parse_fallback_order(&config.providers.fallback_order),
+        provider_order: config.providers.provider_order.clone(),
     }
 }
 

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -32,6 +32,49 @@ pub struct ModelDefaults {
     /// single OpenRouter model, so there is nothing to fall back to when the
     /// account runs out of credits.
     pub fallback_order: Vec<ModelEntry>,
+    /// The user's ordered provider preference, from `[providers] provider_order`,
+    /// best first (e.g. `["codex", "openrouter", "openai"]`).
+    ///
+    /// This is what decides, for a bare model name that more than one configured
+    /// provider serves, which one wins - generalizing [`provider`](Self::provider)
+    /// from a single front-runner into a full ordering. Empty means "use
+    /// [`provider`](Self::provider) alone", which is the historical behavior. Naming a provider
+    /// here is also a deliberate choice to route bare names through it, so a
+    /// subscription transport that is otherwise reachable only by an explicit
+    /// `provider/model` becomes eligible at the priority it is listed.
+    pub provider_order: Vec<String>,
+}
+
+impl ModelDefaults {
+    /// The provider preference, best first: [`provider_order`](Self::provider_order)
+    /// when the user set one, otherwise the single [`provider`](Self::provider).
+    ///
+    /// Every routing decision reads the preference through here, so the
+    /// empty-`provider_order` case reduces to exactly the single-default
+    /// behavior that shipped before an order could be configured.
+    fn order(&self) -> Vec<&str> {
+        match self.provider_order.is_empty() {
+            true => vec![self.provider.as_str()],
+            false => self.provider_order.iter().map(String::as_str).collect(),
+        }
+    }
+
+    /// Where `name` sits in the preference, or [`usize::MAX`] when it is not
+    /// named - so a stable sort by this key puts preferred providers first, in
+    /// order, and leaves the rest in their existing order behind them.
+    fn rank(&self, name: &str) -> usize {
+        self.order()
+            .iter()
+            .position(|p| *p == name)
+            .unwrap_or(usize::MAX)
+    }
+
+    /// Whether `name` is named in the preference at all. A provider reachable
+    /// only by an explicit route (a subscription transport) is exempt from that
+    /// restriction for a bare name exactly when the user named it here.
+    fn is_preferred(&self, name: &str) -> bool {
+        self.order().contains(&name)
+    }
 }
 
 /// Resolve a stage's [`ModelConfig`] to a concrete `(provider, model)` against
@@ -185,22 +228,28 @@ pub(crate) fn resolve_stage_candidates(
             continue;
         }
         let key = model_key(&model);
-        // Default provider first, so an open route follows the same preference
-        // a named model's routes do.
+        // Preferred providers first, in the user's order, so an open route
+        // follows the same preference a named model's routes do. A stable sort
+        // by rank leaves everything not named in the preference in its existing
+        // order behind the named ones.
         let mut candidates_for_model = registry.native_providers();
-        candidates_for_model.sort_by_key(|(name, _)| *name != defaults.provider);
+        candidates_for_model.sort_by_key(|(name, _)| defaults.rank(name));
         // A script provider is not in `native_providers` - it is compiled on
         // demand rather than enumerated - so without this an open route can
         // never land on one, and a local box serving one fast model is
-        // unreachable however the machine sets `default_provider`. The *default*
-        // provider is asked as well, which costs one compile of a script this
-        // machine has explicitly chosen, and leaves every other script on disk
-        // untouched. Put first, because being the default is what it means.
-        if let Some(script) = registry
-            .script_provider_named(&defaults.provider)
-            .filter(|_| model_cfg.allow_user_default)
-        {
-            candidates_for_model.insert(0, (defaults.provider.as_str(), script));
+        // unreachable however the machine prefers it. Each script provider named
+        // in the preference is asked as well, which costs one compile of a
+        // script this machine has explicitly chosen and leaves every other
+        // script on disk untouched. Sorted in with the rest by rank below, so a
+        // preferred script lands at the priority it was listed.
+        if model_cfg.allow_user_default {
+            for name in defaults.order() {
+                let already = candidates_for_model.iter().any(|(n, _)| *n == name);
+                if let Some(script) = registry.script_provider_named(name).filter(|_| !already) {
+                    candidates_for_model.push((name, script));
+                }
+            }
+            candidates_for_model.sort_by_key(|(name, _)| defaults.rank(name));
         }
         let mut routed = false;
         for (name, provider) in candidates_for_model {
@@ -209,9 +258,9 @@ pub(crate) fn resolve_stage_candidates(
             // transport spends a plan rather than an API balance - so enabling
             // it must not silently move every bare-named stage onto it. It is
             // still reachable by an explicit `provider/model`, a fallback
-            // entry, or being the default, which is why the default-provider
-            // case is exempt.
-            if provider.explicit_route_only() && name != defaults.provider {
+            // entry, or being named in the preference, which is the deliberate
+            // choice that exempts it.
+            if provider.explicit_route_only() && !defaults.is_preferred(name) {
                 continue;
             }
             if let Some(id) = provider.serves_model(key) {
@@ -259,9 +308,9 @@ pub(crate) fn resolve_stage_candidates(
     // blueprint's model, which they may never have pulled. A blueprint that
     // must pin its own provider already has the way to say so -
     // `allow_user_default = false` - and that suppresses this too.
-    if model_cfg.allow_user_default && registry.has(&defaults.provider) {
-        // Grouped by MODEL, not by provider. `default_provider` says where a
-        // run should go, which is a statement about routes; letting it reorder
+    if model_cfg.allow_user_default && defaults.order().iter().any(|p| registry.has(p)) {
+        // Grouped by MODEL, not by provider. The provider preference says where
+        // a run should go, which is a statement about routes; letting it reorder
         // across models turns it into a statement about which model to use, and
         // a blueprint that deliberately chose one per stage silently gets
         // another.
@@ -290,9 +339,9 @@ pub(crate) fn resolve_stage_candidates(
                 .filter(|c| model_key(&c.model) == key)
                 .cloned()
                 .collect();
-            // Stable: the default provider's route to this model first, the
-            // blueprint's order behind it.
-            group.sort_by_key(|c| c.provider != defaults.provider);
+            // Stable: within a model, the routes run in the preference order,
+            // and the blueprint's order behind the preferred ones.
+            group.sort_by_key(|c| defaults.rank(&c.provider));
             grouped.extend(group);
         }
         candidates = grouped;
@@ -826,6 +875,7 @@ mod tests {
             provider: "spark".to_string(),
             model: None,
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         };
 
         let picked = resolve_stage_candidates(
@@ -853,6 +903,7 @@ mod tests {
             provider: "spark".to_string(),
             model: None,
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         };
 
         for model in ["cheap-model", "costly-model"] {
@@ -875,6 +926,7 @@ mod tests {
             provider: "spark".to_string(),
             model: None,
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         };
         let mut cfg = model_cfg_open(vec!["local-fast"]);
         cfg.allow_user_default = false;
@@ -1041,6 +1093,7 @@ mod tests {
             provider: "anthropic".to_string(),
             model: Some("claude-default".to_string()),
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         };
         let (p, m) = resolve_stage_model(
             &model_cfg(vec![("ghost", "g")]),
@@ -1060,6 +1113,7 @@ mod tests {
             provider: "ollama".to_string(),
             model: Some("ollama/qwen3.8:latest".to_string()),
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         };
         let (p, m) = resolve_stage_model(
             &model_cfg(vec![("ghost", "g")]),
@@ -1120,6 +1174,7 @@ mod tests {
             provider: "anthropic".to_string(),
             model: None,
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         };
         let (p, m) = resolve_stage_model(
             &model_cfg(vec![("ghost", "g")]),
@@ -1138,6 +1193,7 @@ mod tests {
             provider: "ghost-default".to_string(),
             model: Some("dm".to_string()),
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         };
         let (p, m) = resolve_stage_model(
             &model_cfg(vec![("ghost", "g")]),
@@ -1168,6 +1224,7 @@ mod tests {
             provider: "anthropic".to_string(),
             model: Some("would-be-default".to_string()),
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         };
         let (p, m) = resolve_stage_model(&cfg, None, &defaults, &registry_with(&["anthropic"]));
         assert_eq!((p.as_str(), m.as_str()), ("ghost", "g"));
@@ -1386,6 +1443,7 @@ mod tests {
             provider: "fallback".to_string(),
             model: None,
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         };
         let cfg = model_cfg(vec![("one", "m"), ("two", "m")]);
         assert_eq!(providers_tried(&cfg, None, &defaults), "one, two, fallback");
@@ -1582,6 +1640,7 @@ mod tests {
             provider: "anthropic".to_string(),
             model: Some("sonnet".to_string()),
             fallback_order: vec![ModelEntry::new("openai".to_string(), "gpt".to_string())],
+            provider_order: Vec::new(),
         };
         let registry = registry_with(&["openrouter", "anthropic", "openai"]);
         let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
@@ -1734,6 +1793,7 @@ mod tests {
                 "anthropic".to_string(),
                 "sonnet".to_string(),
             )],
+            provider_order: Vec::new(),
         };
         let registry = registry_with(&["anthropic"]);
         let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
@@ -2464,6 +2524,7 @@ mod tests {
             provider: provider.to_string(),
             model: None,
             fallback_order: Vec::new(),
+            provider_order: Vec::new(),
         }
     }
 
@@ -2580,5 +2641,96 @@ mod tests {
             picked.iter().all(|e| e.provider != "openai"),
             "got {picked:?}"
         );
+    }
+
+    fn defaults_ordered(default_provider: &str, order: &[&str]) -> ModelDefaults {
+        ModelDefaults {
+            provider: default_provider.to_string(),
+            model: None,
+            fallback_order: Vec::new(),
+            provider_order: order.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    /// A subscription transport listed first in `provider_order` wins a bare
+    /// name. Naming it is the deliberate choice the exclusion waits for, so a
+    /// user who prefers their ChatGPT plan gets it used first.
+    #[test]
+    fn a_subscription_first_in_the_order_wins_a_bare_name() {
+        let picked = resolve_stage_candidates(
+            &model_cfg_open(vec!["gpt-5.6-sol"]),
+            None,
+            &defaults_ordered("openai", &["codex", "openai"]),
+            &two_providers(true),
+        );
+        assert_eq!(picked[0].provider, "codex", "{picked:?}");
+    }
+
+    /// The order decides which of two providers serving the same bare name
+    /// wins, in the order listed - so putting the API key first keeps billing
+    /// there even with the subscription configured.
+    #[test]
+    fn the_order_ranks_two_providers_that_both_serve_the_name() {
+        let picked = resolve_stage_candidates(
+            &model_cfg_open(vec!["gpt-5.6-sol"]),
+            None,
+            &defaults_ordered("openai", &["openai", "codex"]),
+            &two_providers(true),
+        );
+        assert_eq!(picked[0].provider, "openai", "{picked:?}");
+        assert!(
+            picked.iter().any(|e| e.provider == "codex"),
+            "codex is still a candidate once named: {picked:?}"
+        );
+    }
+
+    /// A subscription NOT named in the order stays excluded from a bare name,
+    /// even though the order is non-empty. The opt-in is naming it, not merely
+    /// having set an order.
+    #[test]
+    fn a_subscription_absent_from_the_order_stays_excluded() {
+        let picked = resolve_stage_candidates(
+            &model_cfg_open(vec!["gpt-5.6-sol"]),
+            None,
+            &defaults_ordered("openai", &["openrouter", "openai"]),
+            &two_providers(true),
+        );
+        assert!(
+            picked.iter().all(|e| e.provider != "codex"),
+            "codex joined a bare route without being named: {picked:?}"
+        );
+        assert_eq!(picked[0].provider, "openai");
+    }
+
+    /// Two open providers, ranked by the order across a bare name - the general
+    /// case that `default_provider` alone could not express.
+    #[test]
+    fn the_order_ranks_open_providers() {
+        let registry = registry_serving(&[
+            ("openai", &["shared-model"]),
+            ("openrouter", &["shared-model"]),
+        ]);
+        let picked = resolve_stage_candidates(
+            &model_cfg_open(vec!["shared-model"]),
+            None,
+            &defaults_ordered("anthropic", &["openrouter", "openai"]),
+            &registry,
+        );
+        assert_eq!(picked[0].provider, "openrouter", "{picked:?}");
+        assert_eq!(picked[1].provider, "openai", "{picked:?}");
+    }
+
+    /// An empty order is exactly the historical single-default behavior: the
+    /// subscription is still excluded from a bare name.
+    #[test]
+    fn an_empty_order_is_the_old_single_default_behavior() {
+        let picked = resolve_stage_candidates(
+            &model_cfg_open(vec!["gpt-5.6-sol"]),
+            None,
+            &defaults_ordered("openai", &[]),
+            &two_providers(true),
+        );
+        assert_eq!(picked.len(), 1);
+        assert_eq!(picked[0].provider, "openai");
     }
 }

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -106,6 +106,7 @@ codex_verbosity        = "medium"   # low | medium | high
 codex_replay_reasoning = true       # replay each turn's reasoning on the next request
 anthropic_cache_ttl = "5m"           # 5m (default) | 1h
 fallback_order      = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-mini"]
+provider_order      = ["codex", "openrouter", "openai"]   # a bare name's route preference
 ```
 
 `ollama_enabled` turns Ollama on. It is opt-in like every other provider: it needs no key and
@@ -154,6 +155,26 @@ credits, or a rejected key. Entries are `provider/model` pairs, best first, trie
 own model list and your default model. One naming a provider you have not configured is skipped.
 It is read per run, so a change takes effect on the next `lev run` with no restart. See
 [Providers](/docs/providers#a-host-wide-fallback-chain).
+
+### Provider preference order
+
+`provider_order` decides which provider serves a **bare** model name - one a blueprint lists with no
+provider - when more than one you have configured serves it. Entries are plain provider names, best
+first. It generalizes `default_provider` from a single front-runner into a full ordering; leave it
+empty and `default_provider` alone decides, exactly as before.
+
+Naming a provider here is also how you route a bare name onto a subscription transport. A ChatGPT
+(Codex) or Claude subscription is normally reachable only by an explicit `codex/...` or being your
+sole `default_provider`, so that enabling it never silently moves billing. Listing it in
+`provider_order` is the deliberate opt-in: put `codex` first and a stage that names `gpt-5.6-sol`
+with no provider runs on your plan, ahead of an OpenAI key that also serves that name. A provider
+you did not list stays at its old priority, and a subscription you did not list stays excluded from
+bare names.
+
+It shapes routes, not models: a blueprint that chose a different model per stage keeps each stage's
+model, the same way `default_provider` does. `lev doctor` flags an entry naming a provider that is
+not configured. Like the rest of `[providers]`, it is read per run, so a change takes effect on the
+next `lev run` with no restart.
 
 ## `[limits]`
 

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -500,7 +500,12 @@ provider on would otherwise move billing for every such stage with one line of
 config and nothing saying so.
 
 So it is only reachable deliberately: an explicit `codex/...` in a blueprint or
-`--model`, an explicit `fallback_order` entry, or being your `default_provider`.
+`--model`, an explicit `fallback_order` entry, naming it in
+[`provider_order`](/docs/configuration#provider-preference-order), or being your
+`default_provider`. Naming it in `provider_order` is how you say a bare name
+*should* prefer the subscription: put `codex` first there and a stage that lists
+`gpt-5.6-sol` with no provider runs on your plan, ahead of an OpenAI key that
+also serves it.
 
 ### Measured caveats
 

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -136,6 +136,13 @@
           "items": {
             "type": "string"
           }
+        },
+        "provider_order": {
+          "type": "array",
+          "description": "Ordered provider preference for a bare model name, best first, as plain provider names. Decides which configured provider serves a model a blueprint lists with no provider; generalizes default_provider into a full ordering. Naming a subscription transport here opts it into bare-name routing at that priority.",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1952,6 +1952,13 @@
                       "type": "string"
                     },
                     "description": "Gateways to delete, by name. Applied after the edits above."
+                  },
+                  "provider_order": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Ordered provider preference for a bare model name, best first (e.g. [\"codex\", \"openrouter\", \"openai\"]). Absent leaves it untouched; a present list replaces it whole; an empty list clears it back to default_provider alone. Naming a subscription transport here opts it into bare-name routing at that priority."
                   }
                 }
               }
@@ -3181,6 +3188,7 @@
         "required": [
           "default_provider",
           "default_model",
+          "provider_order",
           "has_anthropic_key",
           "has_openai_key",
           "has_google_key",
@@ -3202,6 +3210,13 @@
               "null"
             ],
             "description": "The model every stage runs on while it is set, as a bare model id on `default_provider`. `null` when nothing is pinned, which is the usual and generally better state: each blueprint then picks its own model per stage. Always sent, so a missing key means the server predates this field rather than meaning nothing is set."
+          },
+          "provider_order": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Ordered provider preference for a bare model name, best first. Empty when the user set none, in which case `default_provider` alone decides. Always sent (empty array, not omitted) so a console can tell \"no order set\" from an old daemon that cannot report it."
           },
           "has_anthropic_key": {
             "type": "boolean"


### PR DESCRIPTION
Adds an ordered provider preference for bare model names, answering "if a user prefers codex → openrouter → openai, how do we route a bare `gpt-5.6-sol`?".

## The gap

A blueprint that names a model with no provider is served by whichever configured provider the resolver reaches first, and the only lever was `default_provider` — a single front-runner. There was no way to express an ordering, and a subscription transport (Codex) could be preferred only by making it the *sole* `default_provider`. (The docs sentence the user flagged was correct: bare `gpt-5.6-sol` with both Codex and an OpenAI key goes to OpenAI, because Codex is `explicit_route_only` and excluded from bare-name routing unless it's the default.)

## The feature

`[providers] provider_order = ["codex", "openrouter", "openai"]` — plain provider names, best first, deciding which configured provider serves a bare name when more than one does. It generalizes `default_provider` into a full ordering; an empty order keeps the exact historical single-default behavior.

Confirmed design decisions:
- **Config shape:** a new list; `default_provider` stays as the single-value shorthand / head when `provider_order` is unset.
- **Subscriptions:** naming a provider in `provider_order` is the deliberate opt-in that makes a subscription transport eligible for bare names at that priority — so "codex first" routes a bare name to the plan, ahead of an OpenAI key that also serves it. A subscription left unlisted stays excluded, as before.

## How it's wired

Resolution reads the preference through `ModelDefaults::order`/`rank`/`is_preferred` (`pipeline/resolve.rs`), so every routing decision reduces to the old single-default path when the order is empty — existing behavior-preservation tests still pass unchanged.

Surfaces in this PR:
- **HTTP API:** `GET /api/config` reports `provider_order`; `PUT /api/config` writes it (whole-list replace, empty clears). OpenAPI schema updated.
- **`lev doctor`:** flags a `provider_order` entry naming no configured provider.
- **Schemas + docs:** config schema, OpenAPI schema, and the configuration + providers docs (including the exact sentence the user quoted).

Follow-ups (separate PRs): the `lev setup` TUI, a `lev providers` management command, and the `lev --help` categorization.

Coverage 100% on both changed crates; new resolution, API, and doctor paths are tested, including that a subscription first in the order wins a bare name and that an empty order is byte-identical to the old behavior.
