### PR TITLE
fix(tui): keyboard chords that every terminal actually delivers

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -363,11 +363,12 @@ impl Dashboard {
     /// Keys in the long-form response box and on the Send button under it.
     ///
     /// Enter breaks the line, the way it does in the new-run task and every
-    /// other text box, and Ctrl+Enter sends. Ctrl+Enter reaches the program
-    /// only under the kitty keyboard protocol; elsewhere it arrives as a plain
-    /// Enter, which is a newline here, and the Send button (Tab, then Enter
-    /// or Space, or a click) is how such a terminal sends. `/quit` on its own
-    /// line still ends the conversation when sent.
+    /// other text box, and Ctrl+S or Ctrl+Enter sends. Ctrl+Enter reaches the
+    /// program only under the kitty keyboard protocol; elsewhere it arrives
+    /// as a plain Enter, which is a newline here, so Ctrl+S - an ordinary
+    /// control byte every terminal delivers - is the chord that always works,
+    /// with the Send button (Tab, then Enter or Space, or a click) for the
+    /// mouse. `/quit` on its own line still ends the conversation when sent.
     fn handle_response_box_key(&mut self, key: crossterm::event::KeyEvent) {
         use crossterm::event::KeyModifiers;
         if self.response_focus_send {
@@ -381,6 +382,9 @@ impl Dashboard {
         }
         match key.code {
             KeyCode::Enter if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.submit_input();
+            }
+            KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.submit_input();
             }
             KeyCode::Tab => self.response_focus_send = true,
@@ -3435,6 +3439,21 @@ mod tests {
 
         dash.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL));
         assert!(!dash.input_mode, "Ctrl+Enter sent");
+        assert!(dash.agents[0].pending_request.is_none());
+    }
+
+    /// Ctrl+S sends too - the chord for terminals where Ctrl+Enter never
+    /// arrives - while a bare `s` is just a letter in the answer.
+    #[test]
+    fn response_box_ctrl_s_sends_and_a_plain_s_is_text() {
+        let mut dash = dash_answering_free_text();
+
+        dash.handle_key(key(KeyCode::Char('s')));
+        assert!(dash.input_mode, "a bare s did not send");
+        assert_eq!(dash.input_textarea.text(), "answers");
+
+        dash.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));
+        assert!(!dash.input_mode, "Ctrl+S sent");
         assert!(dash.agents[0].pending_request.is_none());
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -394,13 +394,16 @@ impl Dashboard {
     }
 
     /// Task editor keys. Enter breaks the line, the way it does in any other
-    /// text box, and Ctrl+Enter starts the run.
+    /// text box, and Ctrl+S or Ctrl+Enter starts the run.
     ///
-    /// Ctrl+Enter reaches the program only under the kitty keyboard protocol;
-    /// a terminal without it sends Ctrl+Enter as a plain Enter, which is a
-    /// newline here. That is what the Start button under the editor is for.
-    /// The response box in the detail view works the same way, with a Send
-    /// button in place of Start.
+    /// Two chords because Ctrl+Enter reaches the program only under the kitty
+    /// keyboard protocol; a terminal without it sends Ctrl+Enter as a plain
+    /// Enter (a newline here), and on macOS some terminals swallow it
+    /// entirely. Ctrl+S is an ordinary control byte every terminal delivers,
+    /// and it rhymes with the ^S that commits work elsewhere in the TUI. The
+    /// Start button under the editor remains for the mouse. The response box
+    /// in the detail view works the same way, with a Send button in place of
+    /// Start.
     fn handle_new_run_task_key(&mut self, key: crossterm::event::KeyEvent) {
         use crossterm::event::{KeyCode, KeyModifiers};
         match key.code {
@@ -408,6 +411,9 @@ impl Dashboard {
             KeyCode::Tab => self.new_run_focus = NewRunPane::Start,
             KeyCode::BackTab => self.new_run_focus = NewRunPane::Agents,
             KeyCode::Enter if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.submit_new_run();
+            }
+            KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.submit_new_run();
             }
             KeyCode::Char('@') => {
@@ -1306,6 +1312,45 @@ mod tests {
         assert_eq!(cmd.task, "ship it", "the task is trimmed");
         assert!(cmd.agent_path.ends_with("alpha"), "got: {}", cmd.agent_path);
         assert_eq!(cmd.workdir, dir.path().join("work").display().to_string());
+    }
+
+    /// Ctrl+S is the submit chord that works on every terminal: Ctrl+Enter
+    /// only arrives under the kitty keyboard protocol, and on macOS some
+    /// terminals swallow it outright.
+    #[test]
+    fn ctrl_s_submits_like_ctrl_enter() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents/alpha"), "alpha", "first");
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        dash.new_run_filter = "alpha".to_string();
+        dash.new_run_focus = NewRunPane::Task;
+        dash.new_run_task.area_mut().insert_str("ship it");
+
+        dash.handle_new_run_key(ctrl(KeyCode::Char('s')));
+
+        assert!(!dash.new_run_screen, "the screen closes on dispatch");
+        let cmd = dash
+            .spawn_cmd_rx_for_test()
+            .try_recv()
+            .expect("a spawn was dispatched");
+        assert_eq!(cmd.task, "ship it");
+    }
+
+    /// A bare `s` is text, not a submit: only the chord dispatches.
+    #[test]
+    fn a_plain_s_is_typed_not_submitted() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents/alpha"), "alpha", "first");
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        dash.new_run_filter = "alpha".to_string();
+        dash.new_run_focus = NewRunPane::Task;
+
+        dash.handle_new_run_key(key(KeyCode::Char('s')));
+        assert!(dash.new_run_screen, "still writing the task");
+        assert_eq!(dash.new_run_task.text(), "s");
+        assert!(dash.spawn_cmd_rx_for_test().try_recv().is_err());
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -182,7 +182,7 @@ impl Dashboard {
         // in place rather than in the bottom input bar.
         if self.editing_document() {
             let view = MdEditView::new(
-                " ✎ Editing this document - your changes replace it  ·  [^Enter] save  \
+                " ✎ Editing this document - your changes replace it  ·  [^S] save  \
                  [Enter] newline  [Tab] Save button  [Esc] cancel ",
                 C_SUCCESS,
                 !self.response_focus_send,

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -116,11 +116,11 @@ impl Dashboard {
             // specific question - label it accordingly for consistent UX.
             let is_message_mode = pending_req.is_none() && agent.waiting_prompt.is_none();
             let hint = if self.deny_feedback_open {
-                " Deny with feedback: what should it do instead?  [^Enter] send  [Enter] newline  [Tab] Send  [Esc] back "
+                " Deny with feedback: what should it do instead?  [^S] send  [Enter] newline  [Tab] Send  [Esc] back "
             } else if is_message_mode {
-                " Provide input while this is running  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] cancel "
+                " Provide input while this is running  [^S] send  [Enter] newline  [Tab] Send button  [Esc] cancel "
             } else {
-                " Response  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] cancel "
+                " Response  [^S] send  [Enter] newline  [Tab] Send button  [Esc] cancel "
             };
             // The response box is a long-form field: it wraps, and it carries
             // the same formatting toolbar as the task editor. Enter breaks the

--- a/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
@@ -244,7 +244,7 @@ impl Dashboard {
             // and only there: on the picker it would be a key that does
             // nothing.
             (false, NewRunPane::Task) => format!(
-                " ^Enter start · Enter newline · Tab Start button · @ file · {} bold · {MODE_CHORD} preview · ^Y {unattended} · F1 help · Esc back ",
+                " ^S start · Enter newline · Tab Start button · @ file · {} bold · {MODE_CHORD} preview · ^Y {unattended} · F1 help · Esc back ",
                 chord_label(MdAction::Bold)
             ),
             (false, NewRunPane::Start) => format!(
@@ -385,7 +385,7 @@ mod tests {
         let mut dash = screen();
         dash.new_run_focus = NewRunPane::Task;
         let out = rendered(&mut dash);
-        assert!(out.contains("^Enter start"), "{out}");
+        assert!(out.contains("^S start"), "{out}");
         assert!(out.contains("Enter newline"), "{out}");
         assert!(out.contains("@ file"), "{out}");
     }

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -369,7 +369,7 @@ fn detail_sections() -> Vec<HelpSection> {
                 ("i", "respond, or send a message to a running agent run"),
                 (
                     "enter on Deny with feedback",
-                    "open a box for what the run should do instead; ^Enter or the Send button sends it with the deny, esc goes back to the prompt",
+                    "open a box for what the run should do instead; ^S or the Send button sends it with the deny, esc goes back to the prompt",
                 ),
                 ("g", "the stage graph explorer"),
                 ("t", "the band: the run's path, or the whole blueprint"),
@@ -424,7 +424,11 @@ fn detail_sections() -> Vec<HelpSection> {
         HelpSection {
             title: "Writing a response (i)",
             entries: vec![
-                ("ctrl+enter", "send (needs the kitty keyboard protocol)"),
+                ("ctrl+s", "send"),
+                (
+                    "ctrl+enter",
+                    "also sends (needs the kitty keyboard protocol)",
+                ),
                 ("enter", "insert a newline; so does alt+enter"),
                 ("tab", "move to the Send button; enter or space there sends"),
                 ("pgup / pgdn", "scroll the document above the prompt"),
@@ -462,9 +466,10 @@ fn new_run_sections() -> Vec<HelpSection> {
         HelpSection {
             title: "New run: task",
             entries: vec![
+                ("ctrl+s", "start the run"),
                 (
                     "ctrl+enter",
-                    "start the run (needs the kitty keyboard protocol)",
+                    "also starts it (needs the kitty keyboard protocol)",
                 ),
                 ("enter", "insert a newline; so does alt+enter"),
                 ("@", "reference a file from the working directory"),

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -425,7 +425,7 @@ impl Dashboard {
                 // box's keys, and Esc is back to the choices, not out.
                 _ if self.deny_feedback_open => Line::from(vec![
                     Span::styled(
-                        "[^Enter]",
+                        "[^S]",
                         Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
                     ),
                     Span::raw(" send with the deny  "),
@@ -436,14 +436,15 @@ impl Dashboard {
                     Span::styled("[Esc]", Style::default().add_modifier(Modifier::BOLD)),
                     Span::raw(" back to the prompt"),
                 ]),
-                // The response box: Enter breaks the line and
-                // Ctrl+Enter sends, with the Send button for a terminal
-                // that cannot tell the two apart. An in-place edit is the
-                // same box with a Save button, so it takes the same bar.
+                // The response box: Enter breaks the line and Ctrl+S sends
+                // (Ctrl+Enter too, on a terminal that can tell it from
+                // Enter), with the Send button for the mouse. An in-place
+                // edit is the same box with a Save button, so it takes the
+                // same bar.
                 Some(InteractionKind::FreeText) | Some(InteractionKind::EditText) | None => {
                     Line::from(vec![
                         Span::styled(
-                            "[^Enter]",
+                            "[^S]",
                             Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
                         ),
                         Span::raw(" send  "),
@@ -1216,7 +1217,7 @@ mod tests {
             .unwrap();
         let buf = rendered_buffer(&terminal);
         // Enter is a newline in the box; the bar must not say it sends.
-        assert!(buf.contains("[^Enter] send"), "{buf}");
+        assert!(buf.contains("[^S] send"), "{buf}");
         assert!(buf.contains("[Enter] newline"), "{buf}");
         assert!(buf.contains("[Tab] Send button"), "{buf}");
         assert!(!buf.contains("[Enter] send"), "{buf}");
@@ -1283,7 +1284,7 @@ mod tests {
             })
             .unwrap();
         let buf = rendered_buffer(&terminal);
-        assert!(buf.contains("[^Enter] send with the deny"), "{buf}");
+        assert!(buf.contains("[^S] send with the deny"), "{buf}");
         assert!(buf.contains("[Esc] back to the prompt"), "{buf}");
         assert!(!buf.contains("select"), "{buf}");
     }
@@ -1883,7 +1884,7 @@ mod tests {
             })
             .unwrap();
         let buf = rendered_buffer(&terminal);
-        assert!(buf.contains("[^Enter] send"), "{buf}");
+        assert!(buf.contains("[^S] send"), "{buf}");
         assert!(buf.contains("[Enter] newline"), "{buf}");
         assert!(buf.contains("[Tab] Send button"), "{buf}");
         assert!(!buf.contains("[Enter] confirm"), "{buf}");

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -978,7 +978,7 @@ fn footer_hints(wizard: &Wizard) -> Vec<Hint> {
     if wizard.reorder.is_some() {
         return vec![
             hint("drag ⠿", "move a row"),
-            hint("shift+↑↓", "move"),
+            hint("shift+↑↓/K J", "move"),
             hint("enter", "keep the order"),
             hint("esc", "cancel"),
         ];

--- a/crates/leviath-cli/src/tui/widgets/reorder.rs
+++ b/crates/leviath-cli/src/tui/widgets/reorder.rs
@@ -126,6 +126,12 @@ impl Reorder {
     }
 
     /// Keys while the modal is open.
+    ///
+    /// `K`/`J` move the row exactly as Shift+↑/↓ do, because several terminals
+    /// (Apple Terminal among them) drop the Shift modifier from arrow keys, so
+    /// Shift+↑ arrives here as a plain ↑. A capital letter is an ordinary
+    /// character every terminal delivers. Their lowercase pair moves the
+    /// cursor, mirroring the arrows.
     pub(crate) fn handle_key(&mut self, key: &KeyEvent) -> ReorderOutcome {
         use crossterm::event::KeyModifiers as Mods;
         let shifted = key.modifiers.contains(Mods::SHIFT);
@@ -134,6 +140,14 @@ impl Reorder {
             KeyCode::Down if shifted => self.move_row(1),
             KeyCode::Up => self.move_cursor(-1),
             KeyCode::Down => self.move_cursor(1),
+            // Shift+k may arrive as 'K', or as 'k' with the modifier set,
+            // depending on the terminal's encoding; both mean the row.
+            KeyCode::Char('K') => self.move_row(-1),
+            KeyCode::Char('J') => self.move_row(1),
+            KeyCode::Char('k') if shifted => self.move_row(-1),
+            KeyCode::Char('j') if shifted => self.move_row(1),
+            KeyCode::Char('k') => self.move_cursor(-1),
+            KeyCode::Char('j') => self.move_cursor(1),
             KeyCode::Enter => return ReorderOutcome::Confirmed(self.values()),
             KeyCode::Esc => return ReorderOutcome::Cancelled,
             _ => {}
@@ -238,7 +252,7 @@ impl Reorder {
             .map(|text| Line::from(Span::styled(text.clone(), Style::default().fg(C_MUTED))))
             .collect();
         lines.push(Line::from(Span::styled(
-            "Drag ⠿, or Shift+↑/↓ to move a row. Enter keeps the order, Esc cancels.",
+            "Drag ⠿, or Shift+↑/↓ or K/J to move a row. Enter keeps the order, Esc cancels.",
             Style::default().fg(C_DIM),
         )));
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), chunks[0]);
@@ -335,6 +349,31 @@ mod tests {
         // And back up one: b, c, a -> b, a, c.
         r.handle_key(&shift(KeyCode::Up));
         assert_eq!(r.values(), ["b", "a", "c"]);
+    }
+
+    /// The letters exist because a terminal that drops Shift from the arrows
+    /// (Apple Terminal does) leaves Shift+↑/↓ meaning "move the cursor". They
+    /// arrive either as a capital, or as the lowercase letter with the Shift
+    /// flag; both spellings move the row, and the bare letters mirror the
+    /// arrows.
+    #[test]
+    fn capital_j_and_k_move_the_row_and_lowercase_move_the_cursor() {
+        let mut r = reorder();
+        r.handle_key(&key(KeyCode::Char('J')));
+        r.handle_key(&shift(KeyCode::Char('j')));
+        assert_eq!(r.values(), ["b", "c", "a"]);
+        assert_eq!(r.cursor, 2, "the cursor rode with the row");
+        r.handle_key(&key(KeyCode::Char('K')));
+        assert_eq!(r.values(), ["b", "a", "c"]);
+        r.handle_key(&shift(KeyCode::Char('k')));
+        assert_eq!(r.values(), ["a", "b", "c"]);
+
+        let mut r = reorder();
+        r.handle_key(&key(KeyCode::Char('j')));
+        assert_eq!(r.cursor, 1, "bare j is the cursor");
+        r.handle_key(&key(KeyCode::Char('k')));
+        assert_eq!(r.cursor, 0, "bare k is the cursor");
+        assert_eq!(r.values(), ["a", "b", "c"], "neither moved a row");
     }
 
     #[test]

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -746,7 +746,8 @@ nothing about what gets written.
 
 The Defaults screen leads with **Provider priority** - the order a bare model name prefers, whose
 head is your default provider. Enter opens a modal to arrange it: drag a row by its `⠿` grip, or
-move the one under the cursor with `Shift+↑`/`Shift+↓`. It writes the same
+move the one under the cursor with `Shift+↑`/`Shift+↓`, or with `K`/`J` on a terminal that keeps
+Shift+arrows for itself (Apple Terminal does). It writes the same
 [`provider_order`](/docs/configuration#provider-preference-order) that `lev providers order` and
 `PUT /api/config` set, so putting a subscription like Codex first there is how you route bare model
 names onto your plan.

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -156,7 +156,7 @@ rather than back into the form.
 |---|---|
 | `↑` / `↓` | Choose an agent. Any letter filters the list; `Backspace` shortens the filter |
 | `Tab` / `Enter` | Move from the agent list to the task |
-| `Ctrl+Enter` (in the task) | Start the run. Only a terminal with the kitty keyboard protocol (kitty, WezTerm, Ghostty, foot, recent Alacritty) can tell Ctrl+Enter from Enter; elsewhere it inserts a newline, and the Start button is the way to submit |
+| `Ctrl+S` (in the task) | Start the run. `Ctrl+Enter` also starts it, but only a terminal with the kitty keyboard protocol (kitty, WezTerm, Ghostty, foot, recent Alacritty) can tell Ctrl+Enter from Enter; elsewhere it inserts a newline, and `Ctrl+S` or the Start button is the way to submit |
 | `Enter` / `Alt+Enter` | Newline |
 | `Tab` (in the task) | Move to the Start button under the editor. `Enter` or `Space` there starts the run, as does a click on it; `Tab` or `Esc` returns to the agent list, `Shift+Tab` to the task |
 | `@` | Reference a file from the working directory: `↑` / `↓` choose a path, `Enter` or `Tab` inserts it, `Backspace` over the `@` ends the reference, `Esc` dismisses the list and keeps what you typed |
@@ -213,16 +213,16 @@ for a run whose blueprint could not be read, the flat tab strip stays.
 | `Ctrl-C` | Quit. `q` is unbound here, so a stray keystroke cannot close the dashboard mid-run |
 
 While you are typing a response, `Enter` inserts a newline, the way it does in the new-run task
-box, and `Ctrl+Enter` sends. Only a terminal with the kitty keyboard protocol can tell
-`Ctrl+Enter` from `Enter`; elsewhere `Tab` moves to the Send button under the box, where `Enter`
-or `Space` sends, as does a click on it. `PgUp` / `PgDn` scroll the document above the prompt, and
+box, and `Ctrl+S` sends. `Ctrl+Enter` sends too on a terminal with the kitty keyboard protocol,
+which is what it takes to tell `Ctrl+Enter` from `Enter`; `Tab` moves to the Send button under
+the box, where `Enter` or `Space` sends, as does a click on it. `PgUp` / `PgDn` scroll the document above the prompt, and
 `Esc` cancels. `/quit` or `/exit` on its own line ends the conversation when sent. An in-place
 document edit takes the same keys, with a Save button in place of Send. Single-line boxes (a
 rename, a filter, a server URL) still submit on `Enter`.
 
 A tool approval is a list of choices: `↑` / `↓` pick one and `Enter` answers. Its last row, "Deny
 with feedback", opens the same response box instead of answering, for the line or two that tells
-the run what to do instead of the call. `Ctrl+Enter` or the Send button sends it with the deny, and
+the run what to do instead of the call. `Ctrl+S` or the Send button sends it with the deny, and
 `Esc` goes back to the choices with nothing sent. The text reaches the model inside the refused
 call's tool result; see [Human-in-the-loop](/docs/interaction#tool-approval).
 


### PR DESCRIPTION
## What

Two TUI keyboard fixes for terminals that never deliver the chords the UI depended on, live-verified in a pty harness:

- **Provider priority reorder (`lev setup`)**: Apple Terminal (and others) strip the Shift modifier from arrow keys, so Shift+Up/Down arrived as plain arrows and the only keyboard reorder was unreachable. `K`/`J` now move the row (either as capitals or as `k`/`j` with Shift reported), and `j`/`k` mirror the arrows for the cursor. The modal hint and wizard footer name the keys.
- **Submitting from the dashboard's long-form editors**: Ctrl+Enter reaches the program only under the kitty keyboard protocol; elsewhere it arrives as a plain Enter, and some macOS terminals swallow it outright (one opens a context menu on it). `Ctrl+S` now submits everywhere Ctrl+Enter did: the new-run task editor, the response box, deny-with-feedback, and the in-place document edit. Ctrl+Enter still works where it arrives. Hint bars, help overlays and docs advertise `^S`.

## Verification

- Unit tests for every new key arm (both spellings of the shifted letters, Ctrl+S dispatch, a bare `s` staying text).
- Live pty run of `lev setup`: `J` moved the provider row, `j` moved the cursor, `K` moved it back.
- Live pty run of `lev dash` against an isolated home: typing a task and pressing Ctrl+S (raw `0x13`) dispatched the spawn to the daemon.
