### PR TITLE
fix(perf-tools): close every file handle, and clear the CodeQL findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ plans/
 perf-tools/*.csv
 perf-tools/*.png
 
+# Python bytecode from running the perf-tools scripts
+__pycache__/
+

--- a/perf-tools/daemon_drive.py
+++ b/perf-tools/daemon_drive.py
@@ -54,7 +54,8 @@ def daemon_cpu_seconds():
     so `getrusage(RUSAGE_CHILDREN)` never sees it."""
     pid_file = os.path.join(os.environ["LEVIATH_HOME"], ".leviath", "daemon.pid")
     try:
-        pid = open(pid_file).read().strip().split()[0]
+        with open(pid_file, encoding="utf-8") as f:
+            pid = f.read().strip().split()[0]
         txt = subprocess.run(["ps", "-o", "cputime=", "-p", pid], capture_output=True, text=True).stdout.strip()
     except (OSError, IndexError):
         return None

--- a/perf-tools/dash_pty.py
+++ b/perf-tools/dash_pty.py
@@ -26,7 +26,6 @@ import json
 import os
 import pty
 import re
-import resource
 import select
 import signal
 import struct
@@ -93,6 +92,8 @@ def main():
                 try:
                     out.extend(os.read(fd, 1 << 16))
                 except OSError:
+                    # The pty's slave side is gone once the child exits; the
+                    # next wait4 collects it, so there is nothing to do here.
                     pass
         return None
     done = None
@@ -101,6 +102,8 @@ def main():
         try:
             step()
         except (OSError, ProcessLookupError):
+            # The child already left (closed pty, or no such pid): the reap
+            # below collects it, and a failed step is not an error.
             pass
         done = reap(2.0)
         if done:

--- a/perf-tools/mock.py
+++ b/perf-tools/mock.py
@@ -155,8 +155,8 @@ class Handler(BaseHTTPRequestHandler):
         else:
             message = {"role": "assistant", "content": "done"}
             finish = "stop"
-        self._json({"id": "c1", "object": "chat.completion", "model": "gpt-mock", "usage": USAGE,
-                    "choices": [{"index": 0, "finish_reason": finish, "message": message}]})
+        return self._json({"id": "c1", "object": "chat.completion", "model": "gpt-mock", "usage": USAGE,
+                           "choices": [{"index": 0, "finish_reason": finish, "message": message}]})
 
     def _anthropic(self, req):
         """The Anthropic Messages shape of the same decision, always buffered."""

--- a/perf-tools/puremove.py
+++ b/perf-tools/puremove.py
@@ -12,6 +12,11 @@ import subprocess, sys, collections, re
 ref, orig, news = sys.argv[1], sys.argv[2], sys.argv[3:]
 root = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True).stdout.strip()
 
+def read(path):
+    """The file's text, with the handle closed before returning."""
+    with open(f"{root}/{path}", encoding="utf-8") as f:
+        return f.read()
+
 def norm(line):
     l = line.strip()
     if not l or l.startswith("//") or l.startswith("use ") or l.startswith("mod ") or l.startswith("pub use") or l.startswith("pub(crate) use"):
@@ -22,19 +27,19 @@ def norm(line):
     return l
 
 before = subprocess.run(["git", "-C", root, "show", f"{ref}:{orig}"], capture_output=True, text=True).stdout.split("\n")
-after = open(f"{root}/{orig}").read().split("\n")
+after = read(orig).split("\n")
 removed = collections.Counter(filter(None, map(norm, before)))
 removed.subtract(collections.Counter(filter(None, map(norm, after))))
 removed = +removed  # lines the original lost
 added = collections.Counter()
-for n in news:
-    added.update(filter(None, map(norm, open(f"{root}/{n}").read().split("\n"))))
+new_texts = {n: read(n) for n in news}
+for txt in new_texts.values():
+    added.update(filter(None, map(norm, txt.split("\n"))))
 # The new files carry their own `impl X {` / `}` wrappers; drop one of each per file.
-for n in news:
+for txt in new_texts.values():
     for w in ("}", ):
         if added[w] > 0:
             added[w] -= 1
-    txt = open(f"{root}/{n}").read()
     for m in re.finditer(r"^impl \w+ \{$", txt, re.M):
         added[m.group(0)] -= 1
 added = +added

--- a/perf-tools/ws_churn_test.py
+++ b/perf-tools/ws_churn_test.py
@@ -51,6 +51,8 @@ def open_ws(host: str, port: int, path: str, timeout: float = 5.0) -> socket.soc
     try:
         sock.recv(4096)
     except socket.timeout:
+        # The handshake reply is optional: the test only needs the connection
+        # open on the server side, and a slow reply changes nothing below.
         pass
     return sock
 
@@ -62,6 +64,8 @@ def abrupt_close(sock: socket.socket) -> None:
             socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
         )
     except OSError:
+        # A socket the peer already reset refuses the option; closing it
+        # below is still the right thing, just without the forced reset.
         pass
     sock.close()
 


### PR DESCRIPTION
## What

Clears the twelve open CodeQL alerts.

**Ten Python findings in `perf-tools`, fixed in code:**

- `py/file-not-closed` (4): `puremove.py` and `daemon_drive.py` read files through a bare `open(...).read()`, leaving the handle to the garbage collector. Both now read through `with`, and `puremove.py` reads each new file once instead of twice.
- `py/unused-import`: `dash_pty.py` imported `resource` and never used it.
- `py/mixed-returns`: `do_POST` in `mock.py` mixed explicit and implicit returns; the last branch now returns like the others.
- `py/empty-except` (4): the `except: pass` arms in `dash_pty.py` and `ws_churn_test.py` now say why swallowing the error is right.

Also adds `__pycache__/` to `.gitignore`, since running these scripts leaves bytecode behind.

**Two Rust `unused-variable` notes on `lint/checks.rs`, dismissed as false positives.** Both variables are implicit `{name}` captures inside a `format!` literal that spans lines with backslash continuations. A two-function probe crate on CodeQL 2.26.4 shows the Rust extractor drops every capture from such a literal while seeing the same captures in a one-line literal. The explicit-argument rewrite that would hide it is forbidden by clippy's `uninlined_format_args`, so the alerts carry that reasoning in their dismissal comment.

## Verification

- `pyflakes perf-tools/*.py` is clean.
- `codeql database analyze` with the workflow's `python-security-and-quality` suite over `perf-tools`: zero results, with all four rules confirmed present in the suite.
- `puremove.py` smoke-tested against `origin/main`.
- A sweep of the Rust crates for `mem::forget`, `ManuallyDrop`, `into_raw_fd` and `Box::leak` found only test helpers on channel senders and in-memory duplex halves, no file handles.
