### PR TITLE
feat(setup): move the model choices onto the advanced screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,9 @@ same list.
   /api/config` takes both with the same three states (absent, `null`, a
   string) and the same empty-string refusal. `default_model` is gone from the
   API. `lev setup --default-model` is `--override-model`, with
-  `--fallback-model` beside it; the wizard's model field is labelled Override
-  model. The embedding builder's `default_model(provider, model)` is
+  `--fallback-model` beside it. In the wizard both settings sit on the
+  advanced tuning screen, as Override model and Fallback model, so the main
+  screen asks only for providers and their order. The embedding builder's `default_model(provider, model)` is
   `override_model(provider, model)`, `default_provider(provider)` sets the
   provider alone, `fallback_model(model)` is the new setting, and the old
   `fallback_model(provider, model)` that appended to the failover chain is

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -370,9 +370,9 @@ impl Wizard {
             }
             FieldValue::Choice { options, index } => (options.clone(), *index),
         };
-        // Unconditionally, because the only list-valued fields in the wizard
-        // are the Defaults screen's provider and model. The tuning screen is
-        // numbers and switches, which the arrows already handle well.
+        // The list-valued fields are the two model choices at the end of the
+        // tuning screen; the rest of that screen is numbers and switches, which
+        // the arrows already handle well.
         self.open_picker(label, choice.0, choice.1);
     }
 

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -1136,8 +1136,9 @@ fn wizard_with_models() -> (tempfile::TempDir, Wizard) {
             "claude-haiku-4-5".to_string(),
         ],
     };
-    w.enter(Step::Defaults);
-    w.cursor = 1; // the model choice
+    w.show_advanced = true;
+    w.enter(Step::Limits);
+    w.cursor = Wizard::OVERRIDE_FIELD; // the override model choice
     (dir, w)
 }
 
@@ -1185,7 +1186,10 @@ fn typing_filters_the_chooser_and_enter_takes_the_match() {
     w.handle_key(press(KeyCode::Enter));
 
     assert!(w.picker.is_none(), "choosing closes it");
-    assert_eq!(w.defaults[1].value.display(), "claude-haiku-4-5");
+    assert_eq!(
+        w.limits[Wizard::OVERRIDE_FIELD].value.display(),
+        "claude-haiku-4-5"
+    );
     assert!(w.dirty, "a chosen default is an unsaved change");
 }
 
@@ -1322,7 +1326,10 @@ fn clicking_a_row_in_the_chooser_takes_it_and_the_wheel_moves_within_it() {
 
     assert!(w.picker.is_none(), "a click on a row chooses it");
     // Row 0 is the "no default" option and the models sort after it.
-    assert_eq!(w.defaults[1].value.display(), "claude-opus-4");
+    assert_eq!(
+        w.limits[Wizard::OVERRIDE_FIELD].value.display(),
+        "claude-opus-4"
+    );
 }
 
 /// Page keys and Home/End are bound, not only reachable through the methods
@@ -1406,8 +1413,14 @@ fn a_configured_provider_outside_the_catalog_still_describes_itself() {
     assert_eq!(rows[0].0, "in-house");
     assert_eq!(rows[0].1, "from your config");
 
-    w.cursor = 1;
-    w.open_picker("Default model", w.defaults[1].value.options().to_vec(), 0);
+    w.show_advanced = true;
+    w.enter(Step::Limits);
+    w.cursor = Wizard::OVERRIDE_FIELD;
+    w.open_picker(
+        "Override model",
+        w.limits[Wizard::OVERRIDE_FIELD].value.options().to_vec(),
+        0,
+    );
     let picker = w.picker.as_ref().expect("open");
     let ghost = picker
         .options

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -1309,12 +1309,17 @@ mod tests {
         w.providers[0].outcome = crate::commands::setup::verify::Outcome::Reachable {
             models: vec!["claude-opus-4".to_string()],
         };
-        w.enter(Step::Defaults);
-        w.cursor = 1;
-        w.open_picker("Default model", w.defaults[1].value.options().to_vec(), 0);
+        w.show_advanced = true;
+        w.enter(Step::Limits);
+        w.cursor = Wizard::OVERRIDE_FIELD;
+        w.open_picker(
+            "Override model",
+            w.limits[Wizard::OVERRIDE_FIELD].value.options().to_vec(),
+            0,
+        );
 
         let screen = rendered(&w);
-        assert!(screen.contains("Default model"), "{screen}");
+        assert!(screen.contains("Override model"), "{screen}");
         assert!(
             screen.contains("never sent to a different provider"),
             "the precedence prose is the point of the screen:\n{screen}"
@@ -1743,8 +1748,11 @@ mod tests {
         assert!(screen.contains("[enter]"), "numbers are typed");
         assert!(screen.contains("[enter/space]"), "booleans are toggled");
 
+        // The choices are the two model fields at the end of this screen.
         w.providers[0].selected = true;
-        w.enter(Step::Defaults);
+        w.show_advanced = true;
+        w.enter(Step::Limits);
+        w.scroll_end();
         assert!(rendered(&w).contains("enter/← →"), "choices are cycled");
     }
 

--- a/crates/leviath-cli/src/commands/setup/state/lanes.rs
+++ b/crates/leviath-cli/src/commands/setup/state/lanes.rs
@@ -110,6 +110,12 @@ impl Wizard {
         if landed && self.step == Step::Defaults {
             self.rebuild_defaults();
         }
+        // The model choosers live on the advanced screen and are built from
+        // the same lists, so a reply landing while that screen is open refills
+        // them too, keeping whatever was already chosen.
+        if landed && self.step == Step::Limits {
+            self.rebuild_advanced_models();
+        }
     }
 
     // ── Signing in ──────────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/setup/state/limits.rs
+++ b/crates/leviath-cli/src/commands/setup/state/limits.rs
@@ -7,6 +7,12 @@
 
 use super::*;
 
+/// How many tuning fields the Limits screen has before the two model fields
+/// the wizard appends (see `Wizard::rebuild_advanced_models`). Their indices
+/// are what `apply_limits_fields` matches on, so the two are kept in step by
+/// a test rather than by counting.
+pub(super) const LIMITS_FIXED: usize = 12;
+
 /// The Limits screen's fields, seeded from a config.
 pub(super) fn limits_fields(config: &Config) -> Vec<Field> {
     vec![
@@ -153,7 +159,20 @@ pub(super) fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
             // stores `None` rather than reinstating a number they just removed.
             (10, FieldValue::Number(n)) => config.limits.max_tool_call_write_bytes = *n,
             (11, FieldValue::Number(n)) => config.limits.max_run_write_bytes = *n,
+            // The two model fields past here are read by `build_config` itself.
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The index the model fields are appended at is the number of tuning
+    /// fields, so a field added above has to move this constant with it.
+    #[test]
+    fn the_fixed_field_count_matches_the_form() {
+        assert_eq!(limits_fields(&Config::default()).len(), LIMITS_FIXED);
     }
 }

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -21,6 +21,7 @@ use crate::config::Config;
 // Sections of the former single-file wizard state. Glob re-exported so every
 // existing `state::Wizard` path keeps working.
 mod endpoints;
+mod models;
 mod priority;
 pub(crate) use endpoints::*;
 mod lanes;
@@ -593,9 +594,13 @@ impl Wizard {
         self.scroll = 0;
         self.edit = None;
         if step == Step::Defaults {
-            // The model picker is populated by verification, which may have
-            // finished since the last visit.
+            // The provider priority is populated by verification, which may
+            // have finished since the last visit.
             self.rebuild_defaults();
+        }
+        if step == Step::Limits {
+            // Same for the two model choices at the end of the tuning screen.
+            self.rebuild_advanced_models();
         }
     }
 
@@ -620,65 +625,6 @@ impl Wizard {
             return true;
         }
         false
-    }
-
-    /// What choosing one of these values actually decides.
-    ///
-    /// Written against `leviath_runtime::pipeline::resolve`, which is the code
-    /// that reads them. The line about a blueprint winning is the one worth
-    /// having: a user who sets a default and then watches an agent run on
-    /// something else has been told, by every other tool, that a default is a
-    /// default.
-    fn precedence_explanation(provider: bool) -> Vec<&'static str> {
-        if provider {
-            vec![
-                "Where your runs go by default. A stage that lists this provider among",
-                "its models is served by it first, ahead of the blueprint's own order.",
-                "",
-                "This field does nothing on its own. Until you also set a default model",
-                "below, the only thing it can do is reorder a list that already names",
-                "this provider, so on a machine keyed for one provider that no blueprint",
-                "mentions, every stage still goes somewhere else.",
-                "",
-                "It never overrides a blueprint that pins its provider: a stage with",
-                "allow_user_default = false ignores this, and so does a provider you",
-                "have not given a credential.",
-            ]
-        } else {
-            vec![
-                "The model your default provider is asked for. The two travel together:",
-                "this name is never sent to a different provider, so an OpenAI model is",
-                "never asked of Anthropic.",
-                "",
-                "Setting it is what makes the default provider above take effect. The",
-                "pair is offered to every stage that allows a user default, and moves to",
-                "the front of the models that stage lists.",
-                "",
-                "Leaving it unset does not mean your provider picks a model. It means",
-                "each blueprint uses the models it names, and a stage that names none",
-                "falls back to a model built into Leviath, whoever you configured.",
-            ]
-        }
-    }
-
-    /// Every model id any provider reported, deduplicated, for the picker.
-    pub(crate) fn discovered_models(&self) -> Vec<String> {
-        let mut models: Vec<String> = self
-            .providers
-            .iter()
-            .filter(|r| r.selected)
-            .flat_map(|r| r.outcome.models().iter().cloned())
-            .collect();
-        let selected = self.selected_endpoint_names();
-        models.extend(
-            self.endpoints
-                .iter()
-                .filter(|e| selected.contains(&e.name))
-                .flat_map(|e| e.model_choices()),
-        );
-        models.sort();
-        models.dedup();
-        models
     }
 
     // ── Forms ───────────────────────────────────────────────────────────────
@@ -732,24 +678,6 @@ impl Wizard {
             order.insert(0, head);
         }
 
-        let mut models = vec![Self::NO_DEFAULT_MODEL.to_string()];
-        models.extend(self.discovered_models());
-        // An endpoint entry at the head of the priority brings the model picked
-        // on its own screen, unless a model was already chosen here.
-        let chosen_provider = order.first().cloned().unwrap_or_default();
-        let current_model = self
-            .current_default_model()
-            .filter(|m| m != Self::NO_DEFAULT_MODEL)
-            .or_else(|| self.endpoint_default_model(&chosen_provider))
-            .unwrap_or_else(|| Self::NO_DEFAULT_MODEL.to_string());
-        if !models.contains(&current_model) {
-            models.push(current_model.clone());
-        }
-        let model_index = models
-            .iter()
-            .position(|m| *m == current_model)
-            .unwrap_or_default();
-
         let timeout = self.current_request_timeout();
         self.defaults = vec![
             Field {
@@ -759,25 +687,15 @@ impl Wizard {
                 value: FieldValue::Order(order),
             },
             Field {
-                label: "Override model",
-                help: "One model every stage that allows a user default starts on, ahead of \
-                       what its blueprint names, paired with the provider above. Leave it \
-                       unset to let each blueprint decide. Listed from what your providers \
-                       reported.",
-                value: FieldValue::Choice {
-                    options: models,
-                    index: model_index,
-                },
-            },
-            Field {
                 label: "Request timeout (seconds)",
                 help: "How long to wait on one inference. Unset uses the provider default.",
                 value: FieldValue::Number(timeout),
             },
             Field {
                 label: "Show advanced tuning",
-                help: "Adds a screen of concurrency, retry and context limits. Every one of \
-                       them already has a default that works.",
+                help: "Adds a screen of concurrency, retry and context limits, and the two \
+                       model settings that override or back up what a blueprint names. \
+                       Every one of them already has a default that works.",
                 value: FieldValue::Bool(self.show_advanced),
             },
         ];
@@ -792,8 +710,19 @@ impl Wizard {
     /// Where the provider choice sits on the Defaults screen.
     pub const PROVIDER_FIELD: usize = 0;
 
+    /// Where the request timeout sits on the Defaults screen.
+    pub const TIMEOUT_FIELD: usize = 1;
+
     /// Where the advanced-tuning toggle sits on the Defaults screen.
-    pub const ADVANCED_FIELD: usize = 3;
+    pub const ADVANCED_FIELD: usize = 2;
+
+    /// Where the override model sits on the advanced screen: after every
+    /// tuning limit, so the limits keep the indices `apply_limits_fields`
+    /// matches on.
+    pub const OVERRIDE_FIELD: usize = LIMITS_FIXED;
+
+    /// Where the fallback model sits on the advanced screen.
+    pub const FALLBACK_FIELD: usize = LIMITS_FIXED + 1;
 
     /// The model field's "no default" option.
     ///
@@ -803,100 +732,8 @@ impl Wizard {
     /// Leviath, not to anything the provider chose.
     pub const NO_DEFAULT_MODEL: &'static str = "(each blueprint decides)";
 
-    /// Open the chooser for the Defaults field the cursor is on.
-    ///
-    /// The options come from the caller because it has already matched on the
-    /// field's kind: re-reading them here would add a shape this cannot be in.
-    pub(super) fn open_picker(&mut self, title: &'static str, options: Vec<String>, index: usize) {
-        let field = self.cursor;
-        let options = options
-            .into_iter()
-            .map(|value| {
-                let detail = if field == Self::PROVIDER_FIELD {
-                    self.provider_detail(&value)
-                } else {
-                    self.model_detail(&value)
-                };
-                PickerOption { value, detail }
-            })
-            .collect();
-        self.picker_field = field;
-        // Opening on the current value rather than at the top: the list is
-        // long, and "where am I now" is the first thing you look for.
-        self.picker = Some(Picker::new(
-            title,
-            Self::precedence_explanation(field == Self::PROVIDER_FIELD)
-                .into_iter()
-                .map(str::to_string)
-                .collect(),
-            options,
-            index,
-        ));
-    }
-
-    /// What a provider id is, for the chooser's second column.
-    fn provider_detail(&self, id: &str) -> String {
-        // Entries before rows: an entry is named after its preset by default,
-        // and the preset row is never itself a choice here.
-        if let Some(entry) = self.endpoints.iter().find(|e| e.name == id) {
-            let preset = self
-                .providers
-                .iter()
-                .find(|r| r.provider.id == entry.preset)
-                .map_or(entry.preset, |r| r.provider.display);
-            return format!("{preset} at {}", entry.base_url);
-        }
-        if let Some(row) = self.providers.iter().find(|r| r.provider.id == id) {
-            return row.provider.display.to_string();
-        }
-        // A provider that is configured but not in the catalog: it came
-        // from the config file, so it is still a legitimate choice.
-        "from your config".to_string()
-    }
-
-    /// Which providers reported a model, so the row says where it came from.
-    fn model_detail(&self, model: &str) -> String {
-        // The first row is the absence of a model, not a model, so the
-        // question "who reported it" does not apply to it.
-        if model == Self::NO_DEFAULT_MODEL {
-            return "no default; every blueprint uses the models it names".to_string();
-        }
-        let reported: Vec<&str> = self
-            .providers
-            .iter()
-            .filter(|r| r.selected && r.outcome.models().iter().any(|m| m == model))
-            .map(|r| r.provider.display)
-            .collect();
-        if reported.is_empty() {
-            return "not reported by a provider you selected".to_string();
-        }
-        format!("reported by {}", reported.join(", "))
-    }
-
-    /// Take the chooser's answer (an index into its options), writing it
-    /// back into the field it came from.
-    pub(super) fn commit_picker(&mut self, chosen: usize) {
-        // The chooser's options were built from this field's, one for one and
-        // in order, so the option index *is* the field's index. Indexing rather
-        // than looking up: the field is where it was when the chooser opened,
-        // and nothing rebuilds the form while one is on screen.
-        self.defaults[self.picker_field].value.set_index(chosen);
-        self.dirty = true;
-        // The provider field is an ordered priority now and opens the reorder
-        // modal, not the chooser, so the only field this commits is the default
-        // model - the concurrency-follows-provider adjustment lives in
-        // `commit_reorder`.
-    }
-
-    fn current_default_model(&self) -> Option<String> {
-        match self.defaults.get(1).map(|f| &f.value) {
-            Some(FieldValue::Choice { options, index }) => options.get(*index).cloned(),
-            _ => self.base.override_model.clone(),
-        }
-    }
-
     fn current_request_timeout(&self) -> Option<u64> {
-        match self.defaults.get(2).map(|f| &f.value) {
+        match self.defaults.get(Self::TIMEOUT_FIELD).map(|f| &f.value) {
             Some(FieldValue::Number(n)) => *n,
             _ => self.base.request_timeout_secs,
         }
@@ -1059,9 +896,21 @@ impl Wizard {
             .cloned()
             .unwrap_or_else(|| self.current_default_provider());
         config.providers.provider_order = if order.len() > 1 { order } else { Vec::new() };
-        config.override_model = self
-            .current_default_model()
-            .filter(|m| m != Self::NO_DEFAULT_MODEL);
+        // The two model settings live on the advanced screen. Until it has
+        // been visited the override keeps what the config holds, or what an
+        // endpoint entry at the head of the priority picked for itself; a
+        // visit that chose "(each blueprint decides)" is a real answer and is
+        // not overridden by that pick.
+        let head = config.default_provider.clone();
+        config.override_model = self.chosen_model(Self::OVERRIDE_FIELD).unwrap_or_else(|| {
+            self.base
+                .override_model
+                .clone()
+                .or_else(|| self.endpoint_default_model(&head))
+        });
+        config.fallback_model = self
+            .chosen_model(Self::FALLBACK_FIELD)
+            .unwrap_or_else(|| self.base.fallback_model.clone());
         config.request_timeout_secs = self.current_request_timeout();
 
         apply_limits_fields(&mut config, &self.limits);
@@ -1926,9 +1775,10 @@ pub(super) mod tests {
         let mut wizard = test_wizard(dir.path());
         let (_requests, replies) = wizard.take_verify_ends().expect("first take");
         wizard.providers[0].selected = true;
-        wizard.enter(Step::Defaults);
+        wizard.show_advanced = true;
+        wizard.enter(Step::Limits);
         assert_eq!(
-            wizard.defaults[1].value.options(),
+            wizard.limits[Wizard::OVERRIDE_FIELD].value.options(),
             [Wizard::NO_DEFAULT_MODEL.to_string()],
             "nothing has been reported yet"
         );
@@ -1944,12 +1794,56 @@ pub(super) mod tests {
         wizard.drain_verifications();
 
         assert!(
-            wizard.defaults[1]
+            wizard.limits[Wizard::OVERRIDE_FIELD]
                 .value
                 .options()
                 .contains(&"claude-opus-5".to_string()),
             "the picker should have refilled"
         );
+        assert!(
+            wizard.limits[Wizard::FALLBACK_FIELD]
+                .value
+                .options()
+                .contains(&"claude-opus-5".to_string()),
+            "both choosers share the list"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_late_reply_rebuilds_the_defaults_screen_too() {
+        // The Defaults screen's provider priority is built from the same
+        // replies, so a reply landing while it is open rebuilds it as well.
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = test_wizard(dir.path());
+        let (_requests, replies) = wizard.take_verify_ends().expect("first take");
+        wizard.providers[0].selected = true;
+        wizard.enter(Step::Defaults);
+        let before = wizard.defaults.len();
+        replies
+            .send(VerifyReply {
+                provider_id: "anthropic".to_string(),
+                outcome: Outcome::Reachable {
+                    models: vec!["claude-opus-5".to_string()],
+                },
+            })
+            .unwrap();
+        wizard.drain_verifications();
+        assert_eq!(wizard.defaults.len(), before, "the form keeps its shape");
+        assert_eq!(wizard.step, Step::Defaults);
+    }
+
+    #[test]
+    fn commit_picker_off_a_form_step_changes_no_field() {
+        // The chooser only opens on a form step, but the commit is written
+        // against the step the wizard is on when it lands: a screen with no
+        // fields has nothing to write into and nothing to panic over.
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = test_wizard(dir.path());
+        wizard.enter(Step::Providers);
+        wizard.picker_field = 0;
+        wizard.commit_picker(0);
+        assert!(wizard.dirty);
+        assert!(wizard.fields().is_empty());
     }
 
     #[tokio::test]
@@ -2052,16 +1946,94 @@ pub(super) mod tests {
             models: vec!["claude-opus-5".to_string()],
         };
 
-        wizard.enter(Step::Defaults);
+        wizard.show_advanced = true;
+        wizard.enter(Step::Limits);
 
-        let options = wizard.defaults[1].value.options();
+        let options = wizard.limits[Wizard::OVERRIDE_FIELD].value.options();
         assert!(options.contains(&Wizard::NO_DEFAULT_MODEL.to_string()));
         assert!(options.contains(&"claude-opus-5".to_string()));
         assert_eq!(
-            wizard.defaults[1].value.display(),
+            wizard.limits[Wizard::OVERRIDE_FIELD].value.display(),
             "hand-typed",
             "a model already in the config must survive"
         );
+        assert_eq!(
+            wizard.limits[Wizard::FALLBACK_FIELD].value.display(),
+            Wizard::NO_DEFAULT_MODEL,
+            "nothing configured reads as the blueprints deciding"
+        );
+    }
+
+    /// A choice made on the advanced screen is what gets written, survives
+    /// leaving and re-entering the screen, and an explicit "(each blueprint
+    /// decides)" there beats the model an endpoint entry picked for itself.
+    #[test]
+    fn the_advanced_model_choices_are_written_back_and_kept() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = test_wizard(dir.path());
+        wizard.providers[0].selected = true;
+        wizard.providers[0].outcome = Outcome::Reachable {
+            models: vec!["m-1".to_string(), "m-2".to_string()],
+        };
+        wizard.show_advanced = true;
+        wizard.enter(Step::Defaults);
+        assert_eq!(wizard.build_config().override_model, None);
+        assert_eq!(wizard.build_config().fallback_model, None);
+
+        wizard.enter(Step::Limits);
+        wizard.cursor = Wizard::OVERRIDE_FIELD;
+        wizard.open_picker(
+            "Override model",
+            wizard.limits[Wizard::OVERRIDE_FIELD]
+                .value
+                .options()
+                .to_vec(),
+            0,
+        );
+        let pick = wizard.limits[Wizard::OVERRIDE_FIELD]
+            .value
+            .options()
+            .iter()
+            .position(|m| m == "m-2")
+            .expect("reported");
+        wizard.commit_picker(pick);
+        wizard.cursor = Wizard::FALLBACK_FIELD;
+        wizard.open_picker(
+            "Fallback model",
+            wizard.limits[Wizard::FALLBACK_FIELD]
+                .value
+                .options()
+                .to_vec(),
+            0,
+        );
+        let pick = wizard.limits[Wizard::FALLBACK_FIELD]
+            .value
+            .options()
+            .iter()
+            .position(|m| m == "m-1")
+            .expect("reported");
+        wizard.commit_picker(pick);
+        assert_eq!(wizard.build_config().override_model.as_deref(), Some("m-2"));
+        assert_eq!(wizard.build_config().fallback_model.as_deref(), Some("m-1"));
+
+        // Out and back in: the choices are still there.
+        wizard.enter(Step::Defaults);
+        wizard.enter(Step::Limits);
+        assert_eq!(wizard.limits[Wizard::OVERRIDE_FIELD].value.display(), "m-2");
+        assert_eq!(wizard.limits[Wizard::FALLBACK_FIELD].value.display(), "m-1");
+
+        // Choosing "(each blueprint decides)" is an answer, not an absence.
+        wizard.cursor = Wizard::OVERRIDE_FIELD;
+        wizard.open_picker(
+            "Override model",
+            wizard.limits[Wizard::OVERRIDE_FIELD]
+                .value
+                .options()
+                .to_vec(),
+            0,
+        );
+        wizard.commit_picker(0);
+        assert_eq!(wizard.build_config().override_model, None);
     }
 
     #[test]
@@ -2116,7 +2088,7 @@ pub(super) mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut wizard = test_wizard(dir.path());
         wizard.enter(Step::Defaults);
-        wizard.cursor = 3; // the "Show advanced tuning" bool
+        wizard.cursor = Wizard::ADVANCED_FIELD; // the "Show advanced tuning" bool
         wizard.open_reorder();
         assert!(wizard.reorder.is_none());
     }
@@ -2425,12 +2397,12 @@ pub(super) mod tests {
         wizard.enter(Step::Defaults);
 
         wizard.edit = Some(Edit {
-            target: EditTarget::Field(2),
+            target: EditTarget::Field(1),
             line: crate::tui::widgets::line_edit::LineEdit::new("45".to_string(), false),
         });
         wizard.commit_edit();
 
-        assert_eq!(wizard.defaults[2].value, FieldValue::Number(Some(45)));
+        assert_eq!(wizard.defaults[1].value, FieldValue::Number(Some(45)));
         assert_eq!(wizard.build_config().request_timeout_secs, Some(45));
     }
 
@@ -2615,8 +2587,9 @@ pub(super) mod tests {
         wizard.providers[0].selected = true;
         wizard.enter(Step::Defaults);
 
-        // Index 0 of the model field is always the "no default" option.
+        // Nothing chosen and nothing configured: both settings stay unset.
         assert!(wizard.build_config().override_model.is_none());
+        assert!(wizard.build_config().fallback_model.is_none());
     }
 
     #[test]
@@ -2663,6 +2636,10 @@ pub(super) mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut wizard = test_wizard(dir.path());
         wizard.enter(Step::Limits);
+        // The two model choosers past the tuning fields are read by
+        // `build_config` itself, not by `apply_limits_fields`.
+        assert_eq!(wizard.limits.len(), LIMITS_FIXED + 2);
+        wizard.limits.truncate(LIMITS_FIXED);
         let count = wizard.limits.len();
 
         let before = wizard.build_config();

--- a/crates/leviath-cli/src/commands/setup/state/models.rs
+++ b/crates/leviath-cli/src/commands/setup/state/models.rs
@@ -1,0 +1,249 @@
+//! The model choosers: what the picker offers, what choosing means, and the
+//! two model fields at the end of the advanced screen.
+//!
+//! Split out of the main state file for size. Everything here is about a
+//! single model id and the provider it pairs with; the provider priority
+//! itself lives in `priority`.
+
+use super::limits::LIMITS_FIXED;
+use super::{Field, FieldValue, Picker, PickerOption, Step, Wizard};
+
+impl Wizard {
+    /// What choosing one of these values actually decides.
+    ///
+    /// Written against `leviath_runtime::pipeline::resolve`, which is the code
+    /// that reads them. The line about a blueprint winning is the one worth
+    /// having: a user who sets a default and then watches an agent run on
+    /// something else has been told, by every other tool, that a default is a
+    /// default.
+    pub(super) fn picker_explanation(&self, field: usize) -> Vec<&'static str> {
+        if self.step == Step::Defaults && field == Self::PROVIDER_FIELD {
+            vec![
+                "Where your runs go by default. A stage that lists this provider among",
+                "its models is served by it first, ahead of the blueprint's own order.",
+                "",
+                "This field does nothing on its own. Until you also set an override",
+                "model on the advanced screen, the only thing it can do is reorder a",
+                "list that already names this provider, so on a machine keyed for one",
+                "provider that no blueprint mentions, every stage still goes elsewhere.",
+                "",
+                "It never overrides a blueprint that pins its provider: a stage with",
+                "allow_user_default = false ignores this, and so does a provider you",
+                "have not given a credential.",
+            ]
+        } else if self.step == Step::Limits && field == Self::FALLBACK_FIELD {
+            vec![
+                "The model a stage falls back to when none of the models it names is",
+                "configured on this machine. It is asked of your default provider, and",
+                "this name is never sent to a different provider.",
+                "",
+                "It sits behind everything a blueprint names and is never moved ahead",
+                "of it, so a stage that can run what it asked for is not touched. Only",
+                "a stage none of whose models you have configured lands here.",
+                "",
+                "Leaving it unset means such a stage fails at spawn with 'no usable",
+                "provider' rather than running on something the author did not name.",
+            ]
+        } else {
+            vec![
+                "The model your default provider is asked for. The two travel together:",
+                "this name is never sent to a different provider, so an OpenAI model is",
+                "never asked of Anthropic.",
+                "",
+                "Setting it overrides every blueprint: the pair is offered to every",
+                "stage that allows a user default and moves to the front of the models",
+                "that stage lists, so cheap stages pay this model's price too.",
+                "",
+                "Leaving it unset, the usual choice, means each blueprint uses the",
+                "models it names. The fallback model below is the gentler setting: it",
+                "only carries a stage none of whose models you have configured.",
+            ]
+        }
+    }
+
+    /// Every model id any provider reported, deduplicated, for the picker.
+    pub(crate) fn discovered_models(&self) -> Vec<String> {
+        let mut models: Vec<String> = self
+            .providers
+            .iter()
+            .filter(|r| r.selected)
+            .flat_map(|r| r.outcome.models().iter().cloned())
+            .collect();
+        let selected = self.selected_endpoint_names();
+        models.extend(
+            self.endpoints
+                .iter()
+                .filter(|e| selected.contains(&e.name))
+                .flat_map(|e| e.model_choices()),
+        );
+        models.sort();
+        models.dedup();
+        models
+    }
+
+    /// The two model fields at the end of the advanced screen, (re)built from
+    /// what verification reported. A choice already made there survives the
+    /// rebuild; before one is made, the override shows what the config holds
+    /// or what an endpoint entry at the head of the priority picked for
+    /// itself, and the fallback shows what the config holds.
+    pub(in crate::commands::setup) fn rebuild_advanced_models(&mut self) {
+        let mut models = vec![Self::NO_DEFAULT_MODEL.to_string()];
+        models.extend(self.discovered_models());
+        // The head of the priority, or the configured provider before the
+        // form exists: the one the override pairs with.
+        let head = self.current_default_provider();
+        let override_now = self
+            .chosen_model(Self::OVERRIDE_FIELD)
+            .unwrap_or_else(|| {
+                self.base
+                    .override_model
+                    .clone()
+                    .or_else(|| self.endpoint_default_model(&head))
+            })
+            .unwrap_or_else(|| Self::NO_DEFAULT_MODEL.to_string());
+        let fallback_now = self
+            .chosen_model(Self::FALLBACK_FIELD)
+            .unwrap_or_else(|| self.base.fallback_model.clone())
+            .unwrap_or_else(|| Self::NO_DEFAULT_MODEL.to_string());
+        let field = |label: &'static str, help: &'static str, current: String| {
+            let mut options = models.clone();
+            if !options.contains(&current) {
+                options.push(current.clone());
+            }
+            let index = options
+                .iter()
+                .position(|m| *m == current)
+                .unwrap_or_default();
+            Field {
+                label,
+                help,
+                value: FieldValue::Choice { options, index },
+            }
+        };
+        self.limits.truncate(LIMITS_FIXED);
+        self.limits.push(field(
+            "Override model",
+            "One model every stage that allows a user default starts on, ahead of what \
+             its blueprint names, paired with your default provider. Leave it unset to \
+             let each blueprint decide. Listed from what your providers reported.",
+            override_now,
+        ));
+        self.limits.push(field(
+            "Fallback model",
+            "The model a stage falls back to when none of the models it names is \
+             configured here, on your default provider. Never moves a stage off a \
+             model its blueprint names.",
+            fallback_now,
+        ));
+    }
+
+    /// The model chosen on the advanced screen's field at `index`: `None`
+    /// while the field has not been built, `Some(None)` for an explicit
+    /// "(each blueprint decides)", `Some(Some(model))` for a pick.
+    pub(super) fn chosen_model(&self, index: usize) -> Option<Option<String>> {
+        match self.limits.get(index).map(|f| &f.value) {
+            Some(FieldValue::Choice { options, index }) => Some(
+                options
+                    .get(*index)
+                    .cloned()
+                    .filter(|m| m != Self::NO_DEFAULT_MODEL),
+            ),
+            _ => None,
+        }
+    }
+
+    /// Open the chooser for the Defaults field the cursor is on.
+    ///
+    /// The options come from the caller because it has already matched on the
+    /// field's kind: re-reading them here would add a shape this cannot be in.
+    pub(in crate::commands::setup) fn open_picker(
+        &mut self,
+        title: &'static str,
+        options: Vec<String>,
+        index: usize,
+    ) {
+        let field = self.cursor;
+        let options = options
+            .into_iter()
+            .map(|value| {
+                let detail = if field == Self::PROVIDER_FIELD {
+                    self.provider_detail(&value)
+                } else {
+                    self.model_detail(&value)
+                };
+                PickerOption { value, detail }
+            })
+            .collect();
+        self.picker_field = field;
+        // Opening on the current value rather than at the top: the list is
+        // long, and "where am I now" is the first thing you look for.
+        self.picker = Some(Picker::new(
+            title,
+            self.picker_explanation(field)
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            options,
+            index,
+        ));
+    }
+
+    /// What a provider id is, for the chooser's second column.
+    pub(super) fn provider_detail(&self, id: &str) -> String {
+        // Entries before rows: an entry is named after its preset by default,
+        // and the preset row is never itself a choice here.
+        if let Some(entry) = self.endpoints.iter().find(|e| e.name == id) {
+            let preset = self
+                .providers
+                .iter()
+                .find(|r| r.provider.id == entry.preset)
+                .map_or(entry.preset, |r| r.provider.display);
+            return format!("{preset} at {}", entry.base_url);
+        }
+        if let Some(row) = self.providers.iter().find(|r| r.provider.id == id) {
+            return row.provider.display.to_string();
+        }
+        // A provider that is configured but not in the catalog: it came
+        // from the config file, so it is still a legitimate choice.
+        "from your config".to_string()
+    }
+
+    /// Which providers reported a model, so the row says where it came from.
+    fn model_detail(&self, model: &str) -> String {
+        // The first row is the absence of a model, not a model, so the
+        // question "who reported it" does not apply to it.
+        if model == Self::NO_DEFAULT_MODEL {
+            return "no default; every blueprint uses the models it names".to_string();
+        }
+        let reported: Vec<&str> = self
+            .providers
+            .iter()
+            .filter(|r| r.selected && r.outcome.models().iter().any(|m| m == model))
+            .map(|r| r.provider.display)
+            .collect();
+        if reported.is_empty() {
+            return "not reported by a provider you selected".to_string();
+        }
+        format!("reported by {}", reported.join(", "))
+    }
+
+    /// Take the chooser's answer (an index into its options), writing it
+    /// back into the field it came from.
+    pub(in crate::commands::setup) fn commit_picker(&mut self, chosen: usize) {
+        // The chooser's options were built from this field's, one for one and
+        // in order, so the option index *is* the field's index. Indexing rather
+        // than looking up: the field is where it was when the chooser opened,
+        // and nothing rebuilds the form while one is on screen.
+        let field = self.picker_field;
+        if let Some(fields) = self.fields_mut()
+            && let Some(f) = fields.get_mut(field)
+        {
+            f.value.set_index(chosen);
+        }
+        self.dirty = true;
+        // The provider field is an ordered priority now and opens the reorder
+        // modal, not the chooser, so the fields this commits are the two model
+        // choices on the advanced screen - the concurrency-follows-provider
+        // adjustment lives in `commit_reorder`.
+    }
+}

--- a/crates/leviath-cli/src/commands/setup/state/priority.rs
+++ b/crates/leviath-cli/src/commands/setup/state/priority.rs
@@ -27,7 +27,7 @@ impl Wizard {
         self.reorder_field = field;
         self.reorder = Some(Reorder::new(
             "Provider priority",
-            Self::precedence_explanation(true)
+            self.picker_explanation(Self::PROVIDER_FIELD)
                 .into_iter()
                 .take(2)
                 .map(str::to_string)

--- a/docs/design/setup-wizard.md
+++ b/docs/design/setup-wizard.md
@@ -126,8 +126,8 @@ stateDiagram-v2
 | **Welcome** | Reports what is already configured, how many blueprints need installing, how many MCP servers were found elsewhere. |
 | **Providers** | Multi-select. Pre-checked for anything already configured or supplied by the environment. |
 | **Credentials** | One card per selected provider: masked key entry, Ollama base URL, Claude Code effort. `o` opens the signup page, `v` re-checks, `Ctrl-R` reveals. |
-| **Defaults** | `default_provider` as a radio over what was actually selected. `override_model` filled from what verification reported. Request timeout. |
-| **Limits** | Concurrency, iteration ceiling, exact token counting, the batch-tool hint. |
+| **Defaults** | `default_provider` as a radio over what was actually selected. Request timeout. A toggle for the advanced screen. |
+| **Limits** | Concurrency, iteration ceiling, exact token counting, the batch-tool hint, and the two model settings: `override_model` and `fallback_model`, each a chooser filled from what verification reported with "(each blueprint decides)" as the unset option. |
 | **Agents** | The ten embedded blueprints, each showing `install` / `update X → Y` / `up to date`. Changes pre-checked. |
 | **MCP servers** | Grouped by harness, with the project scope, name collisions, and inline secrets flagged. |
 | **Review** | A diff against the current file, plus warnings, then write. |


### PR DESCRIPTION
The wizard half of #795, following #796. That PR split `default_model` into `override_model` and `fallback_model` and left the wizard's one model field on the Defaults screen, labelled Override model. Both settings belong with the things most people leave alone, so this moves them onto the advanced tuning screen.

## What changes

- **Defaults** asks for the provider priority, the request timeout and the advanced toggle. The model field is gone from it.
- **Limits** (the advanced screen) appends two choosers after its twelve tuning fields: "Override model" and "Fallback model", each with "(each blueprint decides)" as the unset option and the models every selected provider reported. They are rebuilt whenever the screen opens and whenever a late verification reply lands while it is open, keeping a choice already made. The override still seeds from an endpoint entry at the head of the priority, as it did on Defaults.
- `build_config` reads both by index (`OVERRIDE_FIELD`, `FALLBACK_FIELD`), so `apply_limits_fields` is untouched; `LIMITS_FIXED` names where the tuning fields end and a test pins it to the form.
- The picker explanation now has three texts, one each for the provider order (reached from the reorder modal), the override and the fallback, written against how `resolve.rs` reads each setting.
- `state/mod.rs` crossed the 1200-line cap, so the choosers (`picker_explanation`, `discovered_models`, `rebuild_advanced_models`, `chosen_model`, `open_picker`, the detail columns, `commit_picker`) live in `state/models.rs`.
- The design note and the CHANGELOG's Unreleased entry say where the fields are.

## Verified

- Setup tests updated to the new screen and indices; new tests cover both choices being written back and kept, the fixed-field count, a late reply refilling both choosers on Limits and rebuilding Defaults, and a picker commit landing on a screen with no fields.
- Gates: the hook's clippy line, the leviath-cli suite, `cargo xtask docs`, `cargo xtask structure`, and `cargo xtask coverage --package leviath-cli` at 100%.

The console update that reads the new API keys is GEMISIS/leviath.dev#148.
