### PR TITLE
feat(tools): tool groups in available_tools (@builtin, @subagent, @scripts, @mcp, @all)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## Unreleased
+
+### Added
+
+- Tool groups in `available_tools`. An entry that starts with `@` grants a
+  whole kind of tool rather than one: `@builtin` (every compiled-in tool),
+  `@subagent`, `@scripts` (every Rhai tool, the agent's own and the global
+  ones), `@mcp` (every tool every connected server advertises) and `@all`.
+  Groups and names mix, so "every built-in plus these two scripts" is
+  `["@builtin", "summarize", "cite"]` and "everything" is `["@all"]`. A group
+  is resolved when the stage runs, so a script or MCP server added later is
+  offered without editing the manifest, and it grants visibility only: every
+  tool it reaches still goes through `tool_permissions`, the taint gate and
+  the approval prompts. `submit_output` and `fan_out` are never granted by a
+  group. `lev validate` refuses an entry that looks like a group and names
+  none, checks `required_tools` against what the groups reach on this
+  install (`required-tool-not-granted`), and reports an autonomous stage
+  granting `@builtin` once for the group rather than once per blocking tool.
+  The dashboard's tool chooser leads with the five groups and labels each
+  tool by where it comes from, and `GET /api/tools` carries the same
+  `groups` list for other clients.
+
+### Fixed
+
+- The `install_tool` summary and the Rhai tools page pointed at an
+  `available_global_tools` stage key that does not exist. Both now say
+  `@scripts`, which does what that key claimed to.
+
 ## 0.5.8 - 2026-09-01
 
 ### Changed

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -1477,6 +1477,9 @@ mod tests {
         );
         crate::lint::LintEnv {
             known_tools,
+            // Empty on purpose: no bundled blueprint grants a tool group, so
+            // the group-aware checks have nothing to classify here.
+            tool_sources: std::collections::HashMap::new(),
             known_models: crate::commands::models::closed_catalog_models(),
             available_providers: None,
             read_paths: None,

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
@@ -120,8 +120,9 @@ pub(in crate::commands::dashboard) struct Editor {
     pub(in crate::commands::dashboard) message: Option<String>,
     /// `provider/model` ids the model chooser offers.
     pub(in crate::commands::dashboard) models: Vec<String>,
-    /// Tool names the tools chooser offers.
-    pub(in crate::commands::dashboard) tools: Vec<String>,
+    /// What the tools chooser offers: the five group tokens first, then
+    /// every tool by name.
+    pub(in crate::commands::dashboard) tools: Vec<ToolChoice>,
     /// Where the last frame put the inspector's rows: the screen row of
     /// each field, and the column span of each stage tab, so a click lands
     /// on the right one.
@@ -180,6 +181,55 @@ fn chain_graph(names: &[String]) -> Arc<StageGraph> {
     let bp = leviath_core::manifest::parse_manifest(&text)
         .expect("stage names passed the manifest's charset");
     Arc::new(StageGraph::from_blueprint(&bp))
+}
+
+/// One row of the tools chooser: a name the stage may write, and what it is.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) struct ToolChoice {
+    /// The `available_tools` entry: a tool name or a group token.
+    pub(in crate::commands::dashboard) name: String,
+    /// Where it comes from, or what the group reaches, in a few words.
+    pub(in crate::commands::dashboard) detail: String,
+}
+
+/// Everything the tools chooser offers for the agent at `dir`: the group
+/// tokens first, since "all the built-ins" is the usual answer, then the
+/// tools this install has (built in, and scripts under the agent and the
+/// global directory), then whatever the manifest names that was not found.
+pub(super) fn tool_choices(
+    dir: &std::path::Path,
+    name: &str,
+    doc: &ManifestDoc,
+) -> Vec<ToolChoice> {
+    use leviath_core::blueprint::{ToolGroup, is_tool_group_token};
+
+    let mut choices: Vec<ToolChoice> = ToolGroup::ALL
+        .iter()
+        .map(|g| ToolChoice {
+            name: g.token().to_string(),
+            detail: g.describe().to_string(),
+        })
+        .collect();
+    let inventory = crate::tool_inventory::ToolInventory::discover(Some(dir), Some(name));
+    let mut named: Vec<ToolChoice> = inventory
+        .tools
+        .iter()
+        .map(|t| ToolChoice {
+            name: t.name.clone(),
+            detail: t.source.describe().to_string(),
+        })
+        .collect();
+    for tool in doc.known_tools() {
+        if !is_tool_group_token(&tool) && !named.iter().any(|t| t.name == tool) {
+            named.push(ToolChoice {
+                name: tool,
+                detail: "named by this agent, not found on this install".to_string(),
+            });
+        }
+    }
+    named.sort_by(|a, b| a.name.cmp(&b.name));
+    choices.extend(named);
+    choices
 }
 
 impl Editor {
@@ -394,16 +444,7 @@ impl Dashboard {
         );
         models.sort();
         models.dedup();
-        // The tools this install has: built in, plus scripts under the
-        // agent's directory and the ones the manifest already names.
-        let mut tools: Vec<String> =
-            crate::tool_inventory::ToolInventory::discover(Some(&dir), Some(&name))
-                .names()
-                .into_iter()
-                .collect();
-        tools.extend(doc.known_tools());
-        tools.sort();
-        tools.dedup();
+        let tools = tool_choices(&dir, &name, &doc);
         let mut editor = Editor {
             name,
             is_new,

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
@@ -551,19 +551,23 @@ impl Dashboard {
         let rows: Vec<PickerOption> = all
             .iter()
             .map(|t| PickerOption {
-                value: t.clone(),
-                detail: String::new(),
+                value: t.name.clone(),
+                detail: t.detail.clone(),
             })
             .collect();
         let chosen: Vec<usize> = all
             .iter()
             .enumerate()
-            .filter(|(_, t)| have.contains(t))
+            .filter(|(_, t)| have.contains(&t.name))
             .map(|(i, _)| i)
             .collect();
         let mut picker = Picker::new(
             format!("Tools {stage} may use"),
-            vec!["Every tool this install has: built in, and scripts under the agent.".to_string()],
+            vec![
+                "A group such as @builtin grants every tool of that kind, installed now or \
+                 later; the rest are the tools this install has, one by one."
+                    .to_string(),
+            ],
             rows,
             0,
         );
@@ -623,7 +627,10 @@ impl Dashboard {
     pub(super) fn editor_settle_tools(&mut self, chosen: &[usize]) {
         let stage = self.editor().panel_stage().expect("a stage field");
         let all = self.editor().tools.clone();
-        let tools: Vec<String> = chosen.iter().filter_map(|i| all.get(*i).cloned()).collect();
+        let tools: Vec<String> = chosen
+            .iter()
+            .filter_map(|i| all.get(*i).map(|t| t.name.clone()))
+            .collect();
         self.editor_mutate(|d| d.set_tools(&stage, &tools));
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
@@ -432,7 +432,8 @@ fn stage_fields(doc: &ManifestDoc, name: &str, tab: StageTab) -> Vec<Field> {
                 FieldId::ToolSet,
                 "Tools it may use",
                 FieldValue::Row(tools),
-                "Enter picks from every tool this install has; Space toggles one.",
+                "Enter picks from every tool this install has, or a group such as @builtin; \
+                 Space toggles one.",
             ));
             out
         }

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -1942,3 +1942,61 @@ fn a_system_prompt_comes_back_from_the_editor_too() {
     ));
     let _ = std::fs::remove_dir_all(&root);
 }
+
+/// The tools chooser leads with the group tokens, labels each tool by where
+/// it comes from, and keeps a name the manifest uses that this install lacks
+/// (so it can be unticked) without doubling a group the manifest already
+/// grants.
+#[test]
+fn the_tools_chooser_offers_groups_first_and_labels_sources() {
+    let (mut dash, root) = dashboard("tool_choices");
+    let agent_dir = root.join("agents").join("own");
+    std::fs::create_dir_all(agent_dir.join("tools")).unwrap();
+    std::fs::write(
+        agent_dir.join("tools").join("summarize.rhai"),
+        "// @tool summarize\n// @description sums\n1",
+    )
+    .unwrap();
+    open_editor_on(&mut dash, "own");
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_tools("work", &["@builtin".into(), "ghost_tool".into()])
+        .unwrap();
+    let editor = dash.agents().editor.as_ref().unwrap();
+    let choices = super::editor::tool_choices(&editor.dir, "own", &editor.doc);
+
+    let names: Vec<&str> = choices.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(
+        &names[..5],
+        &["@all", "@builtin", "@subagent", "@scripts", "@mcp"],
+        "{names:?}"
+    );
+    assert_eq!(names.iter().filter(|n| **n == "@builtin").count(), 1);
+    let detail = |name: &str| {
+        choices
+            .iter()
+            .find(|c| c.name == name)
+            .map(|c| c.detail.clone())
+            .unwrap_or_else(|| panic!("{name} offered: {names:?}"))
+    };
+    assert_eq!(
+        detail("@builtin"),
+        leviath_core::blueprint::ToolGroup::Builtin.describe()
+    );
+    assert_eq!(detail("read_file"), "built in");
+    assert_eq!(detail("spawn_agent"), "sub-agent tool");
+    assert_eq!(detail("summarize"), "this agent's script");
+    assert_eq!(
+        detail("ghost_tool"),
+        "named by this agent, not found on this install"
+    );
+    // Past the groups the list is alphabetical.
+    let rest: Vec<&str> = names[5..].to_vec();
+    let mut sorted = rest.clone();
+    sorted.sort_unstable();
+    assert_eq!(rest, sorted);
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/leviath-cli/src/commands/serve/tools.rs
+++ b/crates/leviath-cli/src/commands/serve/tools.rs
@@ -87,9 +87,22 @@ pub(super) struct SkippedItem {
     pub(super) source: String,
 }
 
+/// One `available_tools` group token: a grant of every tool of one kind.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct GroupItem {
+    /// The token a blueprint writes, `@builtin` and the like.
+    pub(super) name: String,
+    /// What it reaches, in one line.
+    pub(super) description: String,
+}
+
 /// The body of `GET /api/tools`.
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct ToolsResp {
+    /// The group tokens `available_tools` accepts alongside tool names, so a
+    /// picker can offer "all the built-ins" as one row rather than making
+    /// the user tick twenty-eight boxes.
+    pub(super) groups: Vec<GroupItem>,
     /// Everything that will work if a blueprint names it.
     pub(super) tools: Vec<ToolItem>,
     /// Everything that looked like a tool and will not work, with the reason.
@@ -114,6 +127,13 @@ pub(super) async fn list_tools(
     };
     let inventory = ToolInventory::discover(dir.as_deref(), q.agent.as_deref());
 
+    let groups = leviath_core::blueprint::ToolGroup::ALL
+        .iter()
+        .map(|g| GroupItem {
+            name: g.token().to_string(),
+            description: g.describe().to_string(),
+        })
+        .collect();
     let tools = inventory
         .tools
         .into_iter()
@@ -134,7 +154,11 @@ pub(super) async fn list_tools(
         })
         .collect();
 
-    Ok(Json(ToolsResp { tools, skipped }))
+    Ok(Json(ToolsResp {
+        groups,
+        tools,
+        skipped,
+    }))
 }
 
 #[cfg(test)]
@@ -207,6 +231,21 @@ mod tests {
                 .expect("a built-in");
             assert!(builtin.get("path").is_none());
             assert!(builtin.get("agent").is_none());
+            // The group tokens ride along, so a picker can offer them, and
+            // none of them is ever listed as a tool.
+            let groups = body["groups"].as_array().expect("a groups array");
+            let names: Vec<&str> = groups.iter().filter_map(|g| g["name"].as_str()).collect();
+            assert_eq!(names, ["@all", "@builtin", "@subagent", "@scripts", "@mcp"]);
+            assert!(
+                groups
+                    .iter()
+                    .all(|g| !g["description"].as_str().unwrap().is_empty())
+            );
+            assert!(
+                tools
+                    .iter()
+                    .all(|t| !t["name"].as_str().unwrap().starts_with('@'))
+            );
         })
         .await;
     }

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -370,11 +370,19 @@ fn stage_tools(stage: &leviath_core::Stage) -> Vec<leviath_providers::Tool> {
         leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(std::env::temp_dir()));
     let mut defs = builtins.tool_defs();
     defs.extend(leviath_tools::BuiltinTools::subagent_tool_defs());
-    stage
-        .available_tools
-        .iter()
-        .filter_map(|name| defs.iter().find(|d| d.name == *name).cloned())
-        .collect()
+    // The runtime's own filter, so an alias, a group grant and an unattended
+    // cut mean here what they mean in a run. No MCP servers and no scripts
+    // are behind it: a test drives one inference, not a tool.
+    let owners = leviath_runtime::pipeline::ToolOwners::new();
+    leviath_runtime::pipeline::filter_tools_for_stage(
+        leviath_runtime::pipeline::ToolCatalog {
+            defs: &defs,
+            owners: &owners,
+        },
+        &stage.available_tools,
+        &stage.required_tools,
+        false,
+    )
 }
 
 /// Run a single test case: build a one-off context window from the blueprint,
@@ -704,6 +712,26 @@ max_tokens = 500
         let mut stage = leviath_core::Stage::new("s".to_string(), test_model());
         stage.available_tools = vec!["definitely_not_a_tool".to_string()];
         assert!(stage_tools(&stage).is_empty());
+    }
+
+    /// The same resolver a run uses, so an alias and a group grant advertise
+    /// here what they advertise there.
+    #[test]
+    fn an_alias_and_a_group_grant_resolve_as_in_a_run() {
+        let mut stage = leviath_core::Stage::new("s".to_string(), test_model());
+        stage.available_tools = vec!["bash".to_string()];
+        let names: Vec<String> = stage_tools(&stage).into_iter().map(|t| t.name).collect();
+        assert_eq!(names, vec!["shell"]);
+
+        stage.available_tools = vec!["@builtin".to_string()];
+        let names: Vec<String> = stage_tools(&stage).into_iter().map(|t| t.name).collect();
+        assert!(names.contains(&"read_file".to_string()), "got {names:?}");
+        assert!(names.contains(&"write_file".to_string()), "got {names:?}");
+        assert!(!names.contains(&"spawn_agent".to_string()), "got {names:?}");
+        assert!(
+            !names.contains(&leviath_tools::SUBMIT_OUTPUT_TOOL.to_string()),
+            "got {names:?}"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -931,6 +931,7 @@ fn build_agent_inner(
             scan_dirs: script_scan_dirs(&args.blueprint_path, workdir_tools_dir),
             reserved_names: reserved_tool_names(&builtin_names, deps.mcp_tool_defs),
             static_defs: static_tool_defs,
+            mcp_owners: deps.mcp_tool_owners.clone(),
             stage_available,
             stage_required,
             unattended: args.yolo,

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -421,6 +421,9 @@ pub(crate) struct DynamicToolCtx {
     pub reserved_names: HashSet<String>,
     /// Static (non-script) tool defs: built-in + sub-agent + MCP.
     pub static_defs: Vec<leviath_providers::Tool>,
+    /// Which MCP server owns each MCP def, so a refresh can tell an MCP def
+    /// from a fresh script def when a stage grants `@mcp` or `@scripts`.
+    pub mcp_owners: leviath_runtime::pipeline::ToolOwners,
     /// Each stage's `available_tools` (Layer-1 allowlist), by stage index.
     pub stage_available: Vec<Vec<String>>,
     /// Each stage's `required_tools` (human tools kept through an unattended
@@ -978,7 +981,10 @@ impl ToolService for CliToolService {
         let mut all = ctx.static_defs.clone();
         all.extend(script_defs);
         Some(leviath_runtime::pipeline::filter_tools_for_stage(
-            &all,
+            leviath_runtime::pipeline::ToolCatalog {
+                defs: &all,
+                owners: &ctx.mcp_owners,
+            },
             available,
             required,
             ctx.unattended,
@@ -1548,6 +1554,7 @@ mod tests {
                 scan_dirs: vec![scan_dir],
                 reserved_names: HashSet::new(),
                 static_defs,
+                mcp_owners: Default::default(),
                 stage_available,
                 stage_required,
                 unattended,

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -67,9 +67,22 @@ pub(super) fn lint_declarations(stage: &leviath_core::Stage, keys: StageKeys) ->
 /// never granted.
 pub(super) fn lint_tools(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<LintFinding> {
     let mut findings = Vec::new();
+    let groups = stage.tool_groups();
+
+    // Which group a name written elsewhere in the stage would fall under, or
+    // `None` when the install was never asked (or the name matches nothing),
+    // in which case a group-aware check says nothing rather than guessing.
+    let source_of = |name: &str| -> Option<ToolGroup> {
+        if name.contains("__") {
+            return Some(ToolGroup::Mcp);
+        }
+        leviath_tools::tool_name_spellings(name).find_map(|n| env.tool_sources.get(n).copied())
+    };
+    let group_grants =
+        |name: &str| source_of(name).is_some_and(|source| groups.iter().any(|g| g.covers(source)));
 
     if !env.known_tools.is_empty() {
-        for tool in &stage.available_tools {
+        for tool in stage.named_tools() {
             // `server__tool` is an MCP name, and every MCP name has that shape:
             // advertised names are always server-qualified, so the test is
             // exact rather than a heuristic. Such a name resolves only once
@@ -93,6 +106,42 @@ pub(super) fn lint_tools(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lint
         }
     }
 
+    // `Stage::validate` insists every required tool is also granted, except
+    // when a group is in play: whether `@scripts` reaches `summarize` depends
+    // on where `summarize` lives, which only an install can say. Say it here,
+    // because a required tool the stage never grants is a tool the model
+    // never sees, whatever the name promised.
+    if !groups.is_empty() && !env.tool_sources.is_empty() {
+        let named: Vec<&str> = stage.named_tools().map(String::as_str).collect();
+        for tool in &stage.required_tools {
+            let by_name = named
+                .iter()
+                .any(|n| canonical_tool_name(n) == canonical_tool_name(tool));
+            if by_name || group_grants(tool) {
+                continue;
+            }
+            let granted = groups
+                .iter()
+                .map(|g| g.token())
+                .collect::<Vec<_>>()
+                .join(", ");
+            findings.push(
+                LintFinding::new(
+                    LintSeverity::Error,
+                    "required-tool-not-granted",
+                    format!(
+                        "requires '{tool}' but grants it neither by name nor through \
+                         {granted}, so the model never sees it"
+                    ),
+                )
+                .in_stage(&stage.name)
+                .with_fix(format!(
+                    "add '{tool}' to available_tools, or grant the group it belongs to"
+                )),
+            );
+        }
+    }
+
     // A stage granting a whole connector has a tool set nobody can enumerate
     // here: it is whatever that server advertises at spawn, which is the point
     // of naming the server. So a permission that looks orphaned might name a
@@ -106,6 +155,13 @@ pub(super) fn lint_tools(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lint
     let granted: HashSet<&str> = stage.available_tools.iter().map(String::as_str).collect();
     for tool in stage.tool_permissions.keys() {
         if granted.contains(tool.as_str()) {
+            continue;
+        }
+        // A group is a grant too, of a set only the install can spell out.
+        // Where it can, a permission the group reaches is not orphaned; where
+        // it cannot (no inventory), the check stays quiet for the same reason
+        // it does under a connector.
+        if !groups.is_empty() && (env.tool_sources.is_empty() || group_grants(tool)) {
             continue;
         }
         findings.push(
@@ -138,8 +194,11 @@ pub(super) fn lint_tools(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lint
     let routes_to_region = stage.tool_result_routing.as_ref().is_some_and(|r| {
         r.default_region != "conversation" || r.tool_overrides.values().any(|v| v != "conversation")
     });
-    let reads_files = granted.contains("read_file") || granted.contains("read_files");
-    if routes_to_region && reads_files && !granted.contains("context_read") {
+    let all_builtins = stage.grants_all_builtins();
+    let reads_files =
+        all_builtins || granted.contains("read_file") || granted.contains("read_files");
+    let reads_context = all_builtins || granted.contains("context_read");
+    if routes_to_region && reads_files && !reads_context {
         findings.push(
             LintFinding::new(
                 LintSeverity::Warning,
@@ -165,22 +224,23 @@ pub(super) fn lint_blocking_tools(stage: &leviath_core::Stage) -> Vec<LintFindin
     if !matches!(stage.mode, StageMode::Autonomous) || stage.allow_blocking_tools {
         return Vec::new();
     }
-    stage
+    // A tool kept in `required_tools` is the same statement of intent
+    // `allow_blocking_tools` makes, made one tool at a time - and it is the
+    // one that also survives an unattended run, so it is worth more.
+    //
+    // Canonicalised on both sides, as the runtime does: a stage granting
+    // `bash` and keeping `shell` is one decision, not two.
+    let required = |tool: &str| {
+        stage
+            .required_tools
+            .iter()
+            .any(|r| canonical_tool_name(r) == canonical_tool_name(tool))
+    };
+    let mut findings: Vec<LintFinding> = stage
         .available_tools
         .iter()
         .filter(|t| BLOCKING_INTERACTION_TOOLS.contains(&canonical_tool_name(t)))
-        // A tool kept in `required_tools` is the same statement of intent
-        // `allow_blocking_tools` makes, made one tool at a time - and it is the
-        // one that also survives an unattended run, so it is worth more.
-        //
-        // Canonicalised on both sides, as the runtime does: a stage granting
-        // `bash` and keeping `shell` is one decision, not two.
-        .filter(|t| {
-            !stage
-                .required_tools
-                .iter()
-                .any(|r| canonical_tool_name(r) == canonical_tool_name(t))
-        })
+        .filter(|t| !required(t))
         .map(|tool| {
             LintFinding::new(
                 LintSeverity::Warning,
@@ -197,7 +257,43 @@ pub(super) fn lint_blocking_tools(stage: &leviath_core::Stage) -> Vec<LintFindin
                  allow_blocking_tools = true to say you meant it",
             )
         })
-        .collect()
+        .collect();
+
+    // A group that reaches the built-ins reaches every blocking tool at once.
+    // One finding for the group rather than five for its members: the fix is
+    // the same whichever member is named, and a list that long is skimmed.
+    let group = stage
+        .tool_groups()
+        .into_iter()
+        .find(|g| g.covers(ToolGroup::Builtin));
+    if let Some(group) = group {
+        let members: Vec<&str> = BLOCKING_INTERACTION_TOOLS
+            .iter()
+            .copied()
+            .filter(|t| !required(t))
+            .collect();
+        if !members.is_empty() {
+            findings.push(
+                LintFinding::new(
+                    LintSeverity::Warning,
+                    "blocking-tool-in-autonomous-stage",
+                    format!(
+                        "is autonomous but grants '{group}', which includes {}; each \
+                         suspends the run until a person answers",
+                        members.join(", ")
+                    ),
+                )
+                .in_stage(&stage.name)
+                .with_fix(
+                    "name the tools you want instead of the group, switch the stage to an \
+                     interactive mode, list the blocking tools you need in required_tools \
+                     so they survive an unattended run too, or set allow_blocking_tools = \
+                     true to say you meant it",
+                ),
+            );
+        }
+    }
+    findings
 }
 
 /// A `fail_all` fan-out stage with nowhere to go when a worker fails.
@@ -302,17 +398,23 @@ pub(super) fn lint_output_stage(stage: &leviath_core::Stage) -> Vec<LintFinding>
     // An output stage summarizes work; one that can also change files invites
     // the model to keep working where it was meant to report.
     if stage.mode == StageMode::Output {
-        let modifying: Vec<&String> = stage
-            .available_tools
-            .iter()
+        let modifying = stage
+            .named_tools()
             .filter(|t| leviath_core::blueprint::MODIFYING_TOOLS.contains(&canonical_tool_name(t)))
-            .collect();
-        for tool in modifying {
+            .map(|tool| format!("'{tool}', which changes the workspace"));
+        // A group reaching the built-ins carries every modifying tool with it,
+        // so it is named once, as the group, rather than once per member.
+        let grouped = stage
+            .tool_groups()
+            .into_iter()
+            .find(|g| g.covers(ToolGroup::Builtin))
+            .map(|g| format!("'{g}', which includes every tool that changes the workspace"));
+        for what in modifying.chain(grouped) {
             findings.push(
                 LintFinding::new(
                     LintSeverity::Warning,
                     "output-stage-can-modify",
-                    format!("is an output stage but grants '{tool}', which changes the workspace"),
+                    format!("is an output stage but grants {what}"),
                 )
                 .in_stage(&stage.name)
                 .with_fix(
@@ -816,10 +918,11 @@ pub(super) fn lint_compacted_deliverables(blueprint: &Blueprint) -> Vec<LintFind
 /// them: the caller owns those, and they are validated at spawn.
 pub(super) fn lint_required_regions_enforceable(blueprint: &Blueprint) -> Vec<LintFinding> {
     let writes_context = |stage: &leviath_core::Stage| {
-        stage
-            .available_tools
-            .iter()
-            .any(|t| t == "context_write" || t == "context_append")
+        stage.grants_all_builtins()
+            || stage
+                .available_tools
+                .iter()
+                .any(|t| t == "context_write" || t == "context_append")
     };
 
     let mut findings = Vec::new();

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -29,7 +29,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use leviath_core::Blueprint;
-use leviath_core::blueprint::StageMode;
+use leviath_core::blueprint::{StageMode, ToolGroup};
 use leviath_runtime::dynamic_interaction::BLOCKING_INTERACTION_TOOLS;
 use leviath_tools::canonical_tool_name;
 use serde::{Deserialize, Serialize};
@@ -156,6 +156,13 @@ pub(crate) struct LintEnv {
     /// MCP tools already resolved. Empty skips the unknown-tool check.
     pub known_tools: HashSet<String>,
 
+    /// Which group each known tool belongs to, so a check can say whether a
+    /// `@builtin`-style grant reaches a tool named elsewhere in the stage
+    /// (`required_tools`, `tool_permissions`). MCP tools are absent: their
+    /// `server__tool` shape already places them in [`ToolGroup::Mcp`]. Empty
+    /// means the question was never asked, and no group-aware check guesses.
+    pub tool_sources: HashMap<String, ToolGroup>,
+
     /// `(provider, model)` rows for providers whose catalog is closed enough to
     /// check against. A provider with no row here is not checked at all, which
     /// is what keeps open catalogs (Ollama, OpenRouter, script providers) from
@@ -243,11 +250,17 @@ impl LintEnv {
         // because `GET /api/tools` has to answer the same question and two
         // copies of "where does a tool come from" would not have stayed equal.
         // The lint wants only the names; the endpoint wants the sources too.
-        let known_tools =
-            crate::tool_inventory::ToolInventory::discover(Some(agent_dir), None).names();
+        let inventory = crate::tool_inventory::ToolInventory::discover(Some(agent_dir), None);
+        let known_tools = inventory.names();
+        let tool_sources = inventory
+            .tools
+            .iter()
+            .map(|t| (t.name.clone(), t.source.group()))
+            .collect();
 
         Self {
             known_tools,
+            tool_sources,
             known_models: crate::commands::models::closed_catalog_models(),
             available_providers: None,
             read_paths: None,

--- a/crates/leviath-cli/src/lint/security.rs
+++ b/crates/leviath-cli/src/lint/security.rs
@@ -27,27 +27,44 @@ pub(super) fn lint_tool_policies(
             .any(|n| stage.tool_permissions.contains_key(n) || agent_permissions.contains_key(n))
     };
 
-    stage
-        .available_tools
-        .iter()
-        .filter(|t| !has_policy(t))
-        // Only worth saying for the shell, whose default is `ask` - and an `ask`
-        // with nobody to answer waits rather than denying, so an unattended run
-        // hangs on the first command instead of failing it.
+    // Only worth saying for the shell, whose default is `ask` - and an `ask`
+    // with nobody to answer waits rather than denying, so an unattended run
+    // hangs on the first command instead of failing it.
+    let mut shells: Vec<String> = stage
+        .named_tools()
         .filter(|t| canonical_tool_name(t) == "shell")
+        .filter(|t| !has_policy(t))
+        .map(|t| format!("'{t}'"))
+        .collect();
+    // A group reaching the built-ins grants the shell as surely as naming it,
+    // and the policy still keys on the canonical name. Said once, and not at
+    // all when the shell is also named: that finding already covers it.
+    let builtin_group = stage
+        .tool_groups()
+        .into_iter()
+        .find(|g| g.covers(leviath_core::blueprint::ToolGroup::Builtin));
+    if shells.is_empty()
+        && !has_policy("shell")
+        && let Some(group) = builtin_group
+    {
+        shells.push(format!("'shell' through '{group}'"));
+    }
+
+    shells
+        .into_iter()
         .map(|tool| {
             LintFinding::new(
                 LintSeverity::Warning,
                 "implicit-shell-policy",
                 format!(
-                    "grants '{tool}' with no permission set for it, so it \
+                    "grants {tool} with no permission set for it, so it \
                      defaults to ask - and an unattended run waits on that \
                      prompt rather than being denied"
                 ),
             )
             .in_stage(&stage.name)
             .with_fix(format!(
-                "set {tool} = \"allow\" or \"deny\" in [tool_permissions] or \
+                "set shell = \"allow\" or \"deny\" in [tool_permissions] or \
                  [stages.{}.tool_permissions]",
                 stage.name
             ))

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -632,6 +632,335 @@ read_file = "allow"
     assert!(lint(&toml, &LintEnv::default()).is_empty());
 }
 
+// ─── Tool groups ──────────────────────────────────────────────────────────────
+
+/// An install that knows one tool of each kind, so a group-aware check can
+/// say which group reaches what.
+fn grouped_env() -> LintEnv {
+    use leviath_core::blueprint::ToolGroup;
+    let sources = [
+        ("read_file", ToolGroup::Builtin),
+        ("shell", ToolGroup::Builtin),
+        ("bash", ToolGroup::Builtin),
+        ("write_file", ToolGroup::Builtin),
+        ("ask_user_text", ToolGroup::Builtin),
+        ("ask_user_choice", ToolGroup::Builtin),
+        ("ask_user_confirm", ToolGroup::Builtin),
+        ("present_for_review", ToolGroup::Builtin),
+        ("edit_document", ToolGroup::Builtin),
+        ("spawn_agent", ToolGroup::Subagent),
+        ("summarize", ToolGroup::Scripts),
+    ];
+    LintEnv {
+        known_tools: known_tools(&sources.map(|(n, _)| n)),
+        tool_sources: sources
+            .map(|(n, g)| (n.to_string(), g))
+            .into_iter()
+            .collect(),
+        ..LintEnv::default()
+    }
+}
+
+/// A group token is a grant, not a tool name: `@scripts` is never "not a
+/// built-in", and everything it reaches is left to the runtime to enumerate.
+#[test]
+fn a_group_token_is_not_an_unknown_tool() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["@scripts", "@mcp", "read_file"]
+"#,
+    );
+    let findings = lint(&toml, &grouped_env());
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+/// `Stage::validate` cannot say whether `@scripts` reaches `summarize`; the
+/// lint can, given an inventory, and a required tool nothing grants is an
+/// error either way.
+#[test]
+fn a_required_tool_no_group_reaches_is_an_error() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["@scripts"]
+required_tools = ["summarize", "read_file", "github__create_issue"]
+"#,
+    );
+    let findings = lint(&toml, &grouped_env());
+    let missing = with_code(&findings, "required-tool-not-granted");
+    let named: Vec<&str> = missing
+        .iter()
+        .map(|f| {
+            f.message
+                .split('\'')
+                .nth(1)
+                .expect("the message quotes the tool")
+        })
+        .collect();
+    assert_eq!(named, ["read_file", "github__create_issue"], "{findings:?}");
+    assert!(missing.iter().all(|f| f.is_error()));
+    assert!(missing[0].message.contains("@scripts"), "{findings:?}");
+
+    // With no inventory the question cannot be answered, so it is not asked.
+    assert!(
+        with_code(
+            &lint(&toml, &LintEnv::default()),
+            "required-tool-not-granted"
+        )
+        .is_empty()
+    );
+}
+
+/// A required tool reached by name (either spelling) or by its group is fine,
+/// and `@all` reaches everything, MCP names included.
+#[test]
+fn a_required_tool_a_group_reaches_is_fine() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["@builtin", "@scripts", "bash"]
+required_tools = ["summarize", "read_file", "shell"]
+allow_blocking_tools = true
+
+[stages.main.tool_permissions]
+shell = "allow"
+"#,
+    );
+    let findings = lint(&toml, &grouped_env());
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["@all"]
+required_tools = ["spawn_agent", "github__create_issue"]
+allow_blocking_tools = true
+
+[stages.main.tool_permissions]
+shell = "allow"
+"#,
+    );
+    let findings = lint(&toml, &grouped_env());
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+/// A permission is orphaned only when nothing grants the tool: a group that
+/// reaches it counts, and with no inventory to classify by the check stays
+/// quiet, as it does under a connector.
+#[test]
+fn a_permission_a_group_reaches_is_not_orphaned() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["@scripts", "@mcp", "read_file"]
+
+[stages.main.tool_permissions]
+summarize = "allow"
+github__create_issue = "ask"
+write_file = "allow"
+"#,
+    );
+    let findings = lint(&toml, &grouped_env());
+    assert_eq!(codes(&findings), ["orphan-stage-permission"]);
+    assert!(findings[0].message.contains("write_file"), "{findings:?}");
+
+    assert!(lint(&toml, &LintEnv::default()).is_empty());
+}
+
+/// `@builtin` in an autonomous stage carries every blocking tool, reported
+/// once as the group; keeping one in `required_tools` takes it off the list,
+/// and `allow_blocking_tools` silences it.
+#[test]
+fn a_builtin_group_in_an_autonomous_stage_is_warned_about_once() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["@builtin"]
+required_tools = ["ask_user_text"]
+
+[stages.main.tool_permissions]
+shell = "allow"
+"#,
+    );
+    // The required ask tool also earns its own `holds-under-yolo` note, which
+    // is not what this test is about.
+    let blocking = |toml: &str| -> Vec<LintFinding> {
+        lint(toml, &grouped_env())
+            .into_iter()
+            .filter(|f| f.code != "holds-under-yolo")
+            .collect()
+    };
+    let findings = blocking(&toml);
+    assert_eq!(codes(&findings), ["blocking-tool-in-autonomous-stage"]);
+    assert_eq!(findings[0].severity, LintSeverity::Warning);
+    assert!(findings[0].message.contains("'@builtin'"), "{findings:?}");
+    assert!(
+        findings[0].message.contains("present_for_review"),
+        "{findings:?}"
+    );
+    assert!(
+        !findings[0].message.contains("ask_user_text"),
+        "{findings:?}"
+    );
+
+    let silenced = blocking(&toml.replace(
+        "required_tools",
+        "allow_blocking_tools = true\nrequired_tools",
+    ));
+    assert!(silenced.is_empty(), "{:?}", codes(&silenced));
+
+    // Naming every blocking tool in required_tools leaves nothing to say.
+    let all_required = toml.replace(
+        r#"required_tools = ["ask_user_text"]"#,
+        r#"required_tools = ["ask_user_text", "ask_user_choice", "ask_user_confirm", "present_for_review", "edit_document"]"#,
+    );
+    let findings = blocking(&all_required);
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+/// The shell arrives with `@builtin` as surely as by name, and its default
+/// policy is still `ask`. Said once, through the group; not at all when the
+/// shell is also named, since that finding already covers it.
+#[test]
+fn a_builtin_group_with_no_shell_policy_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["@all"]
+allow_blocking_tools = true
+"#,
+    );
+    let findings = lint(&toml, &grouped_env());
+    assert_eq!(codes(&findings), ["implicit-shell-policy"]);
+    assert!(
+        findings[0].message.contains("'shell' through '@all'"),
+        "{findings:?}"
+    );
+    assert!(
+        findings[0]
+            .fix
+            .as_deref()
+            .is_some_and(|f| f.contains("set shell =")),
+        "{findings:?}"
+    );
+
+    let named = lint(
+        &toml.replace(r#"["@all"]"#, r#"["@all", "bash"]"#),
+        &grouped_env(),
+    );
+    let shells = with_code(&named, "implicit-shell-policy");
+    assert_eq!(shells.len(), 1, "{named:?}");
+    assert!(shells[0].message.contains("'bash'"), "{named:?}");
+}
+
+/// An output stage reaching the built-ins through a group can modify the
+/// workspace, reported once as the group rather than once per member.
+#[test]
+fn an_output_stage_granting_the_builtin_group_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "output"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["@builtin", "submit_output"]
+require_output = true
+
+[stages.main.tool_permissions]
+shell = "allow"
+"#,
+    );
+    let findings = lint(&toml, &grouped_env());
+    let modify = with_code(&findings, "output-stage-can-modify");
+    assert_eq!(modify.len(), 1, "{findings:?}");
+    assert!(modify[0].message.contains("'@builtin'"), "{findings:?}");
+}
+
+/// Routing tool output into a region with `@builtin` granted is fine: the
+/// group carries `context_read` along with `read_file`.
+#[test]
+fn a_builtin_group_satisfies_the_region_read_check() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["@builtin"]
+allow_blocking_tools = true
+
+[stages.main.tool_routing]
+default_region = "notes"
+
+[stages.main.tool_permissions]
+shell = "allow"
+
+[stages.main.context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
+notes = { kind = "temporary", max_tokens = 1000 }
+"#,
+    );
+    let findings = lint(&toml, &grouped_env());
+    assert!(
+        with_code(&findings, "routing-without-region-read").is_empty(),
+        "{:?}",
+        codes(&findings)
+    );
+}
+
+/// A required region is enforceable through `@builtin`: the group carries the
+/// context-writing tools.
+#[test]
+fn a_builtin_group_makes_a_required_region_enforceable() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+available_tools = ["@builtin"]
+allow_blocking_tools = true
+
+[stages.main.tool_permissions]
+shell = "allow"
+
+[stages.main.context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
+findings = { kind = "pinned", max_tokens = 1000, required = true }
+"#,
+    );
+    let findings = lint(&toml, &grouped_env());
+    assert!(
+        with_code(&findings, "required-region-unenforceable").is_empty(),
+        "{:?}",
+        codes(&findings)
+    );
+}
+
 // ─── Blocking tools ───────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/leviath-cli/src/tool_inventory.rs
+++ b/crates/leviath-cli/src/tool_inventory.rs
@@ -42,6 +42,28 @@ impl ToolSource {
             Self::Global => "global",
         }
     }
+
+    /// What to call this source in a chooser, in a few words.
+    pub(crate) fn describe(self) -> &'static str {
+        match self {
+            Self::Builtin => "built in",
+            Self::Subagent => "sub-agent tool",
+            Self::Agent => "this agent's script",
+            Self::Global => "global script",
+        }
+    }
+
+    /// The `available_tools` group a tool from this source answers to. Both
+    /// script directories are one group: `@scripts` grants a script wherever
+    /// it lives, exactly as naming it would.
+    pub(crate) fn group(self) -> leviath_core::blueprint::ToolGroup {
+        use leviath_core::blueprint::ToolGroup;
+        match self {
+            Self::Builtin => ToolGroup::Builtin,
+            Self::Subagent => ToolGroup::Subagent,
+            Self::Agent | Self::Global => ToolGroup::Scripts,
+        }
+    }
 }
 
 /// One tool an agent may name in `available_tools`.
@@ -199,6 +221,15 @@ mod tests {
         assert_eq!(ToolSource::Subagent.as_str(), "subagent");
         assert_eq!(ToolSource::Agent.as_str(), "agent");
         assert_eq!(ToolSource::Global.as_str(), "global");
+        assert_eq!(ToolSource::Builtin.describe(), "built in");
+        assert_eq!(ToolSource::Subagent.describe(), "sub-agent tool");
+        assert_eq!(ToolSource::Agent.describe(), "this agent's script");
+        assert_eq!(ToolSource::Global.describe(), "global script");
+        use leviath_core::blueprint::ToolGroup;
+        assert_eq!(ToolSource::Builtin.group(), ToolGroup::Builtin);
+        assert_eq!(ToolSource::Subagent.group(), ToolGroup::Subagent);
+        assert_eq!(ToolSource::Agent.group(), ToolGroup::Scripts);
+        assert_eq!(ToolSource::Global.group(), ToolGroup::Scripts);
     }
 
     /// All four sources in one inventory, which is the whole point of the

--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -582,10 +582,11 @@ impl Blueprint {
                     if !gate.require_modifications {
                         continue;
                     }
-                    let can_modify = stage.available_tools.iter().any(|t| {
-                        MODIFYING_TOOLS.contains(&t.as_str())
-                            || gate.tools.iter().any(|extra| extra == t)
-                    });
+                    let can_modify = stage.grants_all_builtins()
+                        || stage.available_tools.iter().any(|t| {
+                            MODIFYING_TOOLS.contains(&t.as_str())
+                                || gate.tools.iter().any(|extra| extra == t)
+                        });
                     if !can_modify {
                         return Err(ValidationError::Transition {
                             from: stage.name.clone(),
@@ -713,6 +714,8 @@ mod stage;
 pub use stage::*;
 mod transition;
 pub use transition::*;
+mod tool_groups;
+pub use tool_groups::*;
 
 #[cfg(test)]
 mod tests {
@@ -1317,6 +1320,11 @@ criteria = { kind = "pinned", max_tokens = 10, seed = "criteria" }"#,
         assert!(err.to_string().contains("no file-modifying tool"));
         // A built-in write tool satisfies it...
         assert!(gated(&["read_file", "edit_file"], &[]).validate().is_ok());
+        // ...so does a group that carries one, with neither name written...
+        assert!(gated(&["@builtin"], &[]).validate().is_ok());
+        assert!(gated(&["@all"], &[]).validate().is_ok());
+        // ...but not a group that carries none.
+        assert!(gated(&["@scripts"], &[]).validate().is_err());
         // ...as does one the gate itself declares (MCP / script toolchains).
         assert!(
             gated(&["read_file", "patch_file"], &["patch_file"])
@@ -1652,6 +1660,51 @@ criteria = { kind = "pinned", max_tokens = 10, seed = "criteria" }"#,
         let bp = Blueprint::new("t".into(), "".into(), vec![stage], make_layout());
 
         bp.validate().expect("the tool is on offer");
+    }
+
+    /// With a group in the list the membership question belongs to the
+    /// install, so validation takes the author's word and the lint checks.
+    #[test]
+    fn validate_accepts_a_required_tool_a_group_could_cover() {
+        let mut stage = Stage::new("plan".to_string(), make_model());
+        stage.available_tools = vec!["@builtin".to_string()];
+        stage.required_tools = vec!["ask_user_text".to_string()];
+        let bp = Blueprint::new("t".into(), "".into(), vec![stage], make_layout());
+
+        bp.validate().expect("the group may cover it");
+    }
+
+    #[test]
+    fn validate_rejects_a_group_shaped_entry_that_names_no_group() {
+        let mut stage = Stage::new("plan".to_string(), make_model());
+        stage.available_tools = vec!["read_file".to_string(), "@builtins".to_string()];
+        let bp = Blueprint::new("t".into(), "".into(), vec![stage], make_layout());
+
+        let err = bp.validate().expect_err("not a group");
+        let text = format!("{err:?}");
+        assert!(text.contains("@builtins"), "names the entry: {text}");
+        assert!(text.contains("@builtin,"), "lists the groups: {text}");
+    }
+
+    #[test]
+    fn stage_reports_its_groups_and_named_tools_separately() {
+        let mut stage = Stage::new("plan".to_string(), make_model());
+        stage.available_tools = vec![
+            "read_file".to_string(),
+            "@scripts".to_string(),
+            "github__create_issue".to_string(),
+        ];
+        assert_eq!(stage.tool_groups(), vec![ToolGroup::Scripts]);
+        assert!(stage.grants_group(ToolGroup::Scripts));
+        assert!(!stage.grants_group(ToolGroup::Mcp));
+        assert!(!stage.grants_all_builtins());
+        let named: Vec<&String> = stage.named_tools().collect();
+        assert_eq!(named, vec!["read_file", "github__create_issue"]);
+
+        stage.available_tools = vec!["@all".to_string()];
+        assert!(stage.grants_all_builtins());
+        assert!(stage.grants_group(ToolGroup::Mcp));
+        assert_eq!(stage.named_tools().count(), 0);
     }
 
     /// A stage required to produce an output, without the tool that produces

--- a/crates/leviath-core/src/blueprint/stage.rs
+++ b/crates/leviath-core/src/blueprint/stage.rs
@@ -475,7 +475,12 @@ pub struct Stage {
     /// Model to use for this stage
     pub model: ModelConfig,
 
-    /// Which tools are available in this stage
+    /// Which tools are available in this stage.
+    ///
+    /// Tool names, exact-match and alias-aware, plus any number of group
+    /// tokens (`@all`, `@builtin`, `@subagent`, `@scripts`, `@mcp`) that each
+    /// stand for a whole source and resolve at spawn against what the install
+    /// has then. See [`ToolGroup`](super::ToolGroup).
     pub available_tools: Vec<String>,
 
     /// Human-in-the-loop tools (`ask_user_*`, `present_for_review`,
@@ -491,28 +496,32 @@ pub struct Stage {
     /// Entries must also appear in `available_tools` - listing a tool the stage
     /// can't call in the first place is a validation error, not a silent no-op.
     /// Matched verbatim against `available_tools` (this crate has no alias
-    /// table), so write the name the same way in both.
+    /// table), so write the name the same way in both. A stage that grants a
+    /// group (`@builtin`, `@all`, ...) may require any tool the group could
+    /// cover; which tools those are is only known at spawn, so this crate
+    /// takes the author's word for it and the lint checks the name.
     #[serde(default)]
     pub required_tools: Vec<String>,
 
     /// MCP servers whose whole tool set this stage may use.
     ///
-    /// `available_tools` is an exact-match list, which makes a server's tools
-    /// the author's problem to enumerate - and a server's tool list is not the
-    /// author's to know. It is whatever that server advertises today. A tool
-    /// added to the server later is simply never offered, with nothing said,
-    /// so the stage quietly cannot do a thing its author believed it could.
+    /// A server's tool list is not the author's to know. It is whatever that
+    /// server advertises today; a tool added to the server later is simply
+    /// never offered, with nothing said, so a stage that enumerated the tools
+    /// quietly cannot do a thing its author believed it could.
     ///
     /// Naming the server instead defers the question to spawn, when the answer
     /// is known. Resolved against what the server actually advertises then,
     /// and merged with whatever `available_tools` names, so the two can be
     /// mixed freely.
     ///
-    /// Kept separate from `available_tools` rather than spelled as a wildcard
-    /// in it, for two reasons. That field's contract is exact-match and every
-    /// consumer reads it that way; and the advertised name of an MCP tool does
-    /// not reliably carry its server, so there is no prefix a wildcard could
-    /// match on (see `unique_advertised_name` in `leviath-mcp`).
+    /// This is the per-server form. `@mcp` in `available_tools` is the
+    /// every-server form; a connector grant is the one to reach for when a
+    /// stage should see one server's tools and not another's. Kept as a
+    /// separate field rather than a `github__*` pattern because the advertised
+    /// name of an MCP tool does not reliably carry its server (a server named
+    /// `my.tools` sanitizes to `my_tools`, and a collision appends `_2`), so
+    /// matching the string is a guess where naming the server is a fact.
     #[serde(default)]
     pub available_connectors: Vec<String>,
 
@@ -723,6 +732,33 @@ impl Stage {
         self
     }
 
+    /// The groups this stage's `available_tools` names, in list order.
+    pub fn tool_groups(&self) -> Vec<ToolGroup> {
+        super::groups_in(&self.available_tools)
+    }
+
+    /// Whether `available_tools` grants `group` outright, or through `@all`.
+    pub fn grants_group(&self, group: ToolGroup) -> bool {
+        self.tool_groups().iter().any(|g| g.covers(group))
+    }
+
+    /// Whether every built-in tool is granted, by `@builtin` or `@all`.
+    ///
+    /// The question every reader of `available_tools` that looks for one
+    /// particular built-in (`context_write`, `edit_file`, `shell`) has to
+    /// ask first, because with a group in the list the name is not there and
+    /// the tool is.
+    pub fn grants_all_builtins(&self) -> bool {
+        self.grants_group(ToolGroup::Builtin)
+    }
+
+    /// The entries of `available_tools` that name a tool rather than a group.
+    pub fn named_tools(&self) -> impl Iterator<Item = &String> {
+        self.available_tools
+            .iter()
+            .filter(|t| !super::is_tool_group_token(t))
+    }
+
     /// Validate that this stage is well-formed.
     pub(super) fn validate(&self) -> std::result::Result<(), ValidationError> {
         if self.name.is_empty() {
@@ -732,12 +768,36 @@ impl Stage {
             });
         }
 
+        // A group-shaped entry that names no group (`@builtins`, `@ALL`) can
+        // match nothing, ever - and unlike a misspelled tool name, which the
+        // lint reports against the install's inventory, this one is wrong on
+        // the manifest's own terms.
+        if let Some(entry) = self
+            .available_tools
+            .iter()
+            .find(|t| super::unknown_group(t))
+        {
+            return Err(ValidationError::Stage {
+                stage: self.name.clone(),
+                message: format!(
+                    "available_tools entry '{entry}' looks like a tool group but names none; \
+                     the groups are {}",
+                    super::group_tokens_list()
+                ),
+            });
+        }
+
         // A `required_tools` entry the stage can't call is dead text: it looks
         // like it keeps a tool through an unattended run, and keeps nothing.
         // Rejected rather than ignored so the typo surfaces at `lev validate`
         // instead of at 3am in a `--yolo` run.
+        //
+        // A group grant makes the membership question unanswerable here (which
+        // tools `@builtin` covers is the install's to say), so with one present
+        // the name is only checked by the lint, which can see the inventory.
+        let grants_a_group = !self.tool_groups().is_empty();
         for tool in &self.required_tools {
-            if !self.available_tools.contains(tool) {
+            if !grants_a_group && !self.available_tools.contains(tool) {
                 return Err(ValidationError::Stage {
                     stage: self.name.clone(),
                     message: format!(

--- a/crates/leviath-core/src/blueprint/tool_groups.rs
+++ b/crates/leviath-core/src/blueprint/tool_groups.rs
@@ -1,0 +1,204 @@
+//! Tool groups: one `available_tools` entry that stands for a whole source.
+//!
+//! `available_tools` is an exact-match list, and for a stage that wants a few
+//! named tools that is the right shape. For a stage that wants "everything the
+//! binary ships, plus the two MCP tools I care about" it means copying the
+//! built-in list into the manifest and keeping it current by hand, and a tool
+//! added to Leviath later is simply never offered.
+//!
+//! A group token names a source instead of its members. It is resolved at
+//! spawn against what the install actually has then, the same way a connector
+//! grant is resolved against what its server advertises, and merged with the
+//! names beside it. So the four shapes a stage tends to want each have a
+//! spelling:
+//!
+//! | wants | writes |
+//! |---|---|
+//! | a hand-picked few | `["read_file", "shell"]` |
+//! | every built-in, plus chosen scripts and MCP tools | `["@builtin", "summarize", "github__create_issue"]` |
+//! | every built-in and every script, plus chosen MCP tools | `["@builtin", "@scripts", "github__create_issue"]` |
+//! | everything the install has | `["@all"]` |
+//!
+//! A group grants *visibility* only. `tool_permissions`, the taint gate and the
+//! approval prompts apply to a tool reached through a group exactly as they do
+//! to one named by hand, so `@all` on a stage with `shell = "ask"` still asks.
+//!
+//! The stage-control tools `submit_output` and `fan_out` belong to no group:
+//! the stage mode grants them, or the manifest names them. A group that quietly
+//! handed every stage a way to end the run would be a surprise, not a
+//! convenience.
+
+use std::fmt;
+
+/// The character every group token starts with. A tool name never contains
+/// it (built-ins, script tools and sanitized MCP names are all
+/// `[A-Za-z0-9_-]`), so a token cannot be mistaken for a tool and a tool
+/// cannot be mistaken for a token.
+pub const TOOL_GROUP_PREFIX: char = '@';
+
+/// A source of tools that one `available_tools` entry can grant whole.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ToolGroup {
+    /// Every tool the install has, across every other group.
+    All,
+    /// The tools compiled into this build of Leviath.
+    Builtin,
+    /// The sub-agent tools (`spawn_agent` and its siblings).
+    Subagent,
+    /// Every Rhai script tool: the agent's own `tools/` and the global
+    /// directory, plus, for a `dynamic_tools` agent, whatever it installs
+    /// mid-run.
+    Scripts,
+    /// Every tool every connected MCP server advertises.
+    Mcp,
+}
+
+impl ToolGroup {
+    /// Every group, in the order a picker should list them.
+    pub const ALL: &'static [ToolGroup] = &[
+        ToolGroup::All,
+        ToolGroup::Builtin,
+        ToolGroup::Subagent,
+        ToolGroup::Scripts,
+        ToolGroup::Mcp,
+    ];
+
+    /// The token a manifest writes for this group.
+    pub fn token(self) -> &'static str {
+        match self {
+            ToolGroup::All => "@all",
+            ToolGroup::Builtin => "@builtin",
+            ToolGroup::Subagent => "@subagent",
+            ToolGroup::Scripts => "@scripts",
+            ToolGroup::Mcp => "@mcp",
+        }
+    }
+
+    /// What the group covers, in one line a picker or an error can show.
+    pub fn describe(self) -> &'static str {
+        match self {
+            ToolGroup::All => "every tool this install has: built in, sub-agent, scripts, and MCP",
+            ToolGroup::Builtin => "every tool compiled into Leviath",
+            ToolGroup::Subagent => "the sub-agent tools: spawn, check, wait, send, kill",
+            ToolGroup::Scripts => "every Rhai script tool, the agent's own and the global ones",
+            ToolGroup::Mcp => "every tool every connected MCP server advertises",
+        }
+    }
+
+    /// The group a manifest entry names, or `None` for an ordinary tool name.
+    ///
+    /// An entry that starts with the prefix but names no group is *also*
+    /// `None` here; [`unknown_group`] is the question to ask about those.
+    pub fn parse(entry: &str) -> Option<ToolGroup> {
+        ToolGroup::ALL.iter().copied().find(|g| g.token() == entry)
+    }
+
+    /// Whether a tool from `source` is covered by this group.
+    pub fn covers(self, source: ToolGroup) -> bool {
+        self == ToolGroup::All || self == source
+    }
+}
+
+impl fmt::Display for ToolGroup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.token())
+    }
+}
+
+/// Whether `entry` is spelled like a group token, whether or not it names one.
+pub fn is_tool_group_token(entry: &str) -> bool {
+    entry.starts_with(TOOL_GROUP_PREFIX)
+}
+
+/// An entry spelled like a group that names no group: `@builtins`, `@ALL`,
+/// `@`. Such an entry can never match a tool either, so it is a typo by
+/// construction, and the one place the exact-match list gets to say so.
+pub fn unknown_group(entry: &str) -> bool {
+    is_tool_group_token(entry) && ToolGroup::parse(entry).is_none()
+}
+
+/// The groups a grant list names, in list order, de-duplicated.
+pub fn groups_in(entries: &[String]) -> Vec<ToolGroup> {
+    let mut groups = Vec::new();
+    for entry in entries {
+        if let Some(group) = ToolGroup::parse(entry)
+            && !groups.contains(&group)
+        {
+            groups.push(group);
+        }
+    }
+    groups
+}
+
+/// The comma-separated list of every group token, for an error message.
+pub fn group_tokens_list() -> String {
+    ToolGroup::ALL
+        .iter()
+        .map(|g| g.token())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_token_round_trips_through_parse() {
+        for group in ToolGroup::ALL {
+            assert_eq!(ToolGroup::parse(group.token()), Some(*group));
+            assert!(group.token().starts_with(TOOL_GROUP_PREFIX));
+            assert!(!group.describe().is_empty());
+            assert_eq!(group.to_string(), group.token());
+        }
+    }
+
+    #[test]
+    fn a_tool_name_is_not_a_group() {
+        assert_eq!(ToolGroup::parse("read_file"), None);
+        assert_eq!(ToolGroup::parse("github__create_issue"), None);
+        assert!(!is_tool_group_token("read_file"));
+        assert!(!unknown_group("read_file"));
+    }
+
+    #[test]
+    fn a_misspelled_group_is_unknown_not_a_tool() {
+        for entry in ["@builtins", "@ALL", "@", "@mcp "] {
+            assert_eq!(ToolGroup::parse(entry), None, "{entry}");
+            assert!(is_tool_group_token(entry), "{entry}");
+            assert!(unknown_group(entry), "{entry}");
+        }
+        assert!(!unknown_group("@all"));
+    }
+
+    #[test]
+    fn all_covers_every_source_and_a_source_covers_itself() {
+        for source in ToolGroup::ALL {
+            assert!(ToolGroup::All.covers(*source));
+            assert!(source.covers(*source));
+        }
+        assert!(!ToolGroup::Builtin.covers(ToolGroup::Scripts));
+        assert!(!ToolGroup::Mcp.covers(ToolGroup::Builtin));
+    }
+
+    #[test]
+    fn groups_in_keeps_list_order_and_drops_repeats() {
+        let entries: Vec<String> = ["@scripts", "read_file", "@builtin", "@scripts", "@nope"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            groups_in(&entries),
+            vec![ToolGroup::Scripts, ToolGroup::Builtin]
+        );
+        assert!(groups_in(&[]).is_empty());
+    }
+
+    #[test]
+    fn the_token_list_names_every_group() {
+        let list = group_tokens_list();
+        for group in ToolGroup::ALL {
+            assert!(list.contains(group.token()), "{list}");
+        }
+    }
+}

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -169,6 +169,9 @@ pub struct FinalOutput(pub leviath_core::output::FinalOutput);
 ///
 /// [`MODIFYING_TOOLS`]: leviath_core::blueprint::MODIFYING_TOOLS
 fn stage_can_modify(stage: &leviath_core::Stage) -> bool {
+    if stage.grants_all_builtins() {
+        return true;
+    }
     stage.available_tools.iter().any(|t| {
         let canonical = leviath_tools::canonical_tool_name(t);
         leviath_core::blueprint::MODIFYING_TOOLS.contains(&canonical)
@@ -578,6 +581,9 @@ mod tests {
         // leaves no record, so silence from it stays suspicious rather than
         // excused. The alias resolves, so `bash` is judged as `shell`.
         assert!(no_output_tools(vec![stage_with(&["bash"], None)]));
+        // A built-in group carries `write_file` and `edit_file` unnamed.
+        assert!(!no_output_tools(vec![stage_with(&["@builtin"], None)]));
+        assert!(no_output_tools(vec![stage_with(&["@scripts"], None)]));
         // A built-in modifying tool, under either name.
         assert!(!no_output_tools(vec![stage_with(&["write_file"], None)]));
         assert!(!no_output_tools(vec![stage_with(&["edit_file"], None)]));

--- a/crates/leviath-runtime/src/pipeline/gate_check.rs
+++ b/crates/leviath-runtime/src/pipeline/gate_check.rs
@@ -141,14 +141,15 @@ pub(crate) fn gate_blocks(
     if !gate.require_modifications {
         return GateDecision::Pass;
     }
-    let can_modify = stage.available_tools.iter().any(|t| {
-        let canonical = leviath_tools::canonical_tool_name(t);
-        leviath_core::blueprint::MODIFYING_TOOLS.contains(&canonical)
-            || gate
-                .tools
-                .iter()
-                .any(|extra| leviath_tools::canonical_tool_name(extra) == canonical)
-    });
+    let can_modify = stage.grants_all_builtins()
+        || stage.available_tools.iter().any(|t| {
+            let canonical = leviath_tools::canonical_tool_name(t);
+            leviath_core::blueprint::MODIFYING_TOOLS.contains(&canonical)
+                || gate
+                    .tools
+                    .iter()
+                    .any(|extra| leviath_tools::canonical_tool_name(extra) == canonical)
+        });
     if !can_modify {
         return GateDecision::Pass;
     }

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -140,6 +140,7 @@ mod resolve;
 pub use resolve::{
     ModelDefaults, ToolCatalog, ToolOwners, bare_default_model, expand_connector_grants,
     filter_tools_for_stage, model_key, providers_tried, resolve_stage_model, resolve_stages,
+    tool_source,
 };
 mod stall;
 pub use stall::{DEFAULT_STALL_TIMEOUT_SECS, PausedForSetup, StallTimeout};

--- a/crates/leviath-runtime/src/pipeline/requirements.rs
+++ b/crates/leviath-runtime/src/pipeline/requirements.rs
@@ -103,10 +103,11 @@ pub(crate) fn unmet_required_regions(
     stage: &leviath_core::Stage,
     window: &ContextWindow,
 ) -> Vec<(String, Option<String>)> {
-    let can_write = stage
-        .available_tools
-        .iter()
-        .any(|t| t == "context_write" || t == "context_append");
+    let can_write = stage.grants_all_builtins()
+        || stage
+            .available_tools
+            .iter()
+            .any(|t| t == "context_write" || t == "context_append");
     if !can_write {
         return Vec::new();
     }

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -8,7 +8,7 @@
 //! arrives as a plain [`ModelDefaults`] value.
 
 use leviath_core::Blueprint;
-use leviath_core::blueprint::{ModelConfig, ModelEntry};
+use leviath_core::blueprint::{ModelConfig, ModelEntry, ToolGroup};
 
 use super::ResolvedStage;
 use crate::providers::ProviderRegistry;
@@ -439,12 +439,32 @@ pub fn bare_default_model<'a>(provider: &str, model: &'a str) -> &'a str {
 ///
 /// Built where the servers are registered, because that is the only place the
 /// mapping exists. A [`Tool`] carries a name, a description and a schema, and
-/// the advertised name does not reliably contain the server: `leviath-mcp`
-/// prefers the bare tool name and only prefixes with the server on a collision,
-/// so `github`'s `create_issue` is usually advertised as `create_issue`. There
-/// is no string pattern that answers "does this tool belong to github", which
-/// is why a grant names the server and this table answers for it.
+/// although `leviath-mcp` now always advertises `<server>__<tool>`, the
+/// server half of that name is a sanitized, collision-suffixed spelling
+/// (`my.tools` becomes `my_tools`, a clash appends `_2`), so there is no
+/// string pattern that reliably answers "does this tool belong to github".
+/// A grant names the server and this table answers for it. It is also how
+/// the filter tells an MCP def from a script def, which nothing on the
+/// [`Tool`] itself records.
 pub type ToolOwners = std::collections::HashMap<String, String>;
+
+/// Where a run-time tool def came from, which is what a group grant selects on.
+///
+/// Decided by name, because a [`Tool`] carries no provenance: the built-in and
+/// sub-agent names are fixed lists, an MCP name is in `owners`, and script
+/// discovery drops any script whose name one of those already owns, so what
+/// is left can only be a script.
+pub fn tool_source(name: &str, owners: &ToolOwners) -> ToolGroup {
+    if leviath_tools::is_builtin_tool(name) {
+        ToolGroup::Builtin
+    } else if leviath_tools::is_subagent_tool(name) {
+        ToolGroup::Subagent
+    } else if owners.contains_key(name) {
+        ToolGroup::Mcp
+    } else {
+        ToolGroup::Scripts
+    }
+}
 
 /// Every tool a run could offer, and which MCP server each came from.
 ///
@@ -502,19 +522,31 @@ pub fn expand_connector_grants(
     granted
 }
 
-/// Filter `all` tool defs down to those a stage's `available_tools` names
-/// (alias-resolved). Shared by spawn-time stage resolution and the mid-run
+/// Filter the catalog's tool defs down to those a stage's `available_tools`
+/// grants: the names it lists (alias-resolved), plus every def whose source a
+/// listed group covers. Shared by spawn-time stage resolution and the mid-run
 /// tool-service refresh so both apply Layer-1 identically.
 ///
 /// Connector grants are expanded into `available` by
-/// [`expand_connector_grants`] before this sees it, so both callers apply one
-/// rule and this stays an exact-match filter.
-pub(crate) fn filter_tools_by_available(all: &[Tool], available: &[String]) -> Vec<Tool> {
+/// [`expand_connector_grants`] before this sees it. Group grants are *not*
+/// pre-expanded, on purpose: a `dynamic_tools` agent that grants `@scripts`
+/// installs a tool mid-run and expects the next refresh to offer it, which
+/// only works if the group is still a group when the refresh filters.
+///
+/// The stage-control tools (`submit_output`, `fan_out`) are never granted by
+/// a group; the stage mode writes them into the list by name.
+pub(crate) fn filter_tools_by_available(
+    catalog: ToolCatalog<'_>,
+    available: &[String],
+) -> Vec<Tool> {
     if available.is_empty() {
         return Vec::new();
     }
+    let all = catalog.defs;
+    let groups = leviath_core::blueprint::groups_in(available);
     let wanted: std::collections::HashSet<&str> = available
         .iter()
+        .filter(|n| !leviath_core::blueprint::is_tool_group_token(n))
         .map(|n| leviath_tools::canonical_tool_name(n))
         .collect();
     // Names that match nothing get one more chance, as a server-qualified MCP
@@ -527,8 +559,19 @@ pub(crate) fn filter_tools_by_available(all: &[Tool], available: &[String]) -> V
         .filter(|n| !all.iter().any(|t| t.name == *n))
         .collect();
     let recovered = recover_unqualified(all, &unmatched);
+    let grouped = |name: &str| {
+        !groups.is_empty()
+            && !leviath_tools::STAGE_CONTROL_TOOLS.contains(&name)
+            && groups
+                .iter()
+                .any(|g| g.covers(tool_source(name, catalog.owners)))
+    };
     all.iter()
-        .filter(|t| wanted.contains(t.name.as_str()) || recovered.contains(t.name.as_str()))
+        .filter(|t| {
+            wanted.contains(t.name.as_str())
+                || recovered.contains(t.name.as_str())
+                || grouped(&t.name)
+        })
         .cloned()
         .collect()
 }
@@ -589,12 +632,12 @@ fn recover_unqualified<'a>(
 /// that arrives anyway (a model repeating itself from context) meets the ordinary
 /// unoffered-tool refusal.
 pub fn filter_tools_for_stage(
-    all: &[Tool],
+    catalog: ToolCatalog<'_>,
     available: &[String],
     required: &[String],
     unattended: bool,
 ) -> Vec<Tool> {
-    let mut tools = filter_tools_by_available(all, available);
+    let mut tools = filter_tools_by_available(catalog, available);
     if unattended {
         tools.retain(|t| {
             !crate::dynamic_interaction::BLOCKING_INTERACTION_TOOLS.contains(&t.name.as_str())
@@ -745,16 +788,17 @@ pub fn resolve_stages(
                 });
             }
             // Empty `available_tools` exposes no tools; otherwise filter the full
-            // set by name (alias-resolved). A name matching nothing (a typo, or an
-            // MCP tool whose server isn't installed) is simply omitted. An
-            // unattended run also loses the tools that block on a person.
+            // set by name (alias-resolved) and by group. A name matching nothing
+            // (a typo, or an MCP tool whose server isn't installed) is simply
+            // omitted. An unattended run also loses the tools that block on a
+            // person.
             let granted = expand_connector_grants(
                 &stage.available_tools,
                 &stage.available_connectors,
                 catalog.owners,
             );
             let mut tools =
-                filter_tools_for_stage(catalog.defs, &granted, &stage.required_tools, unattended);
+                filter_tools_for_stage(catalog, &granted, &stage.required_tools, unattended);
             let output = leviath_core::resolve_output_spec(
                 blueprint.output.as_ref(),
                 stage.output.as_ref(),
@@ -1560,7 +1604,7 @@ mod tests {
             "ask_user_text".to_string(),
             "ask_user_choice".to_string(),
         ];
-        let tools = filter_tools_for_stage(&ask_and_read_defs(), &available, &[], false);
+        let tools = filter_tools_for_stage(catalog(&ask_and_read_defs()), &available, &[], false);
         assert_eq!(
             names(&tools),
             vec!["read_file", "ask_user_text", "ask_user_choice"]
@@ -1918,7 +1962,7 @@ mod tests {
             "ask_user_text".to_string(),
             "ask_user_choice".to_string(),
         ];
-        let tools = filter_tools_for_stage(&ask_and_read_defs(), &available, &[], true);
+        let tools = filter_tools_for_stage(catalog(&ask_and_read_defs()), &available, &[], true);
         assert_eq!(names(&tools), vec!["read_file"]);
     }
 
@@ -1932,7 +1976,8 @@ mod tests {
             "ask_user_choice".to_string(),
         ];
         let required = vec!["ask_user_text".to_string()];
-        let tools = filter_tools_for_stage(&ask_and_read_defs(), &available, &required, true);
+        let tools =
+            filter_tools_for_stage(catalog(&ask_and_read_defs()), &available, &required, true);
         assert_eq!(names(&tools), vec!["read_file", "ask_user_text"]);
     }
 
@@ -1943,7 +1988,8 @@ mod tests {
         // this is the belt to that pair of braces.)
         let available = vec!["read_file".to_string()];
         let required = vec!["ask_user_text".to_string()];
-        let tools = filter_tools_for_stage(&ask_and_read_defs(), &available, &required, true);
+        let tools =
+            filter_tools_for_stage(catalog(&ask_and_read_defs()), &available, &required, true);
         assert_eq!(names(&tools), vec!["read_file"]);
     }
 
@@ -1992,7 +2038,7 @@ mod tests {
             parameters: serde_json::Value::Null,
         }];
         let available = vec!["bash".to_string()];
-        let tools = filter_tools_for_stage(&defs, &available, &[], true);
+        let tools = filter_tools_for_stage(catalog(&defs), &available, &[], true);
         assert_eq!(names(&tools), vec!["shell"]);
     }
 
@@ -2415,7 +2461,7 @@ mod tests {
     #[test]
     fn a_grant_naming_an_mcp_tool_without_its_server_still_resolves() {
         let defs = defs_named(&["github__create_issue", "read_file"]);
-        let tools = filter_tools_by_available(&defs, &["create_issue".to_string()]);
+        let tools = filter_tools_by_available(catalog(&defs), &["create_issue".to_string()]);
         assert_eq!(offered(&tools), vec!["github__create_issue"]);
     }
 
@@ -2426,7 +2472,7 @@ mod tests {
     #[test]
     fn an_ambiguous_unqualified_grant_resolves_to_nothing() {
         let defs = defs_named(&["github__create_issue", "gitlab__create_issue"]);
-        let tools = filter_tools_by_available(&defs, &["create_issue".to_string()]);
+        let tools = filter_tools_by_available(catalog(&defs), &["create_issue".to_string()]);
         assert_eq!(offered(&tools), Vec::<&str>::new());
     }
 
@@ -2437,7 +2483,7 @@ mod tests {
     #[test]
     fn a_builtin_is_never_captured_by_a_server_offering_the_same_name() {
         let defs = defs_named(&["read_file", "scratch__read_file"]);
-        let tools = filter_tools_by_available(&defs, &["read_file".to_string()]);
+        let tools = filter_tools_by_available(catalog(&defs), &["read_file".to_string()]);
         assert_eq!(
             offered(&tools),
             vec!["read_file"],
@@ -2451,7 +2497,7 @@ mod tests {
     #[test]
     fn an_already_qualified_grant_is_untouched() {
         let defs = defs_named(&["github__search", "other__github__search"]);
-        let tools = filter_tools_by_available(&defs, &["github__search".to_string()]);
+        let tools = filter_tools_by_available(catalog(&defs), &["github__search".to_string()]);
         assert_eq!(offered(&tools), vec!["github__search"]);
     }
 
@@ -2460,8 +2506,148 @@ mod tests {
     #[test]
     fn a_name_matching_nothing_is_still_omitted() {
         let defs = defs_named(&["read_file"]);
-        let tools = filter_tools_by_available(&defs, &["nonsense".to_string()]);
+        let tools = filter_tools_by_available(catalog(&defs), &["nonsense".to_string()]);
         assert!(offered(&tools).is_empty());
+    }
+
+    // ── group grants ────────────────────────────────────────────────────────
+
+    /// One of everything a run can carry: a built-in, a stage-control
+    /// built-in, a sub-agent tool, an MCP tool and a script.
+    fn mixed_defs() -> Vec<Tool> {
+        defs_named(&[
+            "read_file",
+            "shell",
+            leviath_tools::SUBMIT_OUTPUT_TOOL,
+            leviath_tools::FAN_OUT_TOOL,
+            "spawn_agent",
+            "github__create_issue",
+            "summarize",
+        ])
+    }
+
+    fn mixed_owners() -> ToolOwners {
+        ToolOwners::from([("github__create_issue".to_string(), "github".to_string())])
+    }
+
+    fn strings(names: &[&str]) -> Vec<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    #[test]
+    fn tool_source_sorts_a_def_by_name() {
+        let owners = mixed_owners();
+        assert_eq!(tool_source("read_file", &owners), ToolGroup::Builtin);
+        assert_eq!(tool_source("spawn_agent", &owners), ToolGroup::Subagent);
+        assert_eq!(tool_source("github__create_issue", &owners), ToolGroup::Mcp);
+        assert_eq!(tool_source("summarize", &owners), ToolGroup::Scripts);
+    }
+
+    #[test]
+    fn each_group_grants_its_own_source_and_nothing_else() {
+        let defs = mixed_defs();
+        let owners = mixed_owners();
+        let cat = ToolCatalog {
+            defs: &defs,
+            owners: &owners,
+        };
+        let by = |grant: &str| offered_owned(filter_tools_by_available(cat, &strings(&[grant])));
+        assert_eq!(by("@builtin"), vec!["read_file", "shell"]);
+        assert_eq!(by("@subagent"), vec!["spawn_agent"]);
+        assert_eq!(by("@mcp"), vec!["github__create_issue"]);
+        assert_eq!(by("@scripts"), vec!["summarize"]);
+    }
+
+    /// `@all` is every source at once, and still not the stage-control pair:
+    /// the mode grants those, or the manifest names them.
+    #[test]
+    fn all_grants_every_source_but_never_the_stage_control_tools() {
+        let defs = mixed_defs();
+        let owners = mixed_owners();
+        let cat = ToolCatalog {
+            defs: &defs,
+            owners: &owners,
+        };
+        assert_eq!(
+            offered_owned(filter_tools_by_available(cat, &strings(&["@all"]))),
+            vec![
+                "read_file",
+                "shell",
+                "spawn_agent",
+                "github__create_issue",
+                "summarize"
+            ]
+        );
+        // Named alongside the group, the stage-control tool is granted as
+        // ever: the group's exclusion is not a veto.
+        assert_eq!(
+            offered_owned(filter_tools_by_available(
+                cat,
+                &strings(&["@all", leviath_tools::SUBMIT_OUTPUT_TOOL])
+            )),
+            vec![
+                "read_file",
+                "shell",
+                leviath_tools::SUBMIT_OUTPUT_TOOL,
+                "spawn_agent",
+                "github__create_issue",
+                "summarize"
+            ]
+        );
+    }
+
+    /// The shapes the feature exists for: groups and names mix, and a name
+    /// that a group already covers is granted once.
+    #[test]
+    fn groups_and_names_mix_without_duplicates() {
+        let defs = mixed_defs();
+        let owners = mixed_owners();
+        let cat = ToolCatalog {
+            defs: &defs,
+            owners: &owners,
+        };
+        assert_eq!(
+            offered_owned(filter_tools_by_available(
+                cat,
+                &strings(&["@builtin", "summarize", "github__create_issue"])
+            )),
+            vec!["read_file", "shell", "github__create_issue", "summarize"]
+        );
+        assert_eq!(
+            offered_owned(filter_tools_by_available(
+                cat,
+                &strings(&["@builtin", "@scripts", "github__create_issue", "read_file"])
+            )),
+            vec!["read_file", "shell", "github__create_issue", "summarize"]
+        );
+    }
+
+    /// A group token is not a name: it never reaches the unqualified-MCP
+    /// recovery, so `@mcp` cannot be "resolved" to a tool ending in `__@mcp`.
+    #[test]
+    fn a_group_token_is_never_treated_as_a_tool_name() {
+        let defs = defs_named(&["weird__@mcp", "read_file"]);
+        let tools = filter_tools_by_available(catalog(&defs), &strings(&["@mcp"]));
+        assert_eq!(offered(&tools), Vec::<&str>::new());
+    }
+
+    /// The unattended cut applies to a grouped tool exactly as to a named one.
+    #[test]
+    fn an_unattended_run_still_drops_grouped_blocking_tools() {
+        let defs = ask_and_read_defs();
+        let tools = filter_tools_for_stage(catalog(&defs), &strings(&["@builtin"]), &[], true);
+        assert_eq!(offered(&tools), vec!["read_file"]);
+        let tools = filter_tools_for_stage(
+            catalog(&defs),
+            &strings(&["@builtin"]),
+            &strings(&["ask_user_text"]),
+            true,
+        );
+        assert_eq!(offered(&tools), vec!["read_file", "ask_user_text"]);
+    }
+
+    fn offered_owned(tools: Vec<Tool>) -> Vec<String> {
+        tools.into_iter().map(|t| t.name).collect()
     }
 
     // ── explicit-route-only providers ───────────────────────────────────────

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -9924,6 +9924,12 @@ fn unmet_required_regions_flags_empty_clears_when_filled_and_skips_without_tool(
         unmet_required_regions(&no_tool.0, &no_tool.0.stages[0], &window_with_plan(false))
             .is_empty()
     );
+    // A built-in group carries the writing tools without naming them.
+    let grouped = required_bp(&["@builtin"], None);
+    assert_eq!(
+        unmet_required_regions(&grouped.0, &grouped.0.stages[0], &window_with_plan(false)).len(),
+        1
+    );
     // A required region absent from the window entirely counts as unmet.
     let mut bare = ContextWindow::new(100_000);
     bare.add_region(Region::new(
@@ -10669,6 +10675,18 @@ fn gate_passes_a_stage_that_cannot_modify_anything() {
     assert!(
         block_message(gate_blocks(
             Some(&custom),
+            &stage,
+            &progress_with(0, 0, 0),
+            &conv_window()
+        ))
+        .is_some()
+    );
+    // ...or the stage grants the built-ins as a group, which carries the
+    // modifying tools without naming them.
+    stage.available_tools = vec!["@builtin".to_string()];
+    assert!(
+        block_message(gate_blocks(
+            Some(&g),
             &stage,
             &progress_with(0, 0, 0),
             &conv_window()

--- a/crates/leviath-tools/src/defs.rs
+++ b/crates/leviath-tools/src/defs.rs
@@ -19,6 +19,51 @@ pub fn is_subagent_tool(name: &str) -> bool {
     SUBAGENT_TOOLS.contains(&name)
 }
 
+/// Every canonical built-in tool name, before platform gating and without
+/// aliases. [`BuiltinTools::names`] is this list minus what the host cannot
+/// provide, plus the aliases; this is the one to ask "is this name a
+/// built-in at all", which is what a group grant (`@builtin`) needs to sort
+/// a run's tool defs by source.
+pub const BUILTIN_TOOL_NAMES: &[&str] = &[
+    "read_file",
+    "read_files",
+    "write_file",
+    "edit_file",
+    "list_dir",
+    "shell",
+    "present_for_review",
+    "ask_user_text",
+    "ask_user_choice",
+    "ask_user_confirm",
+    "edit_document",
+    "context_write",
+    "context_append",
+    "context_read",
+    "context_delete",
+    "context_list",
+    "todo_add",
+    "todo_done",
+    "todo_note",
+    "current_time",
+    "system_info",
+    "locale_info",
+    "environment_info",
+    "which_command",
+    "runtime_info",
+    "install_tool",
+    crate::SUBMIT_OUTPUT_TOOL,
+    crate::FAN_OUT_TOOL,
+];
+
+/// The built-ins a stage mode grants rather than a manifest: `submit_output`
+/// and `fan_out` end or fork the run, so no group hands them out.
+pub const STAGE_CONTROL_TOOLS: &[&str] = &[crate::SUBMIT_OUTPUT_TOOL, crate::FAN_OUT_TOOL];
+
+/// Whether `name` is a canonical built-in (not an alias, not a sub-agent tool).
+pub fn is_builtin_tool(name: &str) -> bool {
+    BUILTIN_TOOL_NAMES.contains(&name)
+}
+
 /// The `shell` tool's description, naming the shell this host actually resolved
 /// instead of listing every platform's and leaving the model to guess which one
 /// it got. Pure over the shell so both wordings are testable on any platform.
@@ -709,43 +754,14 @@ impl BuiltinTools {
     /// under an alias name as a built-in; the canonical names are what get
     /// advertised to the model.
     pub fn names(&self) -> Vec<String> {
-        let mut names: Vec<String> = [
-            "read_file",
-            "read_files",
-            "write_file",
-            "edit_file",
-            "list_dir",
-            "shell",
-            "present_for_review",
-            "ask_user_text",
-            "ask_user_choice",
-            "ask_user_confirm",
-            "edit_document",
-            "context_write",
-            "context_append",
-            "context_read",
-            "context_delete",
-            "context_list",
-            "todo_add",
-            "todo_done",
-            "todo_note",
-            "current_time",
-            "system_info",
-            "locale_info",
-            "environment_info",
-            "which_command",
-            "runtime_info",
-            "install_tool",
-            crate::SUBMIT_OUTPUT_TOOL,
-            crate::FAN_OUT_TOOL,
-        ]
-        .iter()
-        // Drop any canonical built-in the current platform can't provide, so a
-        // filtered-out tool (e.g. `shell` without `ProcessSpawn`) isn't even
-        // recognized as a built-in on dispatch.
-        .filter(|n| self.available(n))
-        .map(|s| s.to_string())
-        .collect();
+        let mut names: Vec<String> = BUILTIN_TOOL_NAMES
+            .iter()
+            // Drop any canonical built-in the current platform can't provide, so a
+            // filtered-out tool (e.g. `shell` without `ProcessSpawn`) isn't even
+            // recognized as a built-in on dispatch.
+            .filter(|n| self.available(n))
+            .map(|s| s.to_string())
+            .collect();
         // Include an alias only when its canonical target survived filtering
         // (so `bash` disappears together with `shell`).
         names.extend(

--- a/crates/leviath-tools/src/install.rs
+++ b/crates/leviath-tools/src/install.rs
@@ -80,9 +80,9 @@ impl InstalledTool {
             ));
         }
         out.push_str(
-            "\nEvery agent on this machine can call it from its next spawn. A stage that sets \
-             `available_global_tools = true` advertises it; a `dynamic_tools` agent already running \
-             sees it on its next turn.",
+            "\nEvery agent on this machine can call it from its next spawn. A stage whose \
+             `available_tools` names it or includes `@scripts` advertises it; a `dynamic_tools` \
+             agent already running sees it on its next turn.",
         );
         out
     }
@@ -401,7 +401,7 @@ mod tests {
         assert!(text.contains("Installed tool 'upper'"), "{text}");
         assert!(text.contains("text:string! (input to transform)"), "{text}");
         assert!(!text.contains("replaced"), "{text}");
-        assert!(text.contains("available_global_tools"), "{text}");
+        assert!(text.contains("@scripts"), "{text}");
     }
 
     /// The provenance line is the first line of the file, the annotation

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -23,7 +23,10 @@ mod install;
 mod platform;
 pub mod validate;
 pub use context::*;
-pub use defs::{SUBAGENT_TOOLS, is_subagent_tool, submit_output_description};
+pub use defs::{
+    BUILTIN_TOOL_NAMES, STAGE_CONTROL_TOOLS, SUBAGENT_TOOLS, is_builtin_tool, is_subagent_tool,
+    submit_output_description,
+};
 pub use install::{
     InstallProbes, InstalledTool, MAX_TOOL_SOURCE_BYTES, install_script_tool,
     install_script_tool_with,
@@ -189,6 +192,24 @@ mod tests {
             assert!(is_subagent_tool(name));
         }
         assert!(!is_subagent_tool("read_file"));
+    }
+
+    /// The static list is the catalog `tool_defs` ships, one name per def:
+    /// a built-in added to one and not the other would make `@builtin` miss it.
+    #[test]
+    fn builtin_name_list_matches_the_catalog() {
+        let tools = make_tools(&std::env::temp_dir());
+        let defs: Vec<String> = tools.tool_defs().into_iter().map(|d| d.name).collect();
+        for name in BUILTIN_TOOL_NAMES {
+            assert!(defs.contains(&name.to_string()), "{name} has no def");
+            assert!(is_builtin_tool(name));
+        }
+        assert_eq!(defs.len(), BUILTIN_TOOL_NAMES.len());
+        assert!(!is_builtin_tool("bash"), "an alias is not a canonical name");
+        assert!(!is_builtin_tool("spawn_agent"));
+        for name in STAGE_CONTROL_TOOLS {
+            assert!(is_builtin_tool(name));
+        }
     }
 
     // ── Tool definitions ──────────────────────────────────────────────────

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -148,11 +148,15 @@ without saying so. `lev validate` reports both. See
 
 ### Which tools a stage gets
 
-`available_tools` lists what the stage may call.
+`available_tools` lists what the stage may call, by name or by kind: `@builtin`, `@subagent`,
+`@scripts`, `@mcp` and `@all` each grant every tool of that kind, so `["@builtin", "@scripts"]`
+is every built-in and every Rhai tool with nothing to keep in step. See
+[tool groups](/docs/tools#tool-groups) for what each reaches and what none of them grant.
 
 `required_tools` is the exception to the unattended cut. A [`--yolo`](/docs/glossary) run drops
-every tool that waits on a person, and this is where a stage names the ones it wants kept anyway. Every entry must also
-appear in `available_tools`.
+every tool that waits on a person, and this is where a stage names the ones it wants kept anyway.
+Every entry must also appear in `available_tools`, by name or through a group that reaches it;
+`lev validate` checks the group case against the tools this install has.
 
 Naming a tool here also settles the `blocking-tool-in-autonomous-stage` lint for it, since listing
 it is how you say you meant it. See

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -219,7 +219,8 @@ that was looked for.
 | error | `unknown-tool` | A name in `available_tools` matches nothing. See below |
 | error | `unparseable-safe-command` | A `[safe_commands] shell` entry no call can ever match. See below |
 | error | `output-missing-submit-tool` | A stage must produce an output and has no way to submit one. See below |
-| error | `orphan-stage-permission` | A `[stages.X.tool_permissions]` key names a tool the stage never granted. It reads as a grant and is not one. |
+| error | `orphan-stage-permission` | A `[stages.X.tool_permissions]` key names a tool the stage never granted, by name or through a group. It reads as a grant and is not one. |
+| error | `required-tool-not-granted` | A `required_tools` entry that no name and no group in `available_tools` reaches, so the model never sees it. Only checked when a group is in play; without one the load itself refuses the manifest. |
 | error | `unserved-model` | A stage names a model the provider that would run it does not carry. See below |
 | warning | `stage-missing-model` | No `[stages.X.model]` block, so the stage runs on whatever your `default_provider` is. |
 | warning | `stage-missing-mode` | No `mode`, so the stage runs as `autonomous`. |
@@ -259,10 +260,12 @@ ever match it. Write a program, optionally with the subcommand that narrows it: 
 
 **`blocking-tool-in-autonomous-stage`** fires when an autonomous stage grants `ask_user_*`,
 `present_for_review` or `edit_document`. With nobody attached, the run parks there until it is
-killed. Set `allow_blocking_tools = true` on the stage to say you meant it.
+killed. Set `allow_blocking_tools = true` on the stage to say you meant it. A stage granting
+`@builtin` or `@all` reaches all of them at once and gets one warning naming the group.
 
 **`implicit-shell-policy`** matters because the default is `ask`. An unattended run waits on that
-prompt rather than being denied.
+prompt rather than being denied. The shell arrives with `@builtin` as surely as by name, so a group
+grant with no `shell` policy is reported too.
 
 **`unserved-model`** is the one model finding that fails the command, because it is the one that can
 be proved. The provider is configured here, it published the full list of what it carries, and the

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -156,11 +156,14 @@ through the same `tool_permissions`, the same taint gate, and the same approval 
 you named by hand.
 
 > [!NOTE]
-> There is no wildcard form of `available_tools`, and a connector grant is not sugar for one.
-> Names are server-qualified, so `github__*` would *usually* work - but not reliably enough to
-> build on: a server named `my.tools` sanitizes to `my_tools`, and a name collision appends `_2`,
-> so matching the string is a guess where the connector grant is a fact. `available_connectors`
-> asks Leviath which tools a server owns rather than inferring it from how they are spelled.
+> A connector grant is per server. To grant every connected server at once, put `@mcp` in
+> `available_tools` instead (see [tool groups](/docs/tools#tool-groups)); `@mcp` and
+> `available_connectors` compose, so `["@builtin", "@mcp"]` with no connector list is the
+> "all built-ins and every MCP tool" shape in one line. There is no pattern form such as
+> `github__*`: a server named `my.tools` sanitizes to `my_tools`, and a name collision appends
+> `_2`, so matching the string would be a guess where the connector grant is a fact.
+> `available_connectors` asks Leviath which tools a server owns rather than inferring it from how
+> they are spelled.
 
 ## OAuth, safely
 

--- a/docs/content/rhai-tools.md
+++ b/docs/content/rhai-tools.md
@@ -35,8 +35,8 @@ A tool declares itself with leading `// @` directives and reads its arguments fr
 object. The recognized directives:
 
 - `// @tool <name>` is required and names the tool. A stage sees it when its `available_tools`
-  lists that name, or when the stage sets `available_global_tools = true` and the script lives in
-  `~/.leviath/tools/`.
+  lists that name or includes `@scripts`, the [tool group](/docs/tools#tool-groups) that grants
+  every Rhai tool the install has.
 - `// @description <text>` is an optional one-liner shown to the model.
 - `// @param <name> <type> <required|optional> "<description>"` is repeatable. `<type>` is a JSON
   schema type: `string`, `integer`, `number`, `boolean`, `array`, `object`. A typo here produces a
@@ -154,8 +154,8 @@ decision the model should be making each time ages badly and is hard to notice f
 
 To use an installed tool in the same run, the agent must be a `dynamic_tools` agent, which picks
 the new tool up on its next turn. Any later run sees it at spawn, and a stage advertises it when its
-`available_tools` names it or it sets `available_global_tools = true`. See [Tools](/docs/tools) for
-how a stage's tool set is put together.
+`available_tools` names it or includes `@scripts`. See [Tools](/docs/tools) for how a stage's tool
+set is put together.
 
 ## Inspecting the inventory
 

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -353,6 +353,43 @@ edit_file = "allow"    # apply edits without prompting
 > `available_tools` to be offered at all, and its `tool_permissions` value then decides whether a
 > call is allowed, prompted, or refused.
 
+### Tool groups
+
+Listing twenty-eight built-ins by hand to say "everything" is a chore, and a list written that way
+goes stale the day a tool is added. An `available_tools` entry that starts with `@` names a whole
+kind of tool instead of one:
+
+| Token | Grants |
+|---|---|
+| `@builtin` | every tool compiled into Leviath (this page's catalog) |
+| `@subagent` | `spawn_agent`, `check_agent`, `wait_for_agent`, `send_to_agent`, `kill_agent` |
+| `@scripts` | every [Rhai tool](/docs/rhai-tools), the agent's own and the global ones |
+| `@mcp` | every tool every connected [MCP server](/docs/mcp) advertises |
+| `@all` | all of the above |
+
+Groups and names mix freely, so the four shapes people actually want are each one line:
+
+```toml
+available_tools = ["read_file", "edit_file", "shell"]          # a hand-picked set
+available_tools = ["@builtin", "summarize", "github__search"]  # every built-in, plus a few others by name
+available_tools = ["@builtin", "@scripts", "github__search"]   # every built-in and script, one MCP tool
+available_tools = ["@all"]                                     # everything this install has
+```
+
+A group is resolved when the stage runs, not when the blueprint is written: a script dropped into
+`~/.leviath/tools/` or a server added with `lev mcp add` is offered to a stage granting `@scripts`
+or `@mcp` without touching the manifest. Two things a group never grants: `submit_output` and
+`fan_out`, which decide what a stage *is* rather than what it can do. Name those, or use the mode
+that carries them.
+
+A group is a grant of visibility and nothing more. Every tool it reaches still goes through
+`tool_permissions`, the taint gate, and the approval prompts exactly as a tool you named would, and
+the `@` prefix can never collide with a real tool, since tool names are limited to `[A-Za-z0-9_-]`.
+`lev validate` knows the groups: an entry like `@builtins` is refused as naming no group, a
+`required_tools` entry no group reaches is an error, and an autonomous stage granting `@builtin`
+gets one `blocking-tool-in-autonomous-stage` warning for the group rather than five for its
+members.
+
 ## Default permissions
 
 With nothing configured, tools fall back to these:

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -293,7 +293,7 @@
         },
         "available_tools": {
           "type": "array",
-          "description": "The only tools the model is offered here. Anything absent is refused at dispatch.",
+          "description": "The only tools the model is offered here. Anything absent is refused at dispatch. An entry may be a tool name or a group token: `@builtin` (every compiled-in tool), `@subagent` (spawn, check, wait, send, kill), `@scripts` (every Rhai tool, the agent's own and the global ones), `@mcp` (every tool every connected server advertises) or `@all`. A group grants whatever exists at the time the stage runs, so a script or server installed later is offered without editing the manifest. Groups never grant submit_output or fan_out; name those, or use the mode that carries them.",
           "items": {
             "type": "string"
           }
@@ -304,7 +304,7 @@
           "items": {
             "type": "string"
           },
-          "$comment": "Kept separate from available_tools because that field is exact-match, and because an MCP tool's advertised name does not reliably carry its server - there is no prefix a wildcard could match."
+          "$comment": "The per-server form. `@mcp` in available_tools grants every connected server at once; this field is for granting one server and not another."
         },
         "require_output": {
           "type": "boolean",

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2198,7 +2198,7 @@
           "scripts"
         ],
         "summary": "Tools an agent on this machine can call",
-        "description": "Built-ins, sub-agent tools, the named agent's own `tools/*.rhai` and the global ones, each with a `source`. `skipped` carries the `.rhai` files that were found and could not be offered, with the reason. MCP tools are not included; `/api/mcp/servers/{name}` answers for those.",
+        "description": "Built-ins, sub-agent tools, the named agent's own `tools/*.rhai` and the global ones, each with a `source`. `groups` lists the tokens `available_tools` accepts in place of names (`@all`, `@builtin`, `@subagent`, `@scripts`, `@mcp`), each with a one-line description, so a picker can offer a whole kind at once. `skipped` carries the `.rhai` files that were found and could not be offered, with the reason. MCP tools are not included; `/api/mcp/servers/{name}` answers for those.",
         "parameters": [
           {
             "name": "agent",


### PR DESCRIPTION
## Summary

A stage's `available_tools` can now name a whole kind of tool at once. Five group tokens, all starting with `@` so they can never collide with a tool name:

| Token | Grants |
|---|---|
| `@all` | every tool the daemon has |
| `@builtin` | the tools compiled into Leviath |
| `@subagent` | the sub-agent tools (`spawn_agent`, ...) |
| `@scripts` | every Rhai tool, this agent's and the global ones |
| `@mcp` | every tool from every connected MCP server |

Groups mix freely with plain names, so the four shapes in the request all read naturally:

```toml
available_tools = ["read_file", "shell"]                              # hand-picked
available_tools = ["@builtin", "summarize"]                            # all built-ins plus one script
available_tools = ["@builtin", "@scripts", "github__create_issue"]     # all built-ins and scripts, one MCP tool
available_tools = ["@all"]
```

## Design decisions

- **Resolved at run time, not at parse time.** A group is kept as a token in the blueprint and matched against the daemon's catalog when the stage starts, so a script installed or an MCP server connected later is picked up on the next run without editing the blueprint.
- **Visibility only.** Permissions, blocking-tool handling under `--yolo`, and `required_tools` work exactly as before. No group ever grants `submit_output` or `fan_out`; those stay stage-controlled.
- **A typo is a parse error.** `@builtins` fails validation with the list of real groups rather than silently granting nothing.

## What changed

- **core**: `ToolGroup` in `leviath_core::blueprint` with parse/describe/covers; `Stage::tool_groups()`, `grants_group()`, `grants_all_builtins()`, `named_tools()`.
- **runtime**: `tool_source()` classifies a catalog entry by owner; `filter_tools_by_available` / `filter_tools_for_stage` honour groups. The daemon's tool service records MCP owners so the classification is exact.
- **lint**: knows which group each installed tool belongs to. New `required-tool-not-granted` error when a required tool is neither named nor covered by a granted group. `orphan-stage-permission` no longer fires when a group covers the tool. `blocking-tool-in-autonomous-stage` warns once for `@builtin` (naming the blocking tools it includes) instead of once per tool. `implicit-shell-policy` treats `@builtin` as a shell grant. Output-stage and region checks understand `@builtin` too.
- **TUI**: the agent editor's tool picker lists the groups first with a one-line description, then every install tool labelled with where it comes from (built in, sub-agent tool, this agent's script, global script), and flags a named tool this install does not have.
- **HTTP**: `GET /api/tools` returns `groups` next to `tools`.
- **Docs and schemas**: new "Tool groups" section in tools.md, updated agents.md / mcp.md / cli.md, blueprint and OpenAPI schemas.
- **Fix**: the `install_tool` summary and rhai-tools.md pointed at an `available_global_tools` key that never existed; both now say `@scripts`.

## Verification

- `cargo test --workspace --all-features`, clippy `-D warnings`, `cargo xtask docs`, `cargo xtask structure` all clean.
- `cargo xtask coverage`: all 13 packages at 100%.
- Live: `lev validate` on a scratch blueprint granting `["@builtin", "@scripts"]` and requiring a script plus an MCP tool accepts the script through `@scripts`, reports the MCP tool as `required-tool-not-granted` naming both granted groups, and emits exactly one `@builtin` blocking warning. `@builtins` is rejected at parse time with the group list.
