### PR TITLE
ci: drop the unconfigured Azure signing step from the alpha build

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -153,11 +153,8 @@ jobs:
     secrets: inherit
 
   build:
-    # id-token lets the signing step prove to Azure which workflow it is
-    # (OpenID Connect); contents stays read-only.
     permissions:
       contents: read
-      id-token: write
     name: Build (${{ matrix.target }})
     needs: gate
     runs-on: ${{ matrix.os }}
@@ -273,73 +270,6 @@ jobs:
           esac
           echo "RUSTFLAGS=$RUSTFLAGS"
           cargo build --release --bin lev --target "$TARGET"
-      # Authenticode-sign lev.exe when an Azure Artifact Signing account (the
-      # service formerly called Trusted Signing) is configured.
-      #
-      # An unsigned exe that talks to the network, spawns processes and reads
-      # the credential store is what antivirus heuristics are built to catch,
-      # and an install that Defender quarantines is not an install. A signature
-      # from a publisher Microsoft has verified is the one thing that answers
-      # that on the machine itself, before any reputation accrues.
-      #
-      # Authentication is OpenID Connect: GitHub mints a token for this job and
-      # a federated credential on the Entra app trusts it, so there is no
-      # client secret to store or rotate. Gated on the secrets being present
-      # rather than required, so a fork or a PR build still produces an
-      # (unsigned) binary. To turn it on:
-      #   1. Azure portal: create an Artifact Signing account (Basic), complete
-      #      identity validation, add a Public Trust certificate profile.
-      #   2. Entra: create an app registration; under Certificates & secrets add
-      #      a *federated credential* for GitHub Actions - this repo, entity
-      #      "Branch", branch "main" (the alpha build runs from main).
-      #   3. On the signing account, Access control (IAM): give the app the
-      #      "Artifact Signing Certificate Profile Signer" role.
-      #   4. Repo secrets: AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_SUBSCRIPTION_ID,
-      #      ARTIFACT_SIGNING_ENDPOINT (e.g. https://eus.codesigning.azure.net),
-      #      ARTIFACT_SIGNING_ACCOUNT, ARTIFACT_SIGNING_PROFILE.
-      - name: Decide whether the binary can be signed
-        if: matrix.os == 'windows-latest'
-        id: signing
-        shell: bash
-        env:
-          ACCOUNT: ${{ secrets.ARTIFACT_SIGNING_ACCOUNT }}
-        run: |
-          if [ -n "$ACCOUNT" ]; then
-            echo "configured=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::ARTIFACT_SIGNING_ACCOUNT is not set; lev.exe ships unsigned"
-          fi
-      - name: Log in to Azure (OIDC)
-        if: matrix.os == 'windows-latest' && steps.signing.outputs.configured == 'true'
-        uses: azure/login@0949e32778441b2c442592b7a0e6313466dc8f29 # v3.0.2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: Sign lev.exe
-        if: matrix.os == 'windows-latest' && steps.signing.outputs.configured == 'true'
-        uses: azure/artifact-signing-action@208f8af4bf26cf2af8597424e3cb5582801523ba # v2.0.0
-        with:
-          endpoint: ${{ secrets.ARTIFACT_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.ARTIFACT_SIGNING_ACCOUNT }}
-          certificate-profile-name: ${{ secrets.ARTIFACT_SIGNING_PROFILE }}
-          files-folder: target/${{ matrix.target }}/release
-          files-folder-filter: exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-          # Only the Azure CLI credential the login step established.
-          exclude-environment-credential: true
-          exclude-workload-identity-credential: true
-          exclude-managed-identity-credential: true
-          exclude-shared-token-cache-credential: true
-          exclude-visual-studio-credential: true
-          exclude-visual-studio-code-credential: true
-          exclude-azure-cli-credential: false
-          exclude-azure-powershell-credential: true
-          exclude-azure-developer-cli-credential: true
-          exclude-interactive-browser-credential: true
       - name: Package archive
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## Unreleased
+
+### Removed
+
+- The opt-in Azure Artifact Signing step on the alpha build, along with the
+  `id-token` grant that existed only for it. It was never configured, so every
+  `lev.exe` to date shipped unsigned and nothing changes for users. The version
+  resource in `lev.exe` stays. Should signing ever be wanted, the SignPath
+  Foundation route in CONTRIBUTING is the one to add.
+
 ## 0.5.9 - 2026-09-02
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,31 +279,10 @@ reviewers and approvers), and once accepted the alpha build would submit
 `lev.exe` through `signpath/github-action-submit-signing-request` and receive
 it back signed with the Foundation's certificate - which Windows trusts, and
 which accrues reputation across releases. That is the only way the Defender
-flags stop for good; everything below is the paid alternative.
-
-The alpha build also carries an opt-in step for Azure Artifact Signing (which
-costs money and is not configured). It signs when six repository secrets
-exist and prints a `::notice` and ships unsigned when they do not, so nothing
-about a fork or a PR build depends on Azure. Should that ever be wanted:
-
-1. **Azure portal → Artifact Signing** (Basic tier): create an account, complete
-   the identity validation for Sun Forge AI (this is the slow step - days - and
-   nothing signs until it is approved), then add a certificate profile of type
-   *Public Trust*. Note the account's endpoint (for example
-   `https://eus.codesigning.azure.net`).
-2. **Microsoft Entra → App registrations**: create an app. Under *Certificates &
-   secrets → Federated credentials*, add one for GitHub Actions: organization
-   `GEMISIS`, repository `leviath`, entity **Branch**, branch `main`. No client
-   secret - the workflow authenticates with OpenID Connect, and the alpha build
-   only ever runs from `main`.
-3. **The signing account → Access control (IAM)**: assign the app the role
-   *Artifact Signing Certificate Profile Signer*.
-4. **Repository secrets**: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
-   `AZURE_SUBSCRIPTION_ID`, `ARTIFACT_SIGNING_ENDPOINT`,
-   `ARTIFACT_SIGNING_ACCOUNT`, `ARTIFACT_SIGNING_PROFILE`.
-
-The next alpha run signs. Verify on the published asset with
-`Get-AuthenticodeSignature lev.exe`.
+flags stop for good. The release pipeline carries no signing step today, so
+adopting it means adding that step to the alpha build (beta and stable promote
+the alpha artifacts, so a signature travels with them). Verify a signed asset
+with `Get-AuthenticodeSignature lev.exe`.
 
 ## Design notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -278,7 +278,5 @@ on an unknown file, which the build provenance attestation above answers: it
 proves *which workflow* built the file, which is a stronger statement than a
 publisher signature makes.
 
-The release pipeline can sign if a certificate is ever available - the alpha
-build carries an opt-in step for Azure Artifact Signing, and the free path for
-open-source projects is the SignPath Foundation (see CONTRIBUTING). Neither is
-configured; the step prints a notice and ships the binary unsigned.
+The release pipeline has no signing step. If signing is ever wanted, the free
+path for open-source projects is the SignPath Foundation (see CONTRIBUTING).


### PR DESCRIPTION
Dependabot opened #785 and #786 to bump `azure/login` and `azure/artifact-signing-action`, which raised the question of why the alpha build depends on Azure at all. It does not need to: the signing step was opt-in, gated on six repository secrets that were never set, so every `lev.exe` to date shipped unsigned and the step only ever printed a `::notice`.

This removes:

- the Azure login and signing steps plus the "can we sign" probe from the `build` job in `alpha.yml`
- the `id-token: write` grant on that job, which existed only for Azure OIDC (the `release` job keeps its grant for build provenance attestation, and the `docs` job keeps its grant for the AWS docs publish)
- the Azure setup recipe in CONTRIBUTING and the matching sentence in SECURITY

The version resource in `lev.exe` is untouched, and SignPath stays as the documented route if signing is ever wanted. Nothing changes for users. `CHANGELOG.md` gets a `## Unreleased` / Removed entry.

Closes #785 and #786 once merged (the bumped actions no longer exist in the tree).
