### PR TITLE
chore(release): 0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,36 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
-## Unreleased
+## 0.5.9 - 2026-09-02
 
 ### Added
 
+- `[providers] provider_order`, an ordered list of provider names, best
+  first, that decides which configured provider serves a blueprint model
+  named without one. It generalizes `default_provider` into a full ordering;
+  left empty, resolution is exactly what it was. Naming a subscription
+  transport (Codex, Claude Code) in the order is the deliberate opt-in that
+  lets a plan win a bare model name at the priority it is listed. Every
+  surface that writes config learned it: `GET /api/config` reports the
+  order and `PUT` replaces it, `lev doctor` flags an entry naming no
+  configured provider, and the config and OpenAPI schemas describe it.
+- `lev providers`, which lists the configured providers with the current
+  order, and `lev providers order <name>...` / `--clear` to set or drop it
+  from the command line. An unknown name is refused with the known list
+  rather than persisted as a silent no-op.
+- The setup wizard's Defaults screen replaces the single "Default provider"
+  chooser with a "Provider priority" list arranged in a drag-to-reorder
+  modal (drag a row by its grip, or move it with Shift+arrows or K/J); the
+  head of the order is written as `default_provider`.
+- `install_tool`, a built-in that persists a Rhai tool to `~/.leviath/tools`
+  so every future run can use it. Nothing an agent could do reached that
+  directory before. It compiles the script first and refuses a reserved or
+  malformed name, a `@tool` directive that disagrees with the name, an empty
+  `@description`, an oversized source, an existing script without
+  `overwrite`, a symlinked destination, or a `<name>.toml` sibling whose
+  `[tool]` name differs. The written file leads with a provenance line
+  naming who installed it and when. Like `write_file` and `shell` it
+  defaults to `ask`.
 - Tool groups in `available_tools`. An entry that starts with `@` grants a
   whole kind of tool rather than one: `@builtin` (every compiled-in tool),
   `@subagent`, `@scripts` (every Rhai tool, the agent's own and the global
@@ -33,8 +59,25 @@ same list.
   tool by where it comes from, and `GET /api/tools` carries the same
   `groups` list for other clients.
 
+### Changed
+
+- `lev --help` groups the commands under Setup and configuration,
+  Blueprints, Running agents, Inspecting runs, and Servers instead of one
+  flat list of thirty. Every command is still `lev <command>`; only the help
+  reads differently.
+
 ### Fixed
 
+- The dashboard's task editor, response box, deny-with-feedback prompt and
+  in-place document edit all submit on Ctrl+S. Ctrl+Enter reaches a program
+  only under the kitty keyboard protocol; elsewhere it arrives as a plain
+  Enter, and some macOS terminals swallow it or open a context menu on it,
+  which left the keyboard no way to start a run. Ctrl+Enter still works
+  where it arrives, and the hint bars name ^S.
+- The provider-priority modal accepts K and J to move a row. Apple Terminal
+  and others strip Shift from an arrow key before it reaches the
+  application, so Shift+Up/Down was the only keyboard reorder and it was
+  unreachable there.
 - The `install_tool` summary and the Rhai tools page pointed at an
   `available_global_tools` stage key that does not exist. Both now say
   `@scripts`, which does what that key claimed to.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "leviath-core",
  "leviath-tools",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "encoding_rs",
  "leviath-testkit",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "base64 0.23.1",
  "leviath-core",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "fs4",
  "keyring",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "tokio",
  "tracing",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.8"
+version = "0.5.9"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -98,18 +98,18 @@ allow_attributes_without_reason = "deny"
 # to the repo while every crate that dev-depends on it still publishes.
 # No member depends on the facade; it is listed so the version-parity check
 # (`cargo xtask version --check`) sees every published crate in one table.
-leviath = { path = "crates/leviath", version = "0.5.8" }
-leviath-core = { path = "crates/leviath-core", version = "0.5.8" }
-leviath-net = { path = "crates/leviath-net", version = "0.5.8" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.8" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.8" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.5.8" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.8" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.8" }
-leviath-package = { path = "crates/leviath-package", version = "0.5.8" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.5.8" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.5.8" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.8" }
+leviath = { path = "crates/leviath", version = "0.5.9" }
+leviath-core = { path = "crates/leviath-core", version = "0.5.9" }
+leviath-net = { path = "crates/leviath-net", version = "0.5.9" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.9" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.9" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.5.9" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.9" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.9" }
+leviath-package = { path = "crates/leviath-package", version = "0.5.9" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.5.9" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.5.9" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.9" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.5.8", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.5.9", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Leviath HTTP API",
-    "version": "0.5.8",
+    "version": "0.5.9",
     "description": "The REST and WebSocket surface `lev serve` puts in front of the shared-world daemon. Every route requires a bearer token. Paths here are checked against the router in crates/leviath-cli/src/commands/serve/mod.rs by a test in that file, so a route added without a spec entry fails the build. See https://leviath.dev/docs/api.",
     "license": {
       "name": "MIT"


### PR DESCRIPTION
## Summary

Version bump 0.5.8 -> 0.5.9. Merging cuts the alpha release.

Rolls `## Unreleased` into `## 0.5.9 - 2026-09-02`, carrying everything merged since 0.5.8:

- `[providers] provider_order`, the ordered provider preference (#774), which is what #778 asked to ship so The Lair console sees it in `GET /api/config`
- `lev providers` (#776)
- the setup wizard's drag-to-reorder Provider priority (#777)
- `install_tool` (#780)
- tool groups in `available_tools` (#783)
- categorized `lev --help` (#775)
- Ctrl+S submit and K/J reorder for terminals that drop the chords (#782)

Produced by `cargo xtask version 0.5.9`; the only hand edits are the changelog entries.

Closes #778.
