### PR TITLE
chore(prices): refresh vendor list prices 2026-09-07

### DIFF
--- a/crates/leviath-providers/pricing/rates.toml
+++ b/crates/leviath-providers/pricing/rates.toml
@@ -7,7 +7,7 @@
 # `openrouter` or `litellm` when only one listed it, and `manual` for a row a
 # person wrote, which the refresh never overwrites.
 
-read_on = "2026-08-31"
+read_on = "2026-09-07"
 
 [[rate]]
 provider = "anthropic"
@@ -65,6 +65,15 @@ source = "both"
 
 [[rate]]
 provider = "anthropic"
+prefix = "claude-fable-5-1"
+input = 10.0
+cache_read = 0.25
+cache_write = 12.5
+output = 50.0
+source = "both"
+
+[[rate]]
+provider = "anthropic"
 prefix = "claude-haiku-4-5"
 input = 1.0
 cache_read = 0.1
@@ -77,6 +86,15 @@ provider = "anthropic"
 prefix = "claude-mythos-5"
 input = 10.0
 cache_read = 1.0
+cache_write = 12.5
+output = 50.0
+source = "litellm"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-mythos-5-1"
+input = 10.0
+cache_read = 0.25
 cache_write = 12.5
 output = 50.0
 source = "litellm"
@@ -408,6 +426,15 @@ source = "both"
 [[rate]]
 provider = "google"
 prefix = "gemini-3.7-flash"
+input = 0.75
+cache_read = 0.075
+cache_write = 0.75
+output = 3.75
+source = "both"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3.8-flash"
 input = 0.75
 cache_read = 0.075
 cache_write = 0.75
@@ -961,6 +988,15 @@ input = 2.0
 cache_read = 0.2
 cache_write = 2.5
 output = 12.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-6-astra"
+input = 10.0
+cache_read = 1.0
+cache_write = 12.5
+output = 50.0
 source = "both"
 
 [[rate]]


### PR DESCRIPTION
Weekly refresh of `crates/leviath-providers/pricing/rates.toml`
by `cargo xtask prices`. Auto-merges once the required checks pass.

```
+ anthropic/claude-fable-5-1: 10.0/0.25/12.5/50.0 (both)
+ anthropic/claude-mythos-5-1: 10.0/0.25/12.5/50.0 (litellm)
+ google/gemini-3.8-flash: 0.75/0.075/0.75/3.75 (both)
+ openai/gpt-6-astra: 10.0/1.0/12.5/50.0 (both)
? openai/gpt-5.6-sol: openrouter 2.0/0.2/2.5/10.0 vs litellm 4.0/0.4/5.0/20.0 (not written)
? codex: 'gpt-5.6-luna-pro' is listed by OpenAI and not in the catalog - does Codex serve it?
? codex: 'gpt-5.6-terra-pro' is listed by OpenAI and not in the catalog - does Codex serve it?
prices: 122 rows, 4 added, 0 changed, 1 disagreements; openrouter 102 models, litellm 145 models
prices: wrote 4 rows to /home/runner/work/leviath/leviath/crates/leviath-providers/pricing/rates.toml (read_on 2026-09-07)
```
