### PR TITLE
ci: add explicit CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  CodeQL:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: actions, python, rust
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
The dynamic default setup stopped triggering on new PRs (last ran on PR #777, Sep 1). Replace it with an explicit workflow file so it's controllable and re-runnable from the Actions tab.

Matches the same languages the default setup was configured for: actions, python, rust. Job name is `CodeQL` to match the existing required status check in the branch ruleset.