### PR TITLE
feat(tools): add install_tool for persistent Rhai tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2717,6 +2717,7 @@ dependencies = [
  "jsonschema",
  "leviath-core",
  "leviath-providers",
+ "leviath-scripting",
  "leviath-sys",
  "quick-xml",
  "serde_json",

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -532,8 +532,18 @@ fn build_agent_inner(
         builtins =
             builtins.with_shell_executor(mgr.clone() as Arc<dyn leviath_tools::ShellExecutor>);
     }
-    let builtins = Arc::new(builtins);
     let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
+    // `install_tool` refuses every name discovery would drop a script for: the
+    // built-ins, the sub-agent tools, and this run's MCP tools. The same set
+    // the dynamic re-scan below reserves, so an install never reports a tool
+    // that the next scan silently ignores.
+    let builtins = Arc::new(
+        builtins.with_reserved_names(
+            reserved_tool_names(&builtin_names, deps.mcp_tool_defs)
+                .into_iter()
+                .collect(),
+        ),
+    );
     let mut all_tool_defs = builtins.tool_defs();
     all_tool_defs.extend(leviath_tools::BuiltinTools::subagent_tool_defs());
     all_tool_defs.extend(deps.mcp_tool_defs.iter().cloned());
@@ -2135,6 +2145,61 @@ system = { kind = "pinned", max_tokens = 1000 }
         // The agent's tool state carries a sandbox manager.
         let state = cli.take(entity).expect("state registered");
         assert!(state.sandbox.is_some(), "sandbox manager attached");
+    }
+
+    /// The spawn hands `install_tool` the run's MCP tool names as reserved: a
+    /// script under one of them is dropped at every discovery, so installing
+    /// it would tell the model a tool exists that it can never call. Refused
+    /// before anything is compiled or written, so no tools directory is
+    /// touched here.
+    #[tokio::test]
+    async fn build_agent_reserves_mcp_tool_names_for_install_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"rs\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let mcp_defs = vec![Tool {
+            name: "acme_search".to_string(),
+            description: "d".to_string(),
+            parameters: serde_json::json!({"type": "object", "properties": {}}),
+        }];
+        let entity = build_agent(
+            world.world_mut(),
+            SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &mcp_defs,
+                mcp_tool_owners: &Default::default(),
+                hub: &hub,
+                now_secs: 100,
+                subagent_tx: sub_tx(),
+            },
+            &spawn_args(&manifest.to_string_lossy()),
+        )
+        .expect("spawn succeeds");
+        let state = cli.take(entity).expect("state registered");
+        let out = state
+            .builtins
+            .execute(
+                "install_tool",
+                serde_json::json!({
+                    "name": "acme_search",
+                    "source": "// @tool acme_search\n// @description d\n1\n",
+                }),
+            )
+            .await;
+        assert!(
+            out.contains("'acme_search' is the name of a built-in tool"),
+            "{out}"
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -482,22 +482,22 @@ async fn execute_tool(state: &AgentToolState, is_builtin: bool, tc: &ToolCall) -
 }
 
 /// For a `dynamic_tools` agent, flag its tool set dirty after it writes a `.rhai`
-/// file (via `write_file`/`edit_file`), so the next tick re-scans + re-advertises.
-/// A no-op for static agents. The path lives in the tool args; the actual
-/// discovery is workdir-confined, so an off-`tools/` write just yields a no-op
-/// re-scan.
+/// file (via `write_file`/`edit_file`) or installs one (via `install_tool`), so
+/// the next tick re-scans + re-advertises. A no-op for static agents. The path
+/// lives in the tool args; the actual discovery is workdir-confined, so an
+/// off-`tools/` write just yields a no-op re-scan. An install always lands in
+/// the global directory, which is one of the scan dirs, so it needs no path.
 fn mark_dirty_on_tool_write(state: &AgentToolState, tc: &ToolCall) {
     let Some(ctx) = &state.dynamic else { return };
-    let writes = matches!(
-        leviath_tools::canonical_tool_name(&tc.name),
-        "write_file" | "edit_file"
-    );
+    let canonical = leviath_tools::canonical_tool_name(&tc.name);
+    let installs = canonical == "install_tool";
+    let writes = matches!(canonical, "write_file" | "edit_file");
     let is_rhai = tc
         .arguments
         .get("path")
         .and_then(|p| p.as_str())
         .is_some_and(|p| p.ends_with(".rhai"));
-    if writes && is_rhai {
+    if installs || (writes && is_rhai) {
         ctx.dirty.store(true, Ordering::SeqCst);
     }
 }
@@ -1507,15 +1507,18 @@ mod tests {
         unattended: bool,
     ) -> Arc<AgentToolState> {
         let hub = InteractionHub::new();
+        // `install_tool` writes into the scan dir rather than the real
+        // `~/.leviath/tools`, so a test install is what the next refresh finds.
         let builtins = Arc::new(leviath_tools::BuiltinTools::new(
-            leviath_tools::ToolContext::new(workdir),
+            leviath_tools::ToolContext::new(workdir).with_tools_dir(Some(scan_dir.clone())),
         ));
         let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
         let mut allow = HashMap::new();
-        // Both write tools default to Ask; allow them so tests don't block on an
-        // approval prompt no one answers.
+        // The write tools and the installer default to Ask; allow them so tests
+        // don't block on an approval prompt no one answers.
         allow.insert("write_file".to_string(), ToolPolicy::Allow);
         allow.insert("edit_file".to_string(), ToolPolicy::Allow);
+        allow.insert("install_tool".to_string(), ToolPolicy::Allow);
         Arc::new(AgentToolState {
             writes: Arc::new(unlimited_writes()),
             builtins,
@@ -1709,9 +1712,35 @@ mod tests {
             workdir.path().to_path_buf(),
             tools.path().to_path_buf(),
             vec![],
-            vec![vec![]],
+            vec![vec!["shout".to_string()]],
         );
         let dirty = state.dynamic.as_ref().unwrap().dirty.clone();
+        // An install always flags a re-scan: it lands in the global tools
+        // directory, which is a scan dir, and carries no `path` argument.
+        dispatch_tools(
+            state.clone(),
+            vec![call(
+                "c0",
+                "install_tool",
+                serde_json::json!({
+                    "name": "shout",
+                    "source": "// @tool shout\n// @description Shout text\n// @param text string required \"input\"\nparams.text.to_upper()\n",
+                }),
+            )],
+            noop_progress(),
+        )
+        .await;
+        assert!(dirty.load(Ordering::SeqCst));
+        assert!(tools.path().join("shout.rhai").exists());
+        // The refresh that follows the flag finds and advertises the new tool.
+        let svc = CliToolService::new();
+        let e = Entity::from_raw_u32(7).expect("a small literal index is always a valid entity id");
+        svc.register(e, state.clone());
+        let defs = svc.refresh_tools(e, 0).unwrap();
+        let names: Vec<&str> = defs.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["shout"]);
+        assert!(state.script_tool_names.lock().unwrap().contains("shout"));
+        dirty.store(false, Ordering::SeqCst);
         // Writing a non-.rhai file does not flag a re-scan.
         dispatch_tools(
             state.clone(),

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -249,7 +249,10 @@ pub(crate) fn default_tool_policy(tool_name: &str, is_builtin: bool) -> ToolPoli
         // *values*: a credential-shaped name comes back listed, not read.
         "current_time" | "system_info" | "locale_info" | "environment_info" | "which_command"
         | "runtime_info" => ToolPolicy::Allow,
-        "write_file" | "edit_file" | "shell" => ToolPolicy::Ask,
+        // `install_tool` is listed rather than left to the fall-through because
+        // it is the persistence primitive: an unprompted install puts
+        // model-authored code in front of every future run on this machine.
+        "write_file" | "edit_file" | "shell" | "install_tool" => ToolPolicy::Ask,
         // The sub-agent tools default to `Allow`, and the point of routing them
         // through this function at all is the *config*, not the prompt.
         //
@@ -427,6 +430,11 @@ pub(crate) fn declared_write_bytes(tool_name: &str, arguments: &serde_json::Valu
     let field = match leviath_tools::canonical_tool_name(tool_name) {
         "write_file" => "content",
         "edit_file" => "new_str",
+        // The script lands in the global tools directory, not the workdir, so
+        // the free-space probe (which looks at the workdir's volume) is an
+        // approximation when the two are on different disks. The byte ceiling
+        // is exact either way.
+        "install_tool" => "source",
         _ => return None,
     };
     arguments
@@ -1205,6 +1213,12 @@ mod policy_tests {
             declared_write_bytes("edit_file", &serde_json::json!({"new_str": "abc"})),
             Some(3)
         );
+        // An install is charged for the script it writes, so a run's write
+        // ceiling covers the global tools directory too.
+        assert_eq!(
+            declared_write_bytes("install_tool", &serde_json::json!({"source": "// @tool t"})),
+            Some(10)
+        );
         // A shell redirect's bytes never pass through Leviath, so there is
         // nothing to declare - `None` means "measure afterwards", not "writes
         // nothing".
@@ -1556,6 +1570,7 @@ mod policy_tests {
         assert_eq!(default_tool_policy("write_file", true), ToolPolicy::Ask);
         assert_eq!(default_tool_policy("edit_file", true), ToolPolicy::Ask);
         assert_eq!(default_tool_policy("bash", true), ToolPolicy::Ask);
+        assert_eq!(default_tool_policy("install_tool", true), ToolPolicy::Ask);
     }
 
     #[test]
@@ -2590,16 +2605,17 @@ mod policy_tests {
         }
     }
 
-    /// The two tools that touch the filesystem, and the one that runs code, are
-    /// never `Allow` by default under any spelling.
+    /// The tools that touch the filesystem, the one that runs code, and the
+    /// one that installs code for every future run are never `Allow` by
+    /// default under any spelling.
     ///
-    /// Spelled out separately from the list above because these three are the
-    /// ones an aliasing mistake would quietly promote: `default_tool_policy`
+    /// Spelled out separately from the list above because these are the ones
+    /// an aliasing mistake would quietly promote: `default_tool_policy`
     /// matches on the *canonical* name, so a call arriving as `bash` has to land
     /// on the same arm as `shell`.
     #[test]
     fn the_effectful_tools_ask_under_every_spelling() {
-        for name in ["write_file", "edit_file", "shell"] {
+        for name in ["write_file", "edit_file", "shell", "install_tool"] {
             for spelling in leviath_tools::tool_name_spellings(name) {
                 assert_eq!(
                     default_tool_policy(spelling, true),

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -497,7 +497,9 @@ pub fn classified_builtin(tool_name: &str) -> Option<ToolClassification> {
             ToolDirection::Inbound,
             TaintLevel::Public,
         ),
-        "write_file" => ToolClassification::new(
+        // `install_tool` writes one file to the local tools directory the way
+        // `write_file` writes one to the workdir; nothing leaves the machine.
+        "write_file" | "install_tool" => ToolClassification::new(
             TaintLevel::Internal,
             ToolDirection::Internal,
             TaintLevel::Public,
@@ -1084,6 +1086,21 @@ mod tests {
     fn builtin_write_file_classification() {
         let tc = builtin_tool_classification("write_file");
         assert_eq!(tc.direction, ToolDirection::Internal);
+    }
+
+    /// `install_tool` writes a file on the local machine, like `write_file`;
+    /// without an arm of its own it would fall to the outbound default and
+    /// every taint-tracking run would gate the persist path as a leak.
+    #[test]
+    fn install_tool_is_classified_like_write_file() {
+        assert_eq!(
+            classified_builtin("install_tool"),
+            classified_builtin("write_file")
+        );
+        let tc = builtin_tool_classification("install_tool");
+        assert_eq!(tc.sensitivity, TaintLevel::Internal);
+        assert_eq!(tc.direction, ToolDirection::Internal);
+        assert_eq!(tc.clearance, TaintLevel::Public);
     }
 
     /// An unknown tool is almost always MCP or a Rhai script - third-party code

--- a/crates/leviath-tools/Cargo.toml
+++ b/crates/leviath-tools/Cargo.toml
@@ -15,6 +15,9 @@ readme = "README.md"
 [dependencies]
 leviath-core = { workspace = true }
 leviath-providers = { workspace = true }
+# The one Rhai compiler: `install_tool` asks it whether a script would become
+# a tool before writing into the directory every agent executes from.
+leviath-scripting = { workspace = true }
 leviath-sys = { workspace = true }
 serde_json = { workspace = true }
 jsonschema = { workspace = true }

--- a/crates/leviath-tools/src/context.rs
+++ b/crates/leviath-tools/src/context.rs
@@ -28,6 +28,17 @@ pub struct ToolContext {
     /// Resolved from `[security]` at spawn; the default withholds
     /// credential-shaped names.
     pub(crate) shell_env: ShellEnvPolicy,
+    /// Where `install_tool` writes: the global tools directory every agent
+    /// scans at spawn, [`leviath_core::tools_dir`] by default. `None` when no
+    /// home directory resolves, in which case `install_tool` refuses. Not the
+    /// workdir and not under the workdir fence: this is the one built-in that
+    /// legitimately writes outside the run.
+    pub tools_dir: Option<PathBuf>,
+    /// Names `install_tool` refuses on top of this platform's built-ins and the
+    /// sub-agent tools: the MCP tools the run offers, filled at spawn. A script
+    /// under any of these is dropped at discovery, so installing one would
+    /// report a tool that never runs.
+    pub reserved_names: Vec<String>,
 }
 
 /// The resolved `[security] shell_env` decision for one run.
@@ -89,7 +100,25 @@ impl ToolContext {
             read_paths: Mutex::new(leviath_core::ReadPathPolicy::inactive()),
             file_locks: Arc::new(Mutex::new(HashMap::new())),
             shell_env: ShellEnvPolicy::default(),
+            tools_dir: leviath_core::tools_dir(),
+            reserved_names: Vec::new(),
         }
+    }
+
+    /// Point `install_tool` at a directory other than the data root's
+    /// `tools/`, or at nothing at all. Builder-style. Tests use it to install
+    /// into a temporary directory and to reach the no-home refusal without
+    /// touching the environment.
+    pub fn with_tools_dir(mut self, dir: Option<PathBuf>) -> Self {
+        self.tools_dir = dir;
+        self
+    }
+
+    /// The names `install_tool` refuses beyond the built-ins it can see for
+    /// itself: at spawn, the run's MCP tool names. Builder-style.
+    pub fn with_reserved_names(mut self, names: Vec<String>) -> Self {
+        self.reserved_names = names;
+        self
     }
 
     /// Attach a `[read_paths]` policy resolved at spawn. Builder-style, like

--- a/crates/leviath-tools/src/defs.rs
+++ b/crates/leviath-tools/src/defs.rs
@@ -553,6 +553,28 @@ impl BuiltinTools {
                     "required": []
                 }),
             },
+            Tool {
+                name: "install_tool".to_string(),
+                description: "Compile a Rhai tool script and install it into the global tools directory so every future agent run can call it. Refuses a script that does not compile, lacks `// @tool <name>` or `// @description`, or collides with an existing tool name. Use for repeatable mechanical steps, never for judgement.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The tool's name. Must equal the script's `// @tool` directive and be a plain file stem: letters, digits, '.', '_' or '-' only"
+                        },
+                        "source": {
+                            "type": "string",
+                            "description": "The complete .rhai source, starting with `// @tool <name>` and `// @description <text>`, then `// @param <name> <type> <required|optional> \"<description>\"` per parameter and an optional `// @requires <network|shell|filesystem>`. Arguments arrive in `params`; the script's value is the tool result"
+                        },
+                        "overwrite": {
+                            "type": "boolean",
+                            "description": "Replace an existing script of the same name (default false)"
+                        }
+                    },
+                    "required": ["name", "source"]
+                }),
+            },
         ];
         defs.retain(|t| self.available(&t.name));
         defs
@@ -713,6 +735,7 @@ impl BuiltinTools {
             "environment_info",
             "which_command",
             "runtime_info",
+            "install_tool",
             crate::SUBMIT_OUTPUT_TOOL,
             crate::FAN_OUT_TOOL,
         ]

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -144,6 +144,9 @@ impl BuiltinTools {
             "edit_file" => self.edit_file(&args).await,
             "list_dir" => self.list_dir(&args).await,
             "shell" => self.shell(&args).await,
+            // Synchronous like the environment tools: compile, then one
+            // atomic write into the global tools directory (see `install.rs`).
+            "install_tool" => self.install_tool(&args),
             // Like the context tools, this one needs the live world: the stage,
             // iteration and token counts it reports exist only there.
             "runtime_info" => "[error] runtime_info must be handled by the runtime".to_string(),

--- a/crates/leviath-tools/src/install.rs
+++ b/crates/leviath-tools/src/install.rs
@@ -5,18 +5,35 @@
 //! the filesystem by design, and a script tool's `write_file` is confined to the
 //! run's workdir, so before this nothing an agent could do reached
 //! `~/.leviath/tools/`. The function is deliberately pure over its inputs: the
-//! destination directory, the reserved-name set and the symlink predicate are
-//! all parameters, so the built-in tool, the MCP server and the tests call the
-//! same code with nothing ambient.
+//! destination directory, the reserved-name set, the provenance and the
+//! filesystem predicates are all parameters, so the built-in tool, the MCP
+//! server and the tests call the same code with nothing ambient.
 //!
 //! Every refusal happens before anything is written. A script that does not
 //! compile, a name that collides with a built-in, a name that is not a plain
 //! file stem: each is an `Err` naming what to change, and the directory every
 //! agent executes from is left exactly as it was.
+//!
+//! What lands on disk carries its origin. When the caller says who is
+//! installing, the file starts with one `// installed by leviath: ...` line, so
+//! `lev tools` and `cat` show where a model-authored tool came from. A plain
+//! `//` comment without `@` is invisible to the annotation parser and to the
+//! compiler, and it is the final text, comment included, that is compiled.
 
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use leviath_scripting::ParamSpec;
+use serde_json::Value;
+
+use crate::{BuiltinTools, SUBAGENT_TOOLS};
+
+/// The largest script `install_script_tool` accepts, in bytes.
+///
+/// Every `.rhai` in the tools directory is read and compiled at every spawn of
+/// every agent on the machine, and again on each dynamic refresh. A cap here is
+/// what keeps one oversized install from taxing every later run.
+pub const MAX_TOOL_SOURCE_BYTES: usize = 256 * 1024;
 
 /// What [`install_script_tool`] wrote, and what the model was told about it.
 #[derive(Debug, Clone, PartialEq)]
@@ -25,7 +42,7 @@ pub struct InstalledTool {
     pub name: String,
     /// Where the script now lives.
     pub path: PathBuf,
-    /// The script's `// @description`, possibly empty.
+    /// The script's `// @description`.
     pub description: String,
     /// The declared parameters, in declaration order.
     pub params: Vec<ParamSpec>,
@@ -92,25 +109,70 @@ fn params_summary(params: &[ParamSpec]) -> String {
         .join(", ")
 }
 
+/// The text that is actually written: `source` behind one provenance line when
+/// the caller gave one, `source` unchanged otherwise.
+///
+/// Seconds since the Unix epoch rather than a formatted date: it needs no
+/// dependency, sorts as text, and any shell turns it back into a date.
+fn stamped_source(source: &str, provenance: Option<&str>) -> String {
+    match provenance {
+        Some(who) => {
+            let at = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or_default();
+            format!("// installed by leviath: {who} at {at}\n{source}")
+        }
+        None => source.to_string(),
+    }
+}
+
+/// The `[tool] name` a sibling TOML would install the script under, when the
+/// sibling exists and declares one. Anything else (no file, unreadable, not
+/// TOML, no name) is `None`: discovery will complain about a broken sibling on
+/// its own, and only a *disagreeing* name is this function's concern.
+fn toml_sibling_name(toml_path: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(toml_path).ok()?;
+    let doc: toml::Value = toml::from_str(&text).ok()?;
+    doc.get("tool")?.get("name")?.as_str().map(str::to_string)
+}
+
+/// Whether `path` itself is a symlink, without following it.
+///
+/// Writing through a link that points inside the tools directory would rewrite
+/// whichever script it points at under the wrong name, and the containment
+/// predicate cannot see that because the target is within bounds.
+fn destination_is_symlink(path: &Path) -> bool {
+    path.symlink_metadata()
+        .is_ok_and(|m| m.file_type().is_symlink())
+}
+
 /// Compile `source` as a Rhai tool named `name` and write it to
 /// `<tools_dir>/<name>.rhai`.
 ///
 /// `reserved` holds the names that would never be routed to a script (the
 /// built-in and sub-agent tools; the caller adds MCP names when it knows them).
 /// `overwrite` allows replacing an existing script of the same name.
+/// `provenance`, when given, is written into the file as a leading
+/// `// installed by leviath: <provenance> at <unix seconds>` line, so the
+/// origin of a model-authored tool is visible to anyone who lists or reads it.
 ///
-/// Refuses, writing nothing, when: `tools_dir` is `None`; `name` is not a
-/// single safe path component; `name` is reserved; the script fails to parse
-/// its annotations or to compile; the script's `// @tool` differs from `name`;
-/// a script already exists and `overwrite` is false; the destination resolves
-/// outside `tools_dir` through a symlink; or the directory or file cannot be
-/// written. The `Err` text is written for the model that has to fix the script.
+/// Refuses, writing nothing, when: `tools_dir` is `None`; `source` exceeds
+/// [`MAX_TOOL_SOURCE_BYTES`]; `name` is not a single safe path component;
+/// `name` is reserved; the script fails to parse its annotations or to
+/// compile; the script's `// @tool` differs from `name`; the script has no
+/// `// @description`; a script already exists and `overwrite` is false; the
+/// destination is a symlink or resolves outside `tools_dir`; a `<name>.toml`
+/// sibling declares a different `[tool] name`; or the directory or file cannot
+/// be written. The `Err` text is written for the model that has to fix the
+/// script.
 pub fn install_script_tool(
     tools_dir: Option<&Path>,
     name: &str,
     source: &str,
     overwrite: bool,
     reserved: &[String],
+    provenance: Option<&str>,
 ) -> Result<InstalledTool, String> {
     install_script_tool_with(
         tools_dir,
@@ -118,23 +180,45 @@ pub fn install_script_tool(
         source,
         overwrite,
         reserved,
-        leviath_core::resolves_within,
+        provenance,
+        InstallProbes::real(),
     )
 }
 
-/// [`install_script_tool`] with the symlink predicate injected.
-///
-/// A `fn` pointer rather than `impl Fn`, matching [`crate::resolve_within`]:
-/// the refusal it guards needs a real symlink to reach, and creating one on
-/// Windows takes a privilege CI runners do not have, so the predicate is a
-/// parameter and the refusal is tested on every platform.
+/// The filesystem questions the install asks before writing, as `fn`
+/// pointers rather than `impl Fn`, matching [`crate::resolve_within`]: the
+/// refusals they guard need a real symlink to reach, and creating one on
+/// Windows takes a privilege CI runners do not have, so both predicates are
+/// injectable and both refusals are tested on every platform.
+#[derive(Debug, Clone, Copy)]
+pub struct InstallProbes {
+    /// Whether the destination resolves inside the tools directory once every
+    /// symlink on the way is followed. [`leviath_core::resolves_within`] in
+    /// production.
+    pub within: fn(&Path, &Path) -> bool,
+    /// Whether the destination itself is a symlink, without following it.
+    pub is_symlink: fn(&Path) -> bool,
+}
+
+impl InstallProbes {
+    /// The probes that look at the real filesystem.
+    pub fn real() -> Self {
+        Self {
+            within: leviath_core::resolves_within,
+            is_symlink: destination_is_symlink,
+        }
+    }
+}
+
+/// [`install_script_tool`] with the filesystem predicates injected.
 pub fn install_script_tool_with(
     tools_dir: Option<&Path>,
     name: &str,
     source: &str,
     overwrite: bool,
     reserved: &[String],
-    within: fn(&Path, &Path) -> bool,
+    provenance: Option<&str>,
+    probes: InstallProbes,
 ) -> Result<InstalledTool, String> {
     let Some(tools_dir) = tools_dir else {
         return Err(
@@ -143,6 +227,13 @@ pub fn install_script_tool_with(
                 .to_string(),
         );
     };
+    if source.len() > MAX_TOOL_SOURCE_BYTES {
+        return Err(format!(
+            "the script is {} bytes; a tool script may be at most {MAX_TOOL_SOURCE_BYTES} bytes, \
+             because every agent on this machine compiles it at every spawn",
+            source.len()
+        ));
+    }
     if !leviath_core::is_safe_path_component(name) {
         return Err(format!(
             "tool name '{name}' must be a single path component: letters, digits, '.', '_' \
@@ -156,7 +247,10 @@ pub fn install_script_tool_with(
         ));
     }
     let label = format!("{name}.rhai");
-    let meta = leviath_scripting::tool::check_source(&label, source).map_err(|e| e.to_string())?;
+    // Compile what will be written, provenance line included, so the file on
+    // disk is exactly the text that passed.
+    let text = stamped_source(source, provenance);
+    let meta = leviath_scripting::tool::check_source(&label, &text).map_err(|e| e.to_string())?;
     if meta.name != name {
         return Err(format!(
             "the script declares `// @tool {}` but the name given is '{name}'; they must agree, \
@@ -164,14 +258,28 @@ pub fn install_script_tool_with(
             meta.name
         ));
     }
+    if meta.description.trim().is_empty() {
+        return Err(
+            "the script has no `// @description`; a tool the model cannot tell apart from the \
+             others will never be called, so say what it does"
+                .to_string(),
+        );
+    }
     std::fs::create_dir_all(tools_dir)
         .map_err(|e| format!("cannot create {}: {e}", tools_dir.display()))?;
     let path = tools_dir.join(&label);
-    if !within(&path, tools_dir) {
+    if !(probes.within)(&path, tools_dir) {
         return Err(format!(
             "refusing to write {}: it resolves outside {} through a symlink",
             path.display(),
             tools_dir.display()
+        ));
+    }
+    if (probes.is_symlink)(&path) {
+        return Err(format!(
+            "refusing to write {}: it is a symlink, and writing through it would change \
+             whatever it points at",
+            path.display()
         ));
     }
     let replaced = path.exists();
@@ -181,11 +289,22 @@ pub fn install_script_tool_with(
             path.display()
         ));
     }
-    leviath_sys::write_private(&path, source.as_bytes())
+    let toml_path = path.with_extension("toml");
+    if let Some(other) = toml_sibling_name(&toml_path)
+        && other != name
+    {
+        return Err(format!(
+            "{} sits beside the script and declares `[tool] name = \"{other}\"`; discovery \
+             prefers the TOML, so the tool would be installed under that name instead of \
+             '{name}'; remove or fix the TOML first",
+            toml_path.display()
+        ));
+    }
+    leviath_sys::write_private(&path, text.as_bytes())
         .map_err(|e| format!("cannot write {}: {e}", path.display()))?;
     Ok(InstalledTool {
         name: meta.name.clone(),
-        toml_sibling: path.with_extension("toml").exists(),
+        toml_sibling: toml_path.exists(),
         path,
         description: meta.description.clone(),
         parameters_schema: meta.parameters_schema(),
@@ -195,9 +314,53 @@ pub fn install_script_tool_with(
     })
 }
 
+impl BuiltinTools {
+    /// The `install_tool` built-in: compile the `source` argument as a Rhai
+    /// tool named `name` and install it into the global tools directory.
+    ///
+    /// Synchronous, like the environment tools, so a seed or a host with no
+    /// runtime can call it. It takes no per-path lock: fan-out workers that
+    /// install the same name concurrently are last-writer-wins through an
+    /// atomic rename, which is acceptable for what should be identical
+    /// learnings and never leaves a half-written script.
+    ///
+    /// Reserved names are everything discovery would drop a script for: this
+    /// platform's built-ins, the sub-agent tools, and whatever the spawn put on
+    /// the context (the MCP tools this run offers).
+    pub(crate) fn install_tool(&self, args: &Value) -> String {
+        let Some(name) = args.get("name").and_then(Value::as_str) else {
+            return "[error] install_tool: missing 'name' argument".to_string();
+        };
+        let Some(source) = args.get("source").and_then(Value::as_str) else {
+            return "[error] install_tool: missing 'source' argument".to_string();
+        };
+        let overwrite = args
+            .get("overwrite")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let mut reserved = self.names();
+        reserved.extend(SUBAGENT_TOOLS.iter().map(|s| s.to_string()));
+        reserved.extend(self.ctx.reserved_names.iter().cloned());
+        let provenance = format!("agent run in {}", self.ctx.workdir.display());
+        match install_script_tool(
+            self.ctx.tools_dir.as_deref(),
+            name,
+            source,
+            overwrite,
+            &reserved,
+            Some(&provenance),
+        ) {
+            Ok(installed) => installed.summary(),
+            Err(e) => format!("[error] install_tool: {e}"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ToolContext;
+    use serde_json::json;
 
     const UPPER: &str = "// @tool upper\n// @description Upper-case text\n// @param text string required \"input to transform\"\nparams.text.to_upper()\n";
 
@@ -205,12 +368,22 @@ mod tests {
         vec!["read_file".to_string(), "spawn_agent".to_string()]
     }
 
+    /// The plain install: no provenance, the file is the source verbatim.
+    fn install(
+        tools_dir: Option<&Path>,
+        name: &str,
+        source: &str,
+        overwrite: bool,
+        reserved: &[String],
+    ) -> Result<InstalledTool, String> {
+        install_script_tool(tools_dir, name, source, overwrite, reserved, None)
+    }
+
     #[test]
     fn installs_a_compiling_script_under_its_tool_name() {
         let home = tempfile::tempdir().unwrap();
         let tools = home.path().join("tools");
-        let installed =
-            install_script_tool(Some(&tools), "upper", UPPER, false, &reserved()).unwrap();
+        let installed = install(Some(&tools), "upper", UPPER, false, &reserved()).unwrap();
         assert_eq!(installed.name, "upper");
         assert_eq!(installed.path, tools.join("upper.rhai"));
         assert_eq!(std::fs::read_to_string(&installed.path).unwrap(), UPPER);
@@ -231,17 +404,67 @@ mod tests {
         assert!(text.contains("available_global_tools"), "{text}");
     }
 
+    /// The provenance line is the first line of the file, the annotation
+    /// parser steps over it, and discovery compiles the stamped file exactly
+    /// as the install did.
+    #[test]
+    fn a_provenance_line_leads_the_file_and_survives_discovery() {
+        let home = tempfile::tempdir().unwrap();
+        let tools = home.path().join("tools");
+        let installed = install_script_tool(
+            Some(&tools),
+            "upper",
+            UPPER,
+            false,
+            &[],
+            Some("agent run in /work/repo"),
+        )
+        .unwrap();
+        let text = std::fs::read_to_string(&installed.path).unwrap();
+        let first = text.lines().next().unwrap();
+        assert!(
+            first.starts_with("// installed by leviath: agent run in /work/repo at "),
+            "{first}"
+        );
+        let secs: u64 = first.rsplit(' ').next().unwrap().parse().unwrap();
+        assert!(secs > 1_600_000_000, "a real clock reading: {secs}");
+        assert!(text.ends_with(UPPER), "the source follows unchanged");
+        assert_eq!(installed.description, "Upper-case text");
+        let (set, skipped) = leviath_scripting::ScriptToolSet::discover(&[tools]);
+        assert!(skipped.is_empty(), "{skipped:?}");
+        let meta = &set.get("upper").unwrap().meta;
+        assert_eq!(meta.description, "Upper-case text");
+        assert_eq!(meta.params.len(), 1);
+    }
+
     #[test]
     fn refuses_without_a_tools_dir() {
-        let err = install_script_tool(None, "upper", UPPER, false, &[]).unwrap_err();
+        let err = install(None, "upper", UPPER, false, &[]).unwrap_err();
         assert!(err.contains("LEVIATH_HOME"), "{err}");
+    }
+
+    /// The cap is checked before anything else looks at the text, so an
+    /// oversized script is refused without being compiled.
+    #[test]
+    fn refuses_a_script_over_the_size_cap_before_compiling_it() {
+        let home = tempfile::tempdir().unwrap();
+        let big = format!("{UPPER}// {}\n", "x".repeat(MAX_TOOL_SOURCE_BYTES));
+        let err = install(Some(home.path()), "upper", &big, false, &[]).unwrap_err();
+        assert!(err.contains("at most"), "{err}");
+        assert!(err.contains(&MAX_TOOL_SOURCE_BYTES.to_string()), "{err}");
+        assert!(!home.path().join("upper.rhai").exists());
+        // Exactly at the cap is fine.
+        let padding = MAX_TOOL_SOURCE_BYTES - UPPER.len() - "// \n".len();
+        let exact = format!("{UPPER}// {}\n", "x".repeat(padding));
+        assert_eq!(exact.len(), MAX_TOOL_SOURCE_BYTES);
+        install(Some(home.path()), "upper", &exact, false, &[]).unwrap();
     }
 
     #[test]
     fn refuses_a_name_that_is_not_a_plain_file_stem() {
         let home = tempfile::tempdir().unwrap();
         for bad in ["../upper", "a/b", "", "..", "sp ace"] {
-            let err = install_script_tool(Some(home.path()), bad, UPPER, false, &[]).unwrap_err();
+            let err = install(Some(home.path()), bad, UPPER, false, &[]).unwrap_err();
             assert!(err.contains("single path component"), "{bad}: {err}");
         }
         assert!(std::fs::read_dir(home.path()).unwrap().next().is_none());
@@ -251,16 +474,14 @@ mod tests {
     fn refuses_a_reserved_name() {
         let home = tempfile::tempdir().unwrap();
         let src = UPPER.replace("@tool upper", "@tool read_file");
-        let err = install_script_tool(Some(home.path()), "read_file", &src, false, &reserved())
-            .unwrap_err();
+        let err = install(Some(home.path()), "read_file", &src, false, &reserved()).unwrap_err();
         assert!(err.contains("built-in tool"), "{err}");
     }
 
     #[test]
     fn refuses_a_script_that_does_not_declare_a_tool() {
         let home = tempfile::tempdir().unwrap();
-        let err =
-            install_script_tool(Some(home.path()), "upper", "params.text", false, &[]).unwrap_err();
+        let err = install(Some(home.path()), "upper", "params.text", false, &[]).unwrap_err();
         assert!(err.contains("@tool"), "{err}");
         assert!(!home.path().join("upper.rhai").exists());
     }
@@ -268,8 +489,8 @@ mod tests {
     #[test]
     fn refuses_a_script_that_does_not_compile() {
         let home = tempfile::tempdir().unwrap();
-        let src = "// @tool upper\nlet x = ;\n";
-        let err = install_script_tool(Some(home.path()), "upper", src, false, &[]).unwrap_err();
+        let src = "// @tool upper\n// @description d\nlet x = ;\n";
+        let err = install(Some(home.path()), "upper", src, false, &[]).unwrap_err();
         assert!(err.contains("compilation failed"), "{err}");
         assert!(err.contains("upper.rhai"), "{err}");
     }
@@ -277,22 +498,37 @@ mod tests {
     #[test]
     fn refuses_when_the_tool_directive_disagrees_with_the_name() {
         let home = tempfile::tempdir().unwrap();
-        let err = install_script_tool(Some(home.path()), "lower", UPPER, false, &[]).unwrap_err();
+        let err = install(Some(home.path()), "lower", UPPER, false, &[]).unwrap_err();
         assert!(err.contains("`// @tool upper`"), "{err}");
         assert!(err.contains("'lower'"), "{err}");
+    }
+
+    /// A missing directive and a blank one are the same refusal: neither
+    /// gives the model anything to choose the tool by.
+    #[test]
+    fn refuses_a_script_without_a_description() {
+        let home = tempfile::tempdir().unwrap();
+        let missing = "// @tool upper\nparams.text.to_upper()\n";
+        let blank = "// @tool upper\n// @description   \nparams.text.to_upper()\n";
+        for src in [missing, blank] {
+            let err = install(Some(home.path()), "upper", src, false, &[]).unwrap_err();
+            assert!(err.contains("@description"), "{err}");
+            assert!(err.contains("never be called"), "{err}");
+        }
+        assert!(!home.path().join("upper.rhai").exists());
     }
 
     #[test]
     fn refuses_to_replace_unless_asked_and_reports_the_replacement() {
         let home = tempfile::tempdir().unwrap();
         let tools = home.path().join("tools");
-        install_script_tool(Some(&tools), "upper", UPPER, false, &[]).unwrap();
-        let err = install_script_tool(Some(&tools), "upper", UPPER, false, &[]).unwrap_err();
+        install(Some(&tools), "upper", UPPER, false, &[]).unwrap();
+        let err = install(Some(&tools), "upper", UPPER, false, &[]).unwrap_err();
         assert!(err.contains("already exists"), "{err}");
         assert!(err.contains("overwrite = true"), "{err}");
 
         let newer = UPPER.replace("Upper-case text", "Shout");
-        let installed = install_script_tool(Some(&tools), "upper", &newer, true, &[]).unwrap();
+        let installed = install(Some(&tools), "upper", &newer, true, &[]).unwrap();
         assert!(installed.replaced);
         assert_eq!(std::fs::read_to_string(&installed.path).unwrap(), newer);
         let text = installed.summary();
@@ -304,9 +540,43 @@ mod tests {
     fn reports_a_toml_sibling_that_will_override_the_annotations() {
         let home = tempfile::tempdir().unwrap();
         std::fs::write(home.path().join("upper.toml"), "[tool]\nname = \"upper\"\n").unwrap();
-        let installed = install_script_tool(Some(home.path()), "upper", UPPER, false, &[]).unwrap();
+        let installed = install(Some(home.path()), "upper", UPPER, false, &[]).unwrap();
         assert!(installed.toml_sibling);
         assert!(installed.summary().contains("upper.toml sits beside"));
+    }
+
+    /// A sibling that would install the script under another name is refused:
+    /// the model was told it installed `upper`, and discovery would offer
+    /// something else.
+    #[test]
+    fn refuses_a_toml_sibling_that_names_a_different_tool() {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::write(home.path().join("upper.toml"), "[tool]\nname = \"shout\"\n").unwrap();
+        let err = install(Some(home.path()), "upper", UPPER, false, &[]).unwrap_err();
+        assert!(err.contains("upper.toml"), "{err}");
+        assert!(err.contains("`[tool] name = \"shout\"`"), "{err}");
+        assert!(!home.path().join("upper.rhai").exists());
+    }
+
+    /// A sibling that is not TOML, or has no `[tool] name`, is discovery's
+    /// problem to report; the install goes ahead and notes the sibling.
+    #[test]
+    fn a_toml_sibling_without_a_name_is_noted_but_not_a_refusal() {
+        for text in [
+            "not = [toml",
+            "[tool]\ndescription = \"d\"\n",
+            "[other]\nname = \"x\"\n",
+        ] {
+            let home = tempfile::tempdir().unwrap();
+            std::fs::write(home.path().join("upper.toml"), text).unwrap();
+            let installed = install(Some(home.path()), "upper", UPPER, false, &[]).unwrap();
+            assert!(installed.toml_sibling, "{text}");
+        }
+        // No sibling at all reads as no name.
+        assert_eq!(
+            toml_sibling_name(Path::new("/nonexistent/upper.toml")),
+            None
+        );
     }
 
     #[test]
@@ -314,7 +584,7 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         let file = home.path().join("tools");
         std::fs::write(&file, "not a directory").unwrap();
-        let err = install_script_tool(Some(&file), "upper", UPPER, false, &[]).unwrap_err();
+        let err = install(Some(&file), "upper", UPPER, false, &[]).unwrap_err();
         assert!(err.contains("cannot create"), "{err}");
     }
 
@@ -324,34 +594,89 @@ mod tests {
         // A directory where the file should go: exists, so overwrite is needed,
         // and then the write itself fails.
         std::fs::create_dir_all(home.path().join("upper.rhai")).unwrap();
-        let err = install_script_tool(Some(home.path()), "upper", UPPER, true, &[]).unwrap_err();
+        let err = install(Some(home.path()), "upper", UPPER, true, &[]).unwrap_err();
         assert!(err.contains("cannot write"), "{err}");
     }
 
     #[test]
     fn refuses_a_destination_the_predicate_places_outside_the_tools_dir() {
         let home = tempfile::tempdir().unwrap();
-        let err =
-            install_script_tool_with(Some(home.path()), "upper", UPPER, false, &[], |_, _| false)
-                .unwrap_err();
+        let err = install_script_tool_with(
+            Some(home.path()),
+            "upper",
+            UPPER,
+            false,
+            &[],
+            None,
+            InstallProbes {
+                within: |_, _| false,
+                is_symlink: |_| false,
+            },
+        )
+        .unwrap_err();
         assert!(err.contains("through a symlink"), "{err}");
         assert!(!home.path().join("upper.rhai").exists());
     }
 
-    /// The real predicate, against a real symlink: the injected-predicate test
-    /// above proves the refusal arm, this proves the predicate fires for the
-    /// case an agent could arrange for itself.
+    /// The injected predicate reaches the refusal on every platform; the real
+    /// predicate is exercised on its own below.
+    #[test]
+    fn refuses_a_destination_the_predicate_says_is_a_symlink() {
+        let home = tempfile::tempdir().unwrap();
+        let err = install_script_tool_with(
+            Some(home.path()),
+            "upper",
+            UPPER,
+            true,
+            &[],
+            None,
+            InstallProbes {
+                within: |_, _| true,
+                is_symlink: |_| true,
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("it is a symlink"), "{err}");
+        assert!(!home.path().join("upper.rhai").exists());
+    }
+
+    #[test]
+    fn the_real_symlink_predicate_reads_a_plain_file_and_a_missing_one_as_not_links() {
+        let home = tempfile::tempdir().unwrap();
+        let plain = home.path().join("upper.rhai");
+        std::fs::write(&plain, UPPER).unwrap();
+        assert!(!destination_is_symlink(&plain));
+        assert!(!destination_is_symlink(&home.path().join("absent.rhai")));
+    }
+
+    /// The real predicates, against real symlinks: the injected-predicate
+    /// tests above prove the refusal arms, these prove the predicates fire for
+    /// the cases an agent could arrange for itself. A link pointing outside
+    /// the tools directory and a link pointing at a sibling script inside it
+    /// are both refused, and neither target is touched.
     #[cfg(unix)]
     #[test]
-    fn a_symlinked_script_pointing_outside_is_refused_for_real() {
+    fn a_symlinked_destination_is_refused_for_real() {
         let home = tempfile::tempdir().unwrap();
         let elsewhere = tempfile::tempdir().unwrap();
         let victim = elsewhere.path().join("victim.rhai");
         std::fs::write(&victim, "// untouched\n").unwrap();
         std::os::unix::fs::symlink(&victim, home.path().join("upper.rhai")).unwrap();
-        let err = install_script_tool(Some(home.path()), "upper", UPPER, true, &[]).unwrap_err();
-        assert!(err.contains("through a symlink"), "{err}");
+        let err = install(Some(home.path()), "upper", UPPER, true, &[]).unwrap_err();
+        assert!(err.contains("symlink"), "{err}");
         assert_eq!(std::fs::read_to_string(&victim).unwrap(), "// untouched\n");
+
+        let sibling = home.path().join("other.rhai");
+        std::fs::write(&sibling, "// also untouched\n").unwrap();
+        std::os::unix::fs::symlink(&sibling, home.path().join("lower.rhai")).unwrap();
+        let lower = UPPER.replace("@tool upper", "@tool lower");
+        let err = install(Some(home.path()), "lower", &lower, true, &[]).unwrap_err();
+        assert!(err.contains("it is a symlink"), "{err}");
+        assert_eq!(
+            std::fs::read_to_string(&sibling).unwrap(),
+            "// also untouched\n"
+        );
+        assert!(destination_is_symlink(&home.path().join("lower.rhai")));
     }
 
     #[test]
@@ -377,5 +702,124 @@ mod tests {
         assert!(text.contains("Requires: shell"), "{text}");
         assert!(!text.contains("Description:"), "{text}");
         assert_eq!(params_summary(&[]), "none");
+    }
+
+    // ── The built-in over the core ────────────────────────────────────────
+
+    /// Built-ins over `workdir` that install into `tools`, with the names a
+    /// spawn would reserve on top of the built-ins.
+    fn tools_installing_into(workdir: &Path, tools: &Path) -> BuiltinTools {
+        BuiltinTools::new(
+            ToolContext::new(workdir.to_path_buf())
+                .with_tools_dir(Some(tools.to_path_buf()))
+                .with_reserved_names(vec!["acme_search".to_string()]),
+        )
+    }
+
+    /// Through the public `execute`, so the dispatch arm is what is tested:
+    /// the file lands in the context's tools directory, stamped with the run's
+    /// workdir as its provenance.
+    #[tokio::test]
+    async fn the_builtin_installs_into_the_context_tools_dir_with_provenance() {
+        let workdir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let tools = home.path().join("tools");
+        let builtins = tools_installing_into(workdir.path(), &tools);
+        let out = builtins
+            .execute("install_tool", json!({"name": "upper", "source": UPPER}))
+            .await;
+        assert!(out.starts_with("Installed tool 'upper'"), "{out}");
+        let text = std::fs::read_to_string(tools.join("upper.rhai")).unwrap();
+        let expected = format!(
+            "// installed by leviath: agent run in {} at ",
+            builtins.workdir().display()
+        );
+        assert!(text.starts_with(&expected), "{text}");
+        assert!(text.ends_with(UPPER), "{text}");
+
+        // Without overwrite the second install is refused; with it, replaced.
+        let out = builtins
+            .execute("install_tool", json!({"name": "upper", "source": UPPER}))
+            .await;
+        assert!(
+            out.starts_with("[error] install_tool: tool 'upper' already exists"),
+            "{out}"
+        );
+        let out = builtins
+            .execute(
+                "install_tool",
+                json!({"name": "upper", "source": UPPER, "overwrite": true}),
+            )
+            .await;
+        assert!(out.contains("replaced the previous script"), "{out}");
+    }
+
+    #[test]
+    fn the_builtin_refuses_missing_arguments() {
+        let workdir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let builtins = tools_installing_into(workdir.path(), home.path());
+        assert_eq!(
+            builtins.install_tool(&json!({"source": UPPER})),
+            "[error] install_tool: missing 'name' argument"
+        );
+        assert_eq!(
+            builtins.install_tool(&json!({"name": "upper"})),
+            "[error] install_tool: missing 'source' argument"
+        );
+        assert_eq!(
+            builtins.install_tool(&json!({"name": 3, "source": UPPER})),
+            "[error] install_tool: missing 'name' argument"
+        );
+        assert!(std::fs::read_dir(home.path()).unwrap().next().is_none());
+    }
+
+    /// The reserved set is the union a spawn's discovery would drop for: this
+    /// platform's built-ins (and their aliases), the sub-agent tools, and the
+    /// names the context carries for the run's MCP tools.
+    #[test]
+    fn the_builtin_reserves_builtin_subagent_and_context_names() {
+        let workdir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let builtins = tools_installing_into(workdir.path(), home.path());
+        for taken in ["read_file", "bash", "spawn_agent", "acme_search"] {
+            let src = UPPER.replace("@tool upper", &format!("@tool {taken}"));
+            let out = builtins.install_tool(&json!({"name": taken, "source": src}));
+            assert!(out.contains("built-in tool"), "{taken}: {out}");
+        }
+        assert!(std::fs::read_dir(home.path()).unwrap().next().is_none());
+    }
+
+    /// The spawn learns the reserved set from the constructed built-ins, so the
+    /// names can also arrive after construction; they replace what the context
+    /// carried.
+    #[test]
+    fn the_reserved_names_can_be_set_after_construction() {
+        let workdir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let builtins = tools_installing_into(workdir.path(), home.path())
+            .with_reserved_names(vec!["late_mcp".to_string()]);
+        let src = UPPER.replace("@tool upper", "@tool late_mcp");
+        let out = builtins.install_tool(&json!({"name": "late_mcp", "source": src}));
+        assert!(
+            out.contains("'late_mcp' is the name of a built-in tool"),
+            "{out}"
+        );
+        // The context's own list was replaced, so `acme_search` is free again.
+        let src = UPPER.replace("@tool upper", "@tool acme_search");
+        let out = builtins.install_tool(&json!({"name": "acme_search", "source": src}));
+        assert!(out.starts_with("Installed tool 'acme_search'"), "{out}");
+    }
+
+    #[test]
+    fn the_builtin_reports_a_missing_tools_dir() {
+        let workdir = tempfile::tempdir().unwrap();
+        let builtins =
+            BuiltinTools::new(ToolContext::new(workdir.path().to_path_buf()).with_tools_dir(None));
+        let out = builtins.install_tool(&json!({"name": "upper", "source": UPPER}));
+        assert!(
+            out.starts_with("[error] install_tool: no home directory"),
+            "{out}"
+        );
     }
 }

--- a/crates/leviath-tools/src/install.rs
+++ b/crates/leviath-tools/src/install.rs
@@ -1,0 +1,381 @@
+//! The core of `install_tool`: compile a Rhai tool script and place it in the
+//! global tools directory, where every future agent run discovers it.
+//!
+//! This is the persist path for mechanical learnings. A stage hook cannot touch
+//! the filesystem by design, and a script tool's `write_file` is confined to the
+//! run's workdir, so before this nothing an agent could do reached
+//! `~/.leviath/tools/`. The function is deliberately pure over its inputs: the
+//! destination directory, the reserved-name set and the symlink predicate are
+//! all parameters, so the built-in tool, the MCP server and the tests call the
+//! same code with nothing ambient.
+//!
+//! Every refusal happens before anything is written. A script that does not
+//! compile, a name that collides with a built-in, a name that is not a plain
+//! file stem: each is an `Err` naming what to change, and the directory every
+//! agent executes from is left exactly as it was.
+
+use std::path::{Path, PathBuf};
+
+use leviath_scripting::ParamSpec;
+
+/// What [`install_script_tool`] wrote, and what the model was told about it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InstalledTool {
+    /// The tool's name: the `// @tool` directive, which is also the file stem.
+    pub name: String,
+    /// Where the script now lives.
+    pub path: PathBuf,
+    /// The script's `// @description`, possibly empty.
+    pub description: String,
+    /// The declared parameters, in declaration order.
+    pub params: Vec<ParamSpec>,
+    /// The platform capabilities the script declared with `// @requires`.
+    pub requires: Vec<String>,
+    /// The JSON Schema a stage will advertise for the tool's arguments.
+    pub parameters_schema: serde_json::Value,
+    /// Whether a previous script of the same name was overwritten.
+    pub replaced: bool,
+    /// Whether a `<name>.toml` sits beside the script. Discovery prefers the
+    /// TOML's metadata over the script's annotations, which is worth knowing
+    /// when the annotations were just written.
+    pub toml_sibling: bool,
+}
+
+impl InstalledTool {
+    /// The tool result a model reads back: what was installed, its interface,
+    /// and when it becomes callable.
+    pub fn summary(&self) -> String {
+        let mut out = format!("Installed tool '{}' at {}.", self.name, self.path.display());
+        if self.replaced {
+            out.push_str(" It replaced the previous script of that name.");
+        }
+        if !self.description.is_empty() {
+            out.push_str(&format!("\nDescription: {}", self.description));
+        }
+        out.push_str(&format!("\nParams: {}", params_summary(&self.params)));
+        if !self.requires.is_empty() {
+            out.push_str(&format!("\nRequires: {}", self.requires.join(", ")));
+        }
+        if self.toml_sibling {
+            out.push_str(&format!(
+                "\nNote: {}.toml sits beside the script and overrides its annotations.",
+                self.name
+            ));
+        }
+        out.push_str(
+            "\nEvery agent on this machine can call it from its next spawn. A stage that sets \
+             `available_global_tools = true` advertises it; a `dynamic_tools` agent already running \
+             sees it on its next turn.",
+        );
+        out
+    }
+}
+
+/// `name:type!` for a required parameter, `name:type` for an optional one, with
+/// the description in parentheses when there is one. `none` when the tool takes
+/// no parameters, so the line is never blank.
+fn params_summary(params: &[ParamSpec]) -> String {
+    if params.is_empty() {
+        return "none".to_string();
+    }
+    params
+        .iter()
+        .map(|p| {
+            let bang = if p.required { "!" } else { "" };
+            if p.description.is_empty() {
+                format!("{}:{}{bang}", p.name, p.ty)
+            } else {
+                format!("{}:{}{bang} ({})", p.name, p.ty, p.description)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Compile `source` as a Rhai tool named `name` and write it to
+/// `<tools_dir>/<name>.rhai`.
+///
+/// `reserved` holds the names that would never be routed to a script (the
+/// built-in and sub-agent tools; the caller adds MCP names when it knows them).
+/// `overwrite` allows replacing an existing script of the same name.
+///
+/// Refuses, writing nothing, when: `tools_dir` is `None`; `name` is not a
+/// single safe path component; `name` is reserved; the script fails to parse
+/// its annotations or to compile; the script's `// @tool` differs from `name`;
+/// a script already exists and `overwrite` is false; the destination resolves
+/// outside `tools_dir` through a symlink; or the directory or file cannot be
+/// written. The `Err` text is written for the model that has to fix the script.
+pub fn install_script_tool(
+    tools_dir: Option<&Path>,
+    name: &str,
+    source: &str,
+    overwrite: bool,
+    reserved: &[String],
+) -> Result<InstalledTool, String> {
+    install_script_tool_with(
+        tools_dir,
+        name,
+        source,
+        overwrite,
+        reserved,
+        leviath_core::resolves_within,
+    )
+}
+
+/// [`install_script_tool`] with the symlink predicate injected.
+///
+/// A `fn` pointer rather than `impl Fn`, matching [`crate::resolve_within`]:
+/// the refusal it guards needs a real symlink to reach, and creating one on
+/// Windows takes a privilege CI runners do not have, so the predicate is a
+/// parameter and the refusal is tested on every platform.
+pub fn install_script_tool_with(
+    tools_dir: Option<&Path>,
+    name: &str,
+    source: &str,
+    overwrite: bool,
+    reserved: &[String],
+    within: fn(&Path, &Path) -> bool,
+) -> Result<InstalledTool, String> {
+    let Some(tools_dir) = tools_dir else {
+        return Err(
+            "no home directory resolves, so there is no global tools directory to install \
+             into; set LEVIATH_HOME"
+                .to_string(),
+        );
+    };
+    if !leviath_core::is_safe_path_component(name) {
+        return Err(format!(
+            "tool name '{name}' must be a single path component: letters, digits, '.', '_' \
+             or '-' only"
+        ));
+    }
+    if reserved.iter().any(|r| r == name) {
+        return Err(format!(
+            "'{name}' is the name of a built-in tool; a script under that name would never be \
+             called, so pick another"
+        ));
+    }
+    let label = format!("{name}.rhai");
+    let meta = leviath_scripting::tool::check_source(&label, source).map_err(|e| e.to_string())?;
+    if meta.name != name {
+        return Err(format!(
+            "the script declares `// @tool {}` but the name given is '{name}'; they must agree, \
+             because a tool is discovered by its @tool directive",
+            meta.name
+        ));
+    }
+    std::fs::create_dir_all(tools_dir)
+        .map_err(|e| format!("cannot create {}: {e}", tools_dir.display()))?;
+    let path = tools_dir.join(&label);
+    if !within(&path, tools_dir) {
+        return Err(format!(
+            "refusing to write {}: it resolves outside {} through a symlink",
+            path.display(),
+            tools_dir.display()
+        ));
+    }
+    let replaced = path.exists();
+    if replaced && !overwrite {
+        return Err(format!(
+            "tool '{name}' already exists at {}; pass overwrite = true to replace it",
+            path.display()
+        ));
+    }
+    leviath_sys::write_private(&path, source.as_bytes())
+        .map_err(|e| format!("cannot write {}: {e}", path.display()))?;
+    Ok(InstalledTool {
+        name: meta.name.clone(),
+        toml_sibling: path.with_extension("toml").exists(),
+        path,
+        description: meta.description.clone(),
+        parameters_schema: meta.parameters_schema(),
+        params: meta.params,
+        requires: meta.required_caps,
+        replaced,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UPPER: &str = "// @tool upper\n// @description Upper-case text\n// @param text string required \"input to transform\"\nparams.text.to_upper()\n";
+
+    fn reserved() -> Vec<String> {
+        vec!["read_file".to_string(), "spawn_agent".to_string()]
+    }
+
+    #[test]
+    fn installs_a_compiling_script_under_its_tool_name() {
+        let home = tempfile::tempdir().unwrap();
+        let tools = home.path().join("tools");
+        let installed =
+            install_script_tool(Some(&tools), "upper", UPPER, false, &reserved()).unwrap();
+        assert_eq!(installed.name, "upper");
+        assert_eq!(installed.path, tools.join("upper.rhai"));
+        assert_eq!(std::fs::read_to_string(&installed.path).unwrap(), UPPER);
+        assert_eq!(installed.description, "Upper-case text");
+        assert_eq!(installed.params.len(), 1);
+        assert!(installed.requires.is_empty());
+        assert!(!installed.replaced);
+        assert!(!installed.toml_sibling);
+        assert_eq!(installed.parameters_schema["required"][0], "text");
+        // Discovery finds it exactly as a spawn would.
+        let (set, skipped) = leviath_scripting::ScriptToolSet::discover(&[tools]);
+        assert!(skipped.is_empty());
+        assert!(set.contains("upper"));
+        let text = installed.summary();
+        assert!(text.contains("Installed tool 'upper'"), "{text}");
+        assert!(text.contains("text:string! (input to transform)"), "{text}");
+        assert!(!text.contains("replaced"), "{text}");
+        assert!(text.contains("available_global_tools"), "{text}");
+    }
+
+    #[test]
+    fn refuses_without_a_tools_dir() {
+        let err = install_script_tool(None, "upper", UPPER, false, &[]).unwrap_err();
+        assert!(err.contains("LEVIATH_HOME"), "{err}");
+    }
+
+    #[test]
+    fn refuses_a_name_that_is_not_a_plain_file_stem() {
+        let home = tempfile::tempdir().unwrap();
+        for bad in ["../upper", "a/b", "", "..", "sp ace"] {
+            let err = install_script_tool(Some(home.path()), bad, UPPER, false, &[]).unwrap_err();
+            assert!(err.contains("single path component"), "{bad}: {err}");
+        }
+        assert!(std::fs::read_dir(home.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn refuses_a_reserved_name() {
+        let home = tempfile::tempdir().unwrap();
+        let src = UPPER.replace("@tool upper", "@tool read_file");
+        let err = install_script_tool(Some(home.path()), "read_file", &src, false, &reserved())
+            .unwrap_err();
+        assert!(err.contains("built-in tool"), "{err}");
+    }
+
+    #[test]
+    fn refuses_a_script_that_does_not_declare_a_tool() {
+        let home = tempfile::tempdir().unwrap();
+        let err =
+            install_script_tool(Some(home.path()), "upper", "params.text", false, &[]).unwrap_err();
+        assert!(err.contains("@tool"), "{err}");
+        assert!(!home.path().join("upper.rhai").exists());
+    }
+
+    #[test]
+    fn refuses_a_script_that_does_not_compile() {
+        let home = tempfile::tempdir().unwrap();
+        let src = "// @tool upper\nlet x = ;\n";
+        let err = install_script_tool(Some(home.path()), "upper", src, false, &[]).unwrap_err();
+        assert!(err.contains("compilation failed"), "{err}");
+        assert!(err.contains("upper.rhai"), "{err}");
+    }
+
+    #[test]
+    fn refuses_when_the_tool_directive_disagrees_with_the_name() {
+        let home = tempfile::tempdir().unwrap();
+        let err = install_script_tool(Some(home.path()), "lower", UPPER, false, &[]).unwrap_err();
+        assert!(err.contains("`// @tool upper`"), "{err}");
+        assert!(err.contains("'lower'"), "{err}");
+    }
+
+    #[test]
+    fn refuses_to_replace_unless_asked_and_reports_the_replacement() {
+        let home = tempfile::tempdir().unwrap();
+        let tools = home.path().join("tools");
+        install_script_tool(Some(&tools), "upper", UPPER, false, &[]).unwrap();
+        let err = install_script_tool(Some(&tools), "upper", UPPER, false, &[]).unwrap_err();
+        assert!(err.contains("already exists"), "{err}");
+        assert!(err.contains("overwrite = true"), "{err}");
+
+        let newer = UPPER.replace("Upper-case text", "Shout");
+        let installed = install_script_tool(Some(&tools), "upper", &newer, true, &[]).unwrap();
+        assert!(installed.replaced);
+        assert_eq!(std::fs::read_to_string(&installed.path).unwrap(), newer);
+        let text = installed.summary();
+        assert!(text.contains("replaced the previous script"), "{text}");
+        assert!(text.contains("Description: Shout"), "{text}");
+    }
+
+    #[test]
+    fn reports_a_toml_sibling_that_will_override_the_annotations() {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::write(home.path().join("upper.toml"), "[tool]\nname = \"upper\"\n").unwrap();
+        let installed = install_script_tool(Some(home.path()), "upper", UPPER, false, &[]).unwrap();
+        assert!(installed.toml_sibling);
+        assert!(installed.summary().contains("upper.toml sits beside"));
+    }
+
+    #[test]
+    fn fails_when_the_tools_dir_cannot_be_created() {
+        let home = tempfile::tempdir().unwrap();
+        let file = home.path().join("tools");
+        std::fs::write(&file, "not a directory").unwrap();
+        let err = install_script_tool(Some(&file), "upper", UPPER, false, &[]).unwrap_err();
+        assert!(err.contains("cannot create"), "{err}");
+    }
+
+    #[test]
+    fn fails_when_the_script_cannot_be_written() {
+        let home = tempfile::tempdir().unwrap();
+        // A directory where the file should go: exists, so overwrite is needed,
+        // and then the write itself fails.
+        std::fs::create_dir_all(home.path().join("upper.rhai")).unwrap();
+        let err = install_script_tool(Some(home.path()), "upper", UPPER, true, &[]).unwrap_err();
+        assert!(err.contains("cannot write"), "{err}");
+    }
+
+    #[test]
+    fn refuses_a_destination_the_predicate_places_outside_the_tools_dir() {
+        let home = tempfile::tempdir().unwrap();
+        let err =
+            install_script_tool_with(Some(home.path()), "upper", UPPER, false, &[], |_, _| false)
+                .unwrap_err();
+        assert!(err.contains("through a symlink"), "{err}");
+        assert!(!home.path().join("upper.rhai").exists());
+    }
+
+    /// The real predicate, against a real symlink: the injected-predicate test
+    /// above proves the refusal arm, this proves the predicate fires for the
+    /// case an agent could arrange for itself.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_script_pointing_outside_is_refused_for_real() {
+        let home = tempfile::tempdir().unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        let victim = elsewhere.path().join("victim.rhai");
+        std::fs::write(&victim, "// untouched\n").unwrap();
+        std::os::unix::fs::symlink(&victim, home.path().join("upper.rhai")).unwrap();
+        let err = install_script_tool(Some(home.path()), "upper", UPPER, true, &[]).unwrap_err();
+        assert!(err.contains("through a symlink"), "{err}");
+        assert_eq!(std::fs::read_to_string(&victim).unwrap(), "// untouched\n");
+    }
+
+    #[test]
+    fn summary_covers_tools_with_requirements_and_no_parameters() {
+        let installed = InstalledTool {
+            name: "ls".to_string(),
+            path: PathBuf::from("/x/ls.rhai"),
+            description: String::new(),
+            params: vec![ParamSpec {
+                name: "flags".to_string(),
+                ty: "string".to_string(),
+                required: false,
+                description: String::new(),
+                schema: None,
+            }],
+            requires: vec!["shell".to_string()],
+            parameters_schema: serde_json::json!({}),
+            replaced: false,
+            toml_sibling: false,
+        };
+        let text = installed.summary();
+        assert!(text.contains("Params: flags:string\n"), "{text}");
+        assert!(text.contains("Requires: shell"), "{text}");
+        assert!(!text.contains("Description:"), "{text}");
+        assert_eq!(params_summary(&[]), "none");
+    }
+}

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -24,7 +24,10 @@ mod platform;
 pub mod validate;
 pub use context::*;
 pub use defs::{SUBAGENT_TOOLS, is_subagent_tool, submit_output_description};
-pub use install::{InstalledTool, install_script_tool, install_script_tool_with};
+pub use install::{
+    InstallProbes, InstalledTool, MAX_TOOL_SOURCE_BYTES, install_script_tool,
+    install_script_tool_with,
+};
 pub use platform::*;
 pub use validate::*;
 
@@ -88,6 +91,16 @@ impl BuiltinTools {
     /// namespace sandbox) instead of the host.
     pub fn with_shell_executor(mut self, executor: Arc<dyn ShellExecutor>) -> Self {
         self.shell_executor = Some(executor);
+        self
+    }
+
+    /// The names `install_tool` refuses beyond the built-ins it can see for
+    /// itself, set once the built-ins exist. The spawn computes the reserved
+    /// set from [`names`](Self::names), which needs the constructed tools, so
+    /// this is [`ToolContext::with_reserved_names`] reachable after
+    /// construction.
+    pub fn with_reserved_names(mut self, names: Vec<String>) -> Self {
+        self.ctx.reserved_names = names;
         self
     }
 
@@ -185,7 +198,7 @@ mod tests {
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
         let defs = tools.tool_defs();
-        assert_eq!(defs.len(), 27);
+        assert_eq!(defs.len(), 28);
     }
 
     #[test]
@@ -209,6 +222,37 @@ mod tests {
         assert!(names.contains(&"context_read".to_string()));
         assert!(names.contains(&"context_delete".to_string()));
         assert!(names.contains(&"context_list".to_string()));
+        assert!(names.contains(&"install_tool".to_string()));
+    }
+
+    /// The def a model reads before deciding to persist a learning: `name`
+    /// and `source` are required, `overwrite` is not, and the description
+    /// says what gets refused so the model can write a script that is not.
+    #[test]
+    fn tool_defs_install_tool_requires_name_and_source() {
+        let dir = std::env::temp_dir();
+        let tools = make_tools(&dir);
+        let def = tools
+            .tool_defs()
+            .into_iter()
+            .find(|t| t.name == "install_tool")
+            .expect("install_tool tool def must exist");
+        let required = def.parameters["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "name"));
+        assert!(required.iter().any(|v| v == "source"));
+        assert!(!required.iter().any(|v| v == "overwrite"));
+        assert_eq!(def.parameters["properties"]["overwrite"]["type"], "boolean");
+        assert!(
+            def.description.contains("@description"),
+            "{}",
+            def.description
+        );
+        assert!(
+            def.description.contains("never for judgement"),
+            "{}",
+            def.description
+        );
+        assert!(tools.names().contains(&"install_tool".to_string()));
     }
 
     #[test]
@@ -452,7 +496,7 @@ mod tests {
     fn names_returns_every_tool_and_alias() {
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
-        assert_eq!(tools.names().len(), 28);
+        assert_eq!(tools.names().len(), 29);
     }
 
     /// The taint gate's fallback arm is the third-party default: outbound,
@@ -2200,6 +2244,12 @@ mod tests {
             tool_required_capabilities("read_file"),
             &[ToolCapability::FileSystem]
         );
+        // Writing the global tools directory is a filesystem write like any
+        // other, so the tool disappears with the rest of them.
+        assert_eq!(
+            tool_required_capabilities("install_tool"),
+            &[ToolCapability::FileSystem]
+        );
         // Runtime-handled / platform-agnostic tools require nothing.
         assert!(tool_required_capabilities("context_write").is_empty());
         assert!(tool_required_capabilities("present_for_review").is_empty());
@@ -2212,11 +2262,39 @@ mod tests {
         let tools = make_mobile_tools(&dir);
         let names: Vec<String> = tools.tool_defs().iter().map(|t| t.name.clone()).collect();
         assert!(!names.contains(&"shell".to_string()));
-        // The rest remain.
-        assert_eq!(tools.tool_defs().len(), 26);
+        // The rest remain, `install_tool` included: mobile has a filesystem.
+        assert_eq!(tools.tool_defs().len(), 27);
         assert!(names.contains(&"read_file".to_string()));
+        assert!(names.contains(&"install_tool".to_string()));
         assert!(names.contains(&"context_write".to_string()));
         assert!(names.contains(&"present_for_review".to_string()));
+    }
+
+    /// A platform without a filesystem loses `install_tool` with the file
+    /// tools: it is neither advertised nor recognized, and a direct dispatch
+    /// is refused before any argument is read.
+    #[tokio::test]
+    async fn a_platform_without_a_filesystem_has_no_install_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = BuiltinTools::with_capabilities(
+            ToolContext::new(dir.path().to_path_buf()),
+            PlatformCapabilities::from_capabilities([
+                ToolCapability::ProcessSpawn,
+                ToolCapability::Network,
+            ]),
+        );
+        let defs: Vec<String> = tools.tool_defs().into_iter().map(|t| t.name).collect();
+        assert!(!defs.contains(&"install_tool".to_string()));
+        assert!(!defs.contains(&"write_file".to_string()));
+        assert!(defs.contains(&"shell".to_string()));
+        assert!(!tools.names().contains(&"install_tool".to_string()));
+        let out = tools
+            .execute(
+                "install_tool",
+                json!({"name": "x", "source": "// @tool x\n1"}),
+            )
+            .await;
+        assert!(out.contains("not available on this platform"), "{out}");
     }
 
     #[test]

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -19,10 +19,12 @@ mod env;
 mod exec;
 pub use exec::is_null_device;
 pub use exec::resolve_within;
+mod install;
 mod platform;
 pub mod validate;
 pub use context::*;
 pub use defs::{SUBAGENT_TOOLS, is_subagent_tool, submit_output_description};
+pub use install::{InstalledTool, install_script_tool, install_script_tool_with};
 pub use platform::*;
 pub use validate::*;
 

--- a/crates/leviath-tools/src/platform.rs
+++ b/crates/leviath-tools/src/platform.rs
@@ -135,7 +135,9 @@ impl Default for PlatformCapabilities {
 pub fn tool_required_capabilities(canonical_name: &str) -> &'static [ToolCapability] {
     match canonical_name {
         "shell" => &[ToolCapability::ProcessSpawn],
-        "read_file" | "read_files" | "write_file" | "edit_file" | "list_dir" => {
+        // `install_tool` writes the global tools directory: a filesystem write
+        // like `write_file`, outside the workdir but on the same disk.
+        "read_file" | "read_files" | "write_file" | "edit_file" | "list_dir" | "install_tool" => {
             &[ToolCapability::FileSystem]
         }
         _ => &[],

--- a/docs/content/rhai-tools.md
+++ b/docs/content/rhai-tools.md
@@ -20,15 +20,23 @@ Per-agent tools live in that agent's own `tools/` directory instead, and are che
 
 > [!WARNING]
 > The directory is `~/.leviath/tools/`, inside Leviath's data root next to `providers/` and
-> `agents/`. It is not `$HOME/tools/`. Every `.rhai` file here becomes a tool for every agent, so
-> treat it as a trusted location.
+> `agents/`. It is not `$HOME/tools/`. Every `.rhai` file here becomes a tool for every agent, and
+> not every file in it was written by you: once a run uses the `install_tool` built-in, the
+> directory holds model-authored code as well. Each installed file starts with a
+> `// installed by leviath: agent run in <workdir> at <unix seconds>` line naming where it came
+> from, and every call to any tool here is still gated by the tool policy (`ask` by default, waived
+> only by `--yolo`). Audit the directory with `lev tools`, which lists each tool with its
+> description and parameters, and remove a tool by deleting its `.rhai` file (and any sibling
+> `.toml`): the next spawn no longer sees it.
 
 ## Declaring a tool
 
 A tool declares itself with leading `// @` directives and reads its arguments from the `params`
 object. The recognized directives:
 
-- `// @tool <name>` is required and names the tool (must match a stage's `available_tools` entry).
+- `// @tool <name>` is required and names the tool. A stage sees it when its `available_tools`
+  lists that name, or when the stage sets `available_global_tools = true` and the script lives in
+  `~/.leviath/tools/`.
 - `// @description <text>` is an optional one-liner shown to the model.
 - `// @param <name> <type> <required|optional> "<description>"` is repeatable. `<type>` is a JSON
   schema type: `string`, `integer`, `number`, `boolean`, `array`, `object`. A typo here produces a
@@ -113,6 +121,41 @@ name     = "format"
 required = true
 schema   = { type = "string", enum = ["json", "yaml"], description = "output format" }
 ```
+
+## Installing a tool from a run
+
+A running agent can add to the global inventory itself with the `install_tool` built-in. It takes
+the tool's `name`, the complete `.rhai` `source`, and an optional `overwrite` flag, compiles the
+script, and writes it to `~/.leviath/tools/<name>.rhai`. This is the persist path for mechanical
+learnings: a step an agent worked out by hand once (a parsing routine, a repeated lookup, a fixed
+transformation) becomes a tool every later run can call instead of rediscovering it.
+
+The install is refused, and nothing is written, when the script does not compile, has no
+`// @tool` or `// @description`, declares a `// @tool` name that differs from `name`, takes the
+name of a built-in, sub-agent or MCP tool (a script under one of those is dropped at discovery, so
+it would never run), exceeds 256 KiB, or would replace an existing script without `overwrite`.
+A sibling `<name>.toml` that declares a different `[tool] name` is refused too, since the TOML
+would win and the tool would appear under the other name. The result the model reads back names
+the file, the description, the parameters and the required capabilities.
+
+Three things keep the directory yours:
+
+- Every installed file starts with a `// installed by leviath: agent run in <workdir> at <unix
+  seconds>` comment, so `cat` and `lev tools` show which run wrote it. The comment carries no `@`
+  directive and compiles as an ordinary comment.
+- `install_tool` is `ask` by default, like `write_file` and `shell`. A blueprint or `config.toml`
+  can set `install_tool = "allow"` under `[tool_permissions]`, and `--yolo` waives the prompt for
+  an unattended run. See [Security](/docs/security) for what an unattended run can persist.
+- The script's own calls are still gated when it runs: an installed tool reads the same
+  [`[tool_script_permissions]`](/docs/configuration#tool_script_permissions) as a hand-written one.
+
+A tool is meant for repeatable mechanical steps, never for judgement. A script that encodes a
+decision the model should be making each time ages badly and is hard to notice from the outside.
+
+To use an installed tool in the same run, the agent must be a `dynamic_tools` agent, which picks
+the new tool up on its next turn. Any later run sees it at spawn, and a stage advertises it when its
+`available_tools` names it or it sets `available_global_tools = true`. See [Tools](/docs/tools) for
+how a stage's tool set is put together.
 
 ## Inspecting the inventory
 

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -257,6 +257,7 @@ read (which is Private) flowing into `submit_output` and into `shell`:
 | --- | --- | --- |
 | Attended, through `lev serve` or the dashboard | Raises the leak prompt and parks the run in `waiting_input` | Only if you pick **Allow once** or **Allow for this session** |
 | `--yolo`, or the dashboard's unattended toggle | Waives enforcement and lets the call through, with no prompt | **Yes** |
+| `--yolo`, and the run calls `install_tool` | Installs the script into `~/.leviath/tools/` without a prompt; the file is stamped with the run's workdir and time as its provenance | Not by itself, but the code runs on every later run that advertises it. See [Rhai tools](/docs/rhai-tools#installing-a-tool-from-a-run) |
 | A tool set to `allow` in `[tool_permissions]` | Still prompts. Granting a tool is not granting the data | Only if you allow it |
 | An embedded host with no interaction hub wired | Blocks the call outright and hands the model `[blocked]` | No |
 | A prompt nobody answers before `[limits] interaction_timeout_secs` | Resolves as a deny once the deadline passes | No |

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -28,6 +28,7 @@ Read and modify files relative to the agent's working directory.
 | `write_file` | Write content to a file, creating parent directories as needed. | `path`, `content` |
 | `edit_file` | Replace an exact string that occurs exactly once in a file. | `path`, `old_str`, `new_str` |
 | `list_dir` | List a directory's contents. | `path` (optional; defaults to the working root) |
+| `install_tool` | Compile a Rhai tool script and install it into `~/.leviath/tools/`, where every future run on the machine can call it. Refuses a script that does not compile, lacks `// @tool` or `// @description`, or takes an existing tool's name. See [installing a tool from a run](/docs/rhai-tools#installing-a-tool-from-a-run). | `name`, `source`, `overwrite` (optional, default false) |
 
 > [!TIP]
 > `read_files` is cheaper than repeated `read_file` calls; reach for it after `list_dir` when you
@@ -360,6 +361,7 @@ With nothing configured, tools fall back to these:
 |---|---|
 | `read_file`, `read_files`, `list_dir` | `allow` |
 | `write_file`, `edit_file`, `shell` (and its `bash` alias) | `ask` |
+| `install_tool` | `ask` |
 | `context_read`, `context_write`, `context_append`, `context_delete`, `context_list` | `allow` |
 | `todo_add`, `todo_done`, `todo_note` | `allow` |
 | `ask_user_text`, `ask_user_choice`, `ask_user_confirm`, `edit_document` | `allow` |


### PR DESCRIPTION
## What and why

This adds the first part of the host-agent integration work: a safe path for a run to persist a Rhai script as a tool that future runs can use.

- Add `install_script_tool`, the compile-then-write core in `leviath-tools`.
- Add the `install_tool` built-in and wire it into the daemon tool service.
- Compile before writing and reject unsafe names, reserved names, oversized sources, annotation mismatches, symlinked destinations, and paths that escape the tools directory.
- Stamp installed scripts with a provenance line.
- Update the Rhai tool and security docs.

## Split plan

Gerald asked for the larger host-agent change to be split into smaller review units. This is the first of nine, in this order:

1. `install_tool`
2. `available_global_tools`
3. `lev mcp serve` and `lev run --wait`
4. bundled orchestrator agent
5. `lev integrate`
6. installed-agent support in `lev validate`
7. MCP and `install_tool` hardening
8. host-integration and orchestrator hardening
9. flaky-test fixes

The branches are already prepared as a cumulative stack. GitHub cannot base an upstream PR on a branch that exists only in my fork, so I can either send these one at a time as each predecessor merges, or open the remaining eight now if you create corresponding base branches in `GEMISIS/leviath`.

Gerald, which review flow would you prefer?

## Test status

The full host-agent branch passed its latest CI run, including Ubuntu, Ubuntu ARM, macOS, and Windows. This PR is intentionally limited to the two `install_tool` commits and 15 files so its own CI is the source of truth for this increment.

## Commits

- `735218a7` - add `install_script_tool`, the compile-then-write core
- `bf2ede86` - add the `install_tool` built-in