### PR TITLE
feat: finish typed-mime for 0.6.0 — token-bounded regions, byte media cap, modality refresh, mime write API (#400, #814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,13 @@ same list.
   reported under `limits`. Announced as `spawn.parts`, `messages.parts`,
   `runs.blobs`, `runs.files.raw`, `runs.result.artifacts` and
   `mime.registry` (#400).
+- The mime registry can be written over HTTP, not only read. `PUT /api/mime`
+  adds a row to `mime_types.toml` beside the config, or sets the fields sent
+  on the one already there, and `DELETE /api/mime?mime_type=` takes one out -
+  the same file and the same validation `lev mime add` and `lev mime remove`
+  use, so a console can create the custom type a region, a stage input or a
+  declared artifact names without handing the operator a block of TOML to
+  paste. Both need `--allow-admin` and are announced as `mime.write` (#814).
 - Files reach a run from the command line. `lev run --attach
   path[:region][:type][:text]` puts a file in a region as a typed part, a
   `--<region> @file` whose bytes are not text attaches instead of seeding,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,8 +115,9 @@ same list.
   `input_file`, and a Rhai provider the neutral `mime` block with the
   base64 in `data`; the Claude Code transport and every lane that does not
   hydrate send the stand-in. The journal and `context.json` never hold
-  base64. `[mime] max_stored_per_request` caps how many parts one request
-  carries, oldest dropped first (#400).
+  base64. `[mime] max_media_bytes_per_request` caps the bytes of stored media
+  one request carries, oldest sent as stand-ins first, a backstop for the
+  vendor request-size limits a token budget cannot see (#400).
 - Stages declare typed inputs and outputs. `[stages.<name>.input] accepts`
   states what a stage takes as parts (else the union of its visible regions'
   `accepts`), and `as_text` names types whose parts reach the model as text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,12 +86,12 @@ same list.
   grow by a file's size. What a type *is* comes from a mime registry rather
   than from code: the compiled defaults, then `[mime_types]` in the config,
   each row naming a family, whether the bytes are text, a token rule,
-  extensions, a magic prefix and a stand-in template. `[mime]` sets the size ceilings. `lev doctor`
-  reports a row that will not load. A region says what it takes with
-  `accepts = ["text/*", "image/png"]` and is bounded by its token budget; a
-  region with a `schema` takes text only. A snapshot or
-  journal written before this reads back unchanged, since a plain string is
-  still how a text-only entry is written (#400).
+  extensions, a magic prefix and a stand-in template, and `[mime]` sets the
+  size ceilings. `lev doctor` reports a row that will not load. A region says
+  what it takes with `accepts = ["text/*", "image/png"]` and is bounded by its
+  token budget; a region with a `schema` takes text only. A snapshot or journal
+  written before this reads back unchanged, since a plain string is still how a
+  text-only entry is written (#400).
 - Every model says what it takes and what it can hand back, as mime type
   patterns. The built-in tables know that Claude reads images and PDFs, that
   Gemini also takes audio and video, which OpenAI models see, hear or draw,
@@ -174,9 +174,8 @@ same list.
   `GET /api/mime` lists the effective mime registry. Both byte routes
   advertise `Accept-Ranges: bytes` and answer a single `Range` request with
   `206 Partial Content` and a `Content-Range`, so a client can scrub or
-  resume. `[serve]
-  max_upload_bytes` (32 MiB by default) bounds a request body and is
-  reported under `limits`. Announced as `spawn.parts`, `messages.parts`,
+  resume. `[serve] max_upload_bytes` (32 MiB by default) bounds a request
+  body and is reported under `limits`. Announced as `spawn.parts`, `messages.parts`,
   `runs.blobs`, `runs.files.raw`, `runs.result.artifacts` and
   `mime.registry` (#400).
 - The mime registry can be written over HTTP, not only read. `PUT /api/mime`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,8 +88,8 @@ same list.
   each row naming a family, whether the bytes are text, a token rule,
   extensions, a magic prefix and a stand-in template. `[mime]` sets the size ceilings. `lev doctor`
   reports a row that will not load. A region says what it takes with
-  `accepts = ["text/*", "image/png"]` and how many stored parts it holds with
-  `max_stored`; a region with a `schema` takes text only. A snapshot or
+  `accepts = ["text/*", "image/png"]` and is bounded by its token budget; a
+  region with a `schema` takes text only. A snapshot or
   journal written before this reads back unchanged, since a plain string is
   still how a text-only entry is written (#400).
 - Every model says what it takes and what it can hand back, as mime type
@@ -216,8 +216,7 @@ same list.
   share of the entry model's context window), each candidate shows its own token
   cost, and a file that would overflow the budget is refused with the reason.
   The run is stopped with a named error rather than started with a region that
-  cannot hold what it was given. A blueprint may still set a hard `max_stored`
-  count cap, which the picker honours (#400).
+  cannot hold what it was given (#400).
 - The stage graph shows the mime a stage takes beyond text (`◧ image/*
   audio/wav`, from its regions' `accepts` or its `[input] accepts`) and the
   files it declares it hands back (`▤ video/mp4`), in the explorer, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,9 +99,14 @@ same list.
   that from its `architecture` block and Ollama's `/api/show` from its
   `capabilities`; `[model_capabilities.<id>] input_types / output_types`
   correct both, and a Rhai provider declares `// @input_types` and
-  `// @output_types`. `lev models` shows a `MIME` column and takes
-  `--accepts image/png`, `lev models show` prints both lists, and
-  `GET /api/models` carries `input_types` and `output_types` (#400).
+  `// @output_types`. For the vendors whose APIs report nothing per model,
+  the precise lists live in a compiled table refreshed from OpenRouter's
+  catalogue by `cargo xtask modalities`, as `cargo xtask prices` refreshes
+  list prices, so a model that takes images but not PDFs is described as
+  such rather than by a whole-vendor guess. `lev models` shows a `MIME`
+  column and takes `--accepts image/png`, `lev models show` prints both
+  lists, and `GET /api/models` carries `input_types` and `output_types`
+  (#400).
 - A stored part reaches the model. Assembly emits a mime block per stored
   part beside a one-line stand-in that names it, and the inference lane
   fills the bytes in right before the request goes out: as the vendor's own

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "reviewer"
-version = "0.2.5"
+version = "0.2.6"
 description = "Code review agent - discover, scan, review the areas in parallel, then deep review and report, with error recovery and multi-provider fallback"
 entry_stage = "discover"
 
@@ -351,7 +351,7 @@ review_criteria = { kind = "pinned", budget = "2%", seed = "criteria", volatilit
 # `--attach before.png:screenshots --attach after.png:screenshots`, or a
 # `@path` in `--criteria`. Typed `image/*`, so a model that can see them does, and
 # one that cannot gets a stand-in naming each. Six at most; older ones go.
-screenshots     = { kind = "pinned", budget = "6%", seed = "screenshots", accepts = ["image/*"], max_stored = 6, volatility = "stable" }
+screenshots     = { kind = "pinned", budget = "6%", seed = "screenshots", accepts = ["image/*"], volatility = "stable" }
 # Pre-loaded on startup: architecture / conventions (missing files skipped).
 project_context = { kind = "pinned", budget = "4%", seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "CONVENTIONS.md", "CONTRIBUTING.md", "README.md"] }, volatility = "stable" }
 # Deterministic repo scan, run once at spawn (issue #108) - the discover stage

--- a/crates/leviath-cli/src/blueprint_edit/doc.rs
+++ b/crates/leviath-cli/src/blueprint_edit/doc.rs
@@ -403,8 +403,6 @@ pub(crate) struct RegionView {
     /// `accepts`: the mime type patterns the region takes; empty is
     /// anything.
     pub accepts: Vec<String>,
-    /// `max_stored`: the most stored parts it keeps across its entries.
-    pub max_stored: Option<u64>,
 }
 
 /// The layout a stage runs with.
@@ -811,7 +809,6 @@ fn region_view(name: &str, table: &dyn TableLike) -> RegionView {
             .unwrap_or_default()
             .to_string(),
         accepts: get_strings(table, "accepts"),
-        max_stored: get_int(table, "max_stored").and_then(|n| u64::try_from(n).ok()),
     }
 }
 

--- a/crates/leviath-cli/src/blueprint_edit/mime.rs
+++ b/crates/leviath-cli/src/blueprint_edit/mime.rs
@@ -2,8 +2,7 @@
 //! `[stages.<name>.input]` lists, the `[stages.<name>.output]` format and
 //! `[[artifacts]]` declarations, and the `[stages.<name>.tool_accepts]`
 //! table that says what each tool may be handed. What a region takes
-//! (`accepts`, `max_stored`) is a region key like any other and lives in
-//! `regions.rs`.
+//! (`accepts`) is a region key like any other and lives in `regions.rs`.
 
 use toml_edit::{Array, ArrayOfTables, InlineTable, Item, Table, TableLike, Value};
 

--- a/crates/leviath-cli/src/blueprint_edit/regions.rs
+++ b/crates/leviath-cli/src/blueprint_edit/regions.rs
@@ -60,8 +60,6 @@ pub(crate) enum RegionField {
     Description,
     /// `accepts`, typed as a list: commas or spaces between patterns.
     Accepts,
-    /// `max_stored`, at least 1.
-    MaxStored,
 }
 
 /// A value for a [`RegionField`].
@@ -213,9 +211,6 @@ impl ManifestDoc {
                 } else {
                     set_strings(table, "accepts", &list);
                 }
-            }
-            (RegionField::MaxStored, RegionValue::Number(n)) => {
-                set_or_remove_int(table, "max_stored", n.map(|n| n.max(1)));
             }
             (RegionField::Seed, RegionValue::Text(t)) => {
                 let is_table = table

--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -1251,16 +1251,8 @@ fn mime_keys_write_the_way_the_runtime_reads_them() {
         RegionValue::Text("Image/*, audio/wav image/*".into()),
     )
     .unwrap();
-    doc.set_region_field(
-        &s,
-        "shots",
-        RegionField::MaxStored,
-        RegionValue::Number(Some(0)),
-    )
-    .unwrap();
     let r = doc.region(None, "shots").unwrap();
     assert_eq!(r.accepts, ["image/*", "audio/wav"]);
-    assert_eq!(r.max_stored, Some(1));
     runtime_ok(&doc);
     doc.set_region_field(
         &s,
@@ -1269,15 +1261,8 @@ fn mime_keys_write_the_way_the_runtime_reads_them() {
         RegionValue::Text(" ".into()),
     )
     .unwrap();
-    doc.set_region_field(
-        &s,
-        "shots",
-        RegionField::MaxStored,
-        RegionValue::Number(None),
-    )
-    .unwrap();
     let r = doc.region(None, "shots").unwrap();
-    assert!(r.accepts.is_empty() && r.max_stored.is_none());
+    assert!(r.accepts.is_empty());
     assert!(!doc.to_toml().contains("accepts"), "{}", doc.to_toml());
     // The stage's input lists come and go with their table.
     assert_eq!(

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
@@ -1054,8 +1054,7 @@ impl Dashboard {
             | FieldId::RegionMaxTokens
             | FieldId::RegionMinTokens
             | FieldId::RegionMaxItems
-            | FieldId::RegionOverflow
-            | FieldId::RegionMaxStored => {
+            | FieldId::RegionOverflow => {
                 let value = match text.parse::<u64>() {
                     Ok(n) => Some(n),
                     Err(_) if text.is_empty() => None,

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
@@ -113,7 +113,6 @@ impl Dashboard {
             FieldId::RegionMinTokens => RegionField::MinTokens,
             FieldId::RegionMaxItems => RegionField::MaxItems,
             FieldId::RegionOverflow => RegionField::Overflow,
-            FieldId::RegionMaxStored => RegionField::MaxStored,
             _ => return false,
         };
         if let Some((scope, name)) = self.panel_region() {

--- a/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
@@ -151,8 +151,6 @@ pub(in crate::commands::dashboard) enum FieldId {
     RegionDescription,
     /// The mime type patterns the region takes (a chooser).
     RegionAccepts,
-    /// The most stored parts the region keeps.
-    RegionMaxStored,
     DeleteRegion,
     /// A region the stage reads, on its inputs tab; opens the region.
     IoRegionRow(String),
@@ -849,13 +847,6 @@ fn region_fields(doc: &ManifestDoc, scope: &RegionScope, name: &str) -> Vec<Fiel
             FieldValue::Row(list_or(&region.accepts, "any type")),
             "Mime type patterns the region takes: image/*, audio/wav. A write outside them \
              is refused with the list. Enter picks the types, x takes anything again.",
-        ),
-        Field::new(
-            FieldId::RegionMaxStored,
-            "Stored parts: keeps at most",
-            FieldValue::Number(region.max_stored),
-            "How many stored parts the region holds across its entries; past it the \
-             oldest goes. Empty is unbounded.",
         ),
         Field::new(
             FieldId::RegionRequired,

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -1004,13 +1004,6 @@ fn the_inputs_and_outputs_tab_picks_types_and_opens_files_in_a_window() {
     dash.handle_key(key(KeyCode::Char(' ')));
     dash.handle_key(key(KeyCode::Enter));
     assert_eq!(region(&mut dash).accepts, ["image/png"]);
-    goto(&mut dash, FieldId::RegionMaxStored);
-    dash.handle_key(key(KeyCode::Right));
-    assert_eq!(region(&mut dash).max_stored, Some(1));
-    dash.handle_key(key(KeyCode::Enter));
-    type_str(&mut dash, "2");
-    dash.handle_key(key(KeyCode::Enter));
-    assert_eq!(region(&mut dash).max_stored, Some(12));
     goto(&mut dash, FieldId::RegionAccepts);
     dash.handle_key(key(KeyCode::Char('x')));
     assert!(region(&mut dash).accepts.is_empty());

--- a/crates/leviath-cli/src/commands/dashboard/new_run_inputs.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run_inputs.rs
@@ -38,9 +38,6 @@ pub(super) struct NewRunInput {
     pub(super) accepts: Vec<String>,
     /// Whether the run refuses to start without it.
     pub(super) required: bool,
-    /// The most files the region holds, when the blueprint sets a hard count
-    /// cap. `None` means no count limit: the token budget is the only bound.
-    pub(super) max_stored: Option<usize>,
     /// The region's token budget, resolved against the entry model's context
     /// window. `0` means the region declares none, so no token limit applies.
     pub(super) max_tokens: usize,
@@ -81,11 +78,6 @@ impl NewRunInput {
         let mut bits: Vec<String> = Vec::new();
         if !self.accepts.is_empty() {
             bits.push(self.accepts.join(" "));
-        }
-        if let Some(n) = self.max_stored
-            && n > 1
-        {
-            bits.push(format!("up to {n}"));
         }
         if self.max_tokens > 0 {
             bits.push(format!("≤{} tok", compact_count(self.max_tokens)));
@@ -159,11 +151,10 @@ impl NewRunInput {
                     .unwrap_or_else(|| p.to_string_lossy().to_string())
             })
             .collect();
-        let count = match self.max_stored {
-            // A hard cap shows progress toward it; otherwise just how many.
-            Some(n) if n > 1 => format!(" ({}/{n})", self.files.len()),
-            _ if self.files.len() > 1 => format!(" ({})", self.files.len()),
-            _ => String::new(),
+        // More than one file shows the count; a single file just shows its name.
+        let count = match self.files.len() > 1 {
+            true => format!(" ({})", self.files.len()),
+            false => String::new(),
         };
         format!("{}{count}", names.join(", "))
     }
@@ -222,7 +213,6 @@ impl Dashboard {
                                 region: r.name.clone(),
                                 accepts: r.accepts.clone(),
                                 required: r.required,
-                                max_stored: r.max_stored,
                                 max_tokens: r.max_tokens,
                                 edit: LineEdit::new(String::new(), false),
                                 files: Vec::new(),
@@ -762,7 +752,6 @@ mod tests {
             region: "x".to_string(),
             accepts: Vec::new(),
             required: false,
-            max_stored: None,
             max_tokens: 0,
             edit: LineEdit::new(String::new(), false),
             files: Vec::new(),
@@ -803,13 +792,8 @@ mod tests {
         dash.new_run_inputs[0].files = vec![PathBuf::from("out/hero.png")];
         let text = screen(&mut dash);
         assert!(text.contains("hero.png"), "{text}");
-        // With a hard cap, the count shows progress toward it.
-        dash.new_run_inputs[0].max_stored = Some(3);
+        // Several files show a count.
         dash.new_run_inputs[0].files = vec![PathBuf::from("a.png"), PathBuf::from("b.png")];
-        let text = screen(&mut dash);
-        assert!(text.contains("(2/3)"), "{text}");
-        // With no cap, the chip shows just how many.
-        dash.new_run_inputs[0].max_stored = None;
         let text = screen(&mut dash);
         assert!(text.contains("(2)"), "{text}");
         // The notes slot takes anything, so text and a file chip sit together.

--- a/crates/leviath-cli/src/commands/dashboard/new_run_picker.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run_picker.rs
@@ -7,9 +7,8 @@
 //! tools are confined to, so the picker can never offer a file the run could
 //! not read. It is filtered to the region's `accepts`: a `pictures` region of
 //! `image/*` shows images, not the run's `notes.md`. Files are toggled on and
-//! off and each one's token cost is shown, so the limit is the region's token
-//! budget (its share of the model's context window), not an arbitrary count; a
-//! blueprint may still set a hard `max_stored` cap, which the picker honours.
+//! off and each one's token cost is shown, so the only limit is the region's
+//! token budget (its share of the model's context window), never a file count.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -52,9 +51,6 @@ pub(super) struct FilePicker {
     row: usize,
     /// The region's name, for the title.
     region: String,
-    /// A hard count cap the region declares, when it does; `None` means the
-    /// only limit is the token budget.
-    max_stored: Option<usize>,
     /// The region's token budget, resolved against the entry model's window.
     /// `0` means the region declares none, so no token limit is enforced.
     budget: usize,
@@ -99,10 +95,9 @@ impl FilePicker {
         self.chosen.values().sum()
     }
 
-    /// Toggle the highlighted file in or out of the choice. A one-file region
-    /// (`max_stored = 1`) swaps rather than adds. Otherwise the only limit is
-    /// the token budget, plus any hard count cap the region declares; a pick
-    /// that would exceed either is refused with the reason.
+    /// Toggle the highlighted file in or out of the choice. The only limit is
+    /// the region's token budget; a pick that would exceed it is refused with
+    /// the reason.
     fn toggle_highlighted(&mut self) {
         self.warn = None;
         let Some((path, tokens)) = self.highlighted().map(|f| (f.rel.clone(), f.tokens)) else {
@@ -110,17 +105,6 @@ impl FilePicker {
         };
         if self.chosen.remove(&path).is_some() {
             return;
-        }
-        match self.max_stored {
-            // A single-file region swaps the one it holds.
-            Some(1) => self.chosen.clear(),
-            // A region with a hard cap refuses past it.
-            Some(n) if self.chosen.len() >= n => {
-                self.warn = Some(format!("holds at most {n} files"));
-                return;
-            }
-            // Room under a cap, or no cap at all.
-            _ => {}
         }
         if self.budget > 0 && self.chosen_tokens() + tokens > self.budget {
             let left = self.budget.saturating_sub(self.chosen_tokens());
@@ -208,7 +192,6 @@ impl Dashboard {
         };
         let region = slot.region.clone();
         let accepts = slot.accepts.clone();
-        let max_stored = slot.max_stored;
         let budget = slot.max_tokens;
         let workdir = self.new_run_ctx.workdir.clone();
         let registry = cli_registry();
@@ -234,7 +217,6 @@ impl Dashboard {
         let mut picker = FilePicker {
             row,
             region,
-            max_stored,
             budget,
             files,
             filtered: Vec::new(),
@@ -307,13 +289,6 @@ impl Dashboard {
             width: popup.width.saturating_sub(2),
             height: popup.height.saturating_sub(2),
         };
-        // The count cap is named only when the region declares one; otherwise
-        // the token budget is the only limit and the title says so by omission.
-        let cap_note = match picker.max_stored {
-            Some(1) => "one file, ".to_string(),
-            Some(n) => format!("up to {n}, "),
-            None => String::new(),
-        };
         // The token line is the honest answer to "how many files fit": the
         // budget is the region's share of the model's context window.
         let budget_note = match picker.budget > 0 {
@@ -321,9 +296,8 @@ impl Dashboard {
             false => String::new(),
         };
         let title = format!(
-            " Choose files for {} ({}{} chosen{}) ",
+            " Choose files for {} ({} chosen{}) ",
             picker.region,
-            cap_note,
             picker.chosen.len(),
             budget_note,
         );
@@ -414,10 +388,7 @@ impl Dashboard {
                 Style::default().fg(C_WARN).add_modifier(Modifier::BOLD),
             )),
             None => Line::from(Span::styled(
-                match picker.max_stored {
-                    Some(1) => " Space choose (swaps) · Enter done · Esc cancel · type to filter ",
-                    _ => " Space add/remove · Enter done · Esc cancel · type to filter ",
-                },
+                " Space add/remove · Enter done · Esc cancel · type to filter ",
                 Style::default().fg(C_MUTED),
             )),
         };
@@ -463,10 +434,10 @@ mod tests {
              [stages.main.model]\nprovider = \"anthropic\"\nmodel = \"claude-sonnet-5\"\n\n\
              [context.regions]\n\
              task = { kind = \"pinned\", max_tokens = 1000, seed = \"task\" }\n\
-             cover = { kind = \"pinned\", max_tokens = 100000, seed = \"input\", accepts = [\"image/*\"], max_stored = 1 }\n\
-             gallery = { kind = \"pinned\", max_tokens = 100000, seed = \"input\", accepts = [\"image/*\"], max_stored = 3 }\n\
+             cover = { kind = \"pinned\", max_tokens = 100000, seed = \"input\", accepts = [\"image/*\"] }\n\
+             gallery = { kind = \"pinned\", max_tokens = 100000, seed = \"input\", accepts = [\"image/*\"] }\n\
              notes = { kind = \"pinned\", max_tokens = 1000, seed = \"input\", accepts = [\"text/*\"] }\n\
-             tight = { kind = \"pinned\", max_tokens = 1000, seed = \"input\", accepts = [\"image/*\"], max_stored = 4 }\n\
+             tight = { kind = \"pinned\", max_tokens = 1000, seed = \"input\", accepts = [\"image/*\"] }\n\
              stream = { kind = \"pinned\", max_tokens = 100000, seed = \"input\", accepts = [\"image/*\"] }\n\
              conversation = { kind = \"sliding_window\", max_items = 20, max_tokens = 10000 }\n",
         )
@@ -545,10 +516,10 @@ mod tests {
         assert_eq!(resolved.parts[0].region.as_deref(), Some("cover"));
     }
 
-    /// A many-file row toggles files with Space up to its cap, and Enter keeps
-    /// what was toggled.
+    /// A file row toggles several files with Space, Enter keeps them, and
+    /// re-opening pre-checks them so one can be toggled back off.
     #[test]
-    fn a_multi_file_row_toggles_up_to_the_cap() {
+    fn a_file_row_toggles_several() {
         let dir = tempfile::tempdir().unwrap();
         write_agent(&dir.path().join("agents").join("looker"));
         let mut dash = dash_at(dir.path());
@@ -562,7 +533,6 @@ mod tests {
         dash.new_run_input_selected = gallery;
         dash.handle_new_run_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
         assert!(dash.new_run_picker_open(), "Ctrl+O opens it");
-        assert_eq!(dash.new_run_picker.as_ref().unwrap().max_stored, Some(3));
         // Toggle both files on, then confirm.
         dash.handle_new_run_key(key(KeyCode::Char(' ')));
         dash.handle_new_run_key(key(KeyCode::Down));
@@ -577,52 +547,6 @@ mod tests {
         dash.handle_new_run_key(key(KeyCode::Char(' ')));
         dash.handle_new_run_key(key(KeyCode::Enter));
         assert_eq!(dash.new_run_inputs[gallery].files.len(), 1);
-    }
-
-    /// The cap holds: a fourth pick on a three-file region is ignored, and a
-    /// one-file region swaps rather than stacks.
-    #[test]
-    fn the_cap_and_the_single_swap_hold() {
-        let dir = tempfile::tempdir().unwrap();
-        write_agent(&dir.path().join("agents").join("looker"));
-        let mut dash = dash_at(dir.path());
-        std::fs::write(
-            dir.path().join("work").join("extra.png"),
-            b"\x89PNG\r\n\x1a\nc",
-        )
-        .unwrap();
-        std::fs::write(
-            dir.path().join("work").join("more.png"),
-            b"\x89PNG\r\n\x1a\nd",
-        )
-        .unwrap();
-        dash.open_new_run_screen();
-        // Single region: two picks leave one.
-        let cover = dash
-            .new_run_inputs
-            .iter()
-            .position(|s| s.region == "cover")
-            .unwrap();
-        dash.open_new_run_picker(cover);
-        let p = dash.new_run_picker.as_mut().unwrap();
-        p.toggle_highlighted();
-        p.selected = 1;
-        p.toggle_highlighted();
-        assert_eq!(p.chosen.len(), 1, "one-file region swaps");
-
-        // Many region caps at three however many are toggled.
-        let gallery = dash
-            .new_run_inputs
-            .iter()
-            .position(|s| s.region == "gallery")
-            .unwrap();
-        dash.open_new_run_picker(gallery);
-        let p = dash.new_run_picker.as_mut().unwrap();
-        for i in 0..p.filtered.len() {
-            p.selected = i;
-            p.toggle_highlighted();
-        }
-        assert_eq!(p.chosen.len(), 3, "capped at max_stored");
     }
 
     /// The modal draws its title, the tick boxes and the footer.
@@ -644,7 +568,7 @@ mod tests {
             .collect();
         assert!(text.contains("Choose files for cover"), "{text}");
         assert!(text.contains("hero.png"), "{text}");
-        assert!(text.contains("Space choose"), "{text}");
+        assert!(text.contains("Space add/remove"), "{text}");
         assert!(text.contains("Enter done"), "{text}");
         // Filtering narrows the list.
         dash.handle_new_run_key(key(KeyCode::Char('v')));
@@ -703,8 +627,8 @@ mod tests {
         assert!(dash.new_run_picker.as_ref().unwrap().chosen.is_empty());
     }
 
-    /// A multi-file picker draws its tick boxes, its cap in the title, the
-    /// active filter, and its footer; an empty match says so.
+    /// A multi-file picker draws its tick boxes, the active filter, and its
+    /// footer; an empty match says so.
     #[test]
     fn the_multi_picker_draws_every_part() {
         let dir = tempfile::tempdir().unwrap();
@@ -718,11 +642,10 @@ mod tests {
             .unwrap();
         dash.open_new_run_picker(gallery);
         // Choose one, leave one, and render: [x] and [ ] both appear, with the
-        // cap in the title and the multi-file footer.
+        // multi-file footer.
         dash.handle_new_run_key(key(KeyCode::Char(' ')));
         let text = draw(&mut dash);
         assert!(text.contains("Choose files for gallery"), "{text}");
-        assert!(text.contains("up to 3"), "{text}");
         assert!(text.contains("[x]"), "{text}");
         assert!(text.contains("[ ]"), "{text}");
         assert!(text.contains("Space add/remove"), "{text}");
@@ -852,7 +775,6 @@ mod tests {
             .iter()
             .position(|s| s.region == "stream")
             .unwrap();
-        assert_eq!(dash.new_run_inputs[stream].max_stored, None);
         dash.open_new_run_picker(stream);
         // Toggle both images on: no count cap stops them.
         dash.handle_new_run_key(key(KeyCode::Char(' ')));

--- a/crates/leviath-cli/src/commands/dashboard/new_run_picker.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run_picker.rs
@@ -762,6 +762,37 @@ mod tests {
         assert!(tokens <= 1, "a missing file costs about nothing: {tokens}");
     }
 
+    /// The picker's pre-flight token estimate and what the daemon charges a
+    /// part at ingest are one calculation - `TokenRule::estimate` over the
+    /// type's rule with the probed dimensions - so the budget the picker shows,
+    /// the tokens the HTTP blob listing serves and what the region accounts for
+    /// all agree. This pins the TUI path to the ingest path on a real PNG,
+    /// whose dimensions both read from the header.
+    #[test]
+    fn the_picker_estimate_matches_the_ingest_charge() {
+        use leviath_core::mime::{Blob, MimeType};
+        let dir = tempfile::tempdir().unwrap();
+        let reg = crate::commands::run::attach::cli_registry();
+        // A valid PNG header carrying 640x480 in its IHDR, then some body.
+        let mut png = b"\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR".to_vec();
+        png.extend_from_slice(&640u32.to_be_bytes());
+        png.extend_from_slice(&480u32.to_be_bytes());
+        png.extend_from_slice(b"the rest of the file bytes");
+        let path = dir.path().join("hero.png");
+        std::fs::write(&path, &png).unwrap();
+
+        // The picker's estimate, read from the file on disk.
+        let picker = estimate_file_tokens(&path, &reg);
+        // What the daemon charges the same bytes at ingest, which is the value
+        // the HTTP blob listing (`blob.tokens`) and the region budget then use.
+        let ingest = Blob::new(MimeType::parse("image/png").unwrap(), png)
+            .describe(&reg)
+            .tokens;
+        assert_eq!(picker, ingest, "picker {picker} vs ingest {ingest}");
+        // The real per-pixel estimate, not the cap an unprobed image falls to.
+        assert!(picker > 1 && picker < 1600, "probed, not the cap: {picker}");
+    }
+
     /// A region with no count cap takes as many files as the budget allows, and
     /// its title names no count, only the token line. Each row shows its tokens.
     #[test]

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -212,6 +212,13 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // `GET /api/mime`: the effective mime registry and where each row
     // came from.
     "mime.registry",
+    // `PUT /api/mime` and `DELETE /api/mime`: write a row into
+    // `mime_types.toml` or take one out. Admin-gated, so announced whether or
+    // not `--allow-admin` was passed - the same narrower promise as the other
+    // admin routes, that this build has them, not that this daemon mounts
+    // them. A console offers "New type..." where it will land, and knows
+    // to fall back to handing over the TOML where it will not.
+    "mime.write",
     "runs.stages",
     // `cost_usd`, `unpriced_calls` and `cost_is_exact` on each stage record, and
     // the `visits` split beneath them. Without the price a console drawing a

--- a/crates/leviath-cli/src/commands/serve/mime.rs
+++ b/crates/leviath-cli/src/commands/serve/mime.rs
@@ -1,0 +1,326 @@
+//! Writing a mime row over the API.
+//!
+//! `GET /api/mime` (in [`super::blobs`]) reads the effective registry, but
+//! nothing wrote to it, so a console could show a custom type and never make
+//! one - and a custom type is the point of the registry: the family, token
+//! rule, extensions and check that lift a format Leviath has never heard of
+//! out of behaving like `application/octet-stream`. `PUT /api/mime` adds or
+//! updates a row and `DELETE /api/mime` takes one out, both admin-gated and
+//! both writing `mime_types.toml` beside the config - the same file and the
+//! same validation `lev mime add` and `lev mime remove` use, so the rows the
+//! browser writes and the rows the operator writes are one set in one place.
+
+use axum::Json;
+use axum::extract::Query;
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
+
+use leviath_core::mime::MimeType;
+
+use super::types::*;
+use crate::commands::mime_rows::{Added, RowEdit, TokenSpec, add_row, remove_row};
+
+/// A token rule as JSON: exactly one of the four rates, `max` only beside
+/// `per_pixel`, the shape a `[mime_types]` row's `tokens` table takes.
+#[derive(Debug, Deserialize)]
+pub(super) struct TokenRuleReq {
+    /// `{ per_byte = 0.25 }`.
+    per_byte: Option<f64>,
+    /// `{ per_pixel = 750 }`, with an optional `max`.
+    per_pixel: Option<i64>,
+    /// `{ per_second = 32 }`.
+    per_second: Option<i64>,
+    /// `{ fixed = 1000 }`.
+    fixed: Option<i64>,
+    /// The cap, only alongside `per_pixel`.
+    max: Option<i64>,
+}
+
+impl TokenRuleReq {
+    /// The rule this describes, or the reason it is not one.
+    fn into_spec(self) -> Result<TokenSpec, String> {
+        let named = [
+            self.per_byte.is_some(),
+            self.per_pixel.is_some(),
+            self.per_second.is_some(),
+            self.fixed.is_some(),
+        ]
+        .iter()
+        .filter(|set| **set)
+        .count();
+        if named != 1 {
+            return Err("name exactly one of per_byte, per_pixel, per_second, fixed".into());
+        }
+        if self.max.is_some() && self.per_pixel.is_none() {
+            return Err("max only goes with per_pixel".into());
+        }
+        if let Some(rate) = self.per_byte {
+            Ok(TokenSpec::PerByte(rate))
+        } else if let Some(divisor) = self.per_pixel {
+            Ok(TokenSpec::PerPixel {
+                divisor,
+                max: self.max,
+            })
+        } else if let Some(rate) = self.per_second {
+            Ok(TokenSpec::PerSecond(rate))
+        } else {
+            Ok(TokenSpec::Fixed(self.fixed.unwrap_or_default()))
+        }
+    }
+}
+
+/// Body of `PUT /api/mime`: the type to write and the fields to set on its row,
+/// each field optional so a caller changes only what it names.
+#[derive(Debug, Deserialize)]
+pub(super) struct MimeRowReq {
+    /// `type/subtype`, or `type/*` for a whole family.
+    mime_type: String,
+    /// `family`.
+    family: Option<String>,
+    /// `text`.
+    text: Option<bool>,
+    /// `tokens`.
+    tokens: Option<TokenRuleReq>,
+    /// `extensions`.
+    extensions: Option<Vec<String>>,
+    /// `magic`, a hex prefix.
+    magic: Option<String>,
+    /// `stand_in` template.
+    stand_in: Option<String>,
+    /// `check`, a Rhai script path; an empty string lifts a broader row's check.
+    check: Option<String>,
+}
+
+/// What `PUT /api/mime` answers with.
+#[derive(Debug, Serialize)]
+pub(super) struct MimeRowWritten {
+    /// The type the row is for, as it was parsed.
+    mime_type: String,
+    /// Whether the row was new, rather than an update of one already there.
+    created: bool,
+}
+
+/// Query for `DELETE /api/mime`: the type to take out.
+#[derive(Debug, Deserialize)]
+pub(super) struct DeleteMimeQuery {
+    /// `type/subtype` or `type/*`.
+    mime_type: String,
+}
+
+/// The operator's `mime_types.toml`, beside the config this process edits.
+fn mime_types_path() -> std::path::PathBuf {
+    super::mcp::admin_paths()
+        .config
+        .with_file_name("mime_types.toml")
+}
+
+/// `PUT /api/mime` (admin-only): add a row to `mime_types.toml`, or set the
+/// given fields on the one already there. Validated the way `lev mime add` is -
+/// a bad type, a bad token rule, or a `check` that will not compile is a 400
+/// and nothing is written.
+pub(super) async fn put_mime_row(
+    Json(req): Json<MimeRowReq>,
+) -> Result<Json<MimeRowWritten>, ApiError> {
+    let key = MimeType::parse(&req.mime_type)
+        .map_err(|e| err(StatusCode::BAD_REQUEST, format!("{}: {e}", req.mime_type)))?;
+    let tokens = match req.tokens {
+        Some(t) => Some(t.into_spec().map_err(|e| err(StatusCode::BAD_REQUEST, e))?),
+        None => None,
+    };
+    let edit = RowEdit {
+        family: req.family,
+        text: req.text,
+        tokens,
+        extensions: req.extensions,
+        magic: req.magic,
+        stand_in: req.stand_in,
+        check: req.check,
+    };
+    let path = mime_types_path();
+    let added = add_row(&path, key.as_str(), &edit).map_err(|e| err(StatusCode::BAD_REQUEST, e))?;
+    Ok(Json(MimeRowWritten {
+        mime_type: key.as_str().to_string(),
+        created: added == Added::Created,
+    }))
+}
+
+/// `DELETE /api/mime?mime_type=...` (admin-only): take a row out of
+/// `mime_types.toml`. A type that has no row there is a 404.
+pub(super) async fn delete_mime_row(
+    Query(q): Query<DeleteMimeQuery>,
+) -> Result<StatusCode, ApiError> {
+    let key = MimeType::parse(&q.mime_type)
+        .map_err(|e| err(StatusCode::BAD_REQUEST, format!("{}: {e}", q.mime_type)))?;
+    let path = mime_types_path();
+    remove_row(&path, key.as_str()).map_err(|e| err(StatusCode::NOT_FOUND, e))?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::serve::mcp::{AdminPaths, scoped};
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::put;
+    use tower::ServiceExt;
+
+    /// A router mounting the two write handlers, scoped to a `mime_types.toml`
+    /// beside `config` so `admin_paths()` resolves there.
+    fn app(config: std::path::PathBuf) -> Router {
+        let paths = AdminPaths {
+            store: config.with_file_name("mcp-auth.json"),
+            grants: config.with_file_name("provider-auth.json"),
+            config,
+        };
+        scoped(
+            Router::new().route("/api/mime", put(put_mime_row).delete(delete_mime_row)),
+            paths,
+        )
+    }
+
+    async fn put_row(dir: &std::path::Path, body: serde_json::Value) -> StatusCode {
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/mime")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        app(dir.join("config.toml"))
+            .oneshot(req)
+            .await
+            .unwrap()
+            .status()
+    }
+
+    async fn delete_row(dir: &std::path::Path, mime_type: &str) -> StatusCode {
+        let req = Request::builder()
+            .method("DELETE")
+            .uri(format!("/api/mime?mime_type={mime_type}"))
+            .body(Body::empty())
+            .unwrap();
+        app(dir.join("config.toml"))
+            .oneshot(req)
+            .await
+            .unwrap()
+            .status()
+    }
+
+    #[tokio::test]
+    async fn a_row_is_written_then_updated_then_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        // Created: a new row with every field kind, a per_pixel rule with a cap.
+        let status = put_row(
+            dir.path(),
+            serde_json::json!({
+                "mime_type": "application/x-acme-scene",
+                "family": "model",
+                "text": false,
+                "tokens": { "per_pixel": 750, "max": 1600 },
+                "extensions": ["scene"],
+                "magic": "41434D45",
+                "stand_in": "[{type} {size}] {name}"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let file = std::fs::read_to_string(dir.path().join("mime_types.toml")).unwrap();
+        assert!(file.contains("x-acme-scene") && file.contains("per_pixel"));
+
+        // Updated: the same key again is a 200 that says it was not created.
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/mime")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::json!({ "mime_type": "application/x-acme-scene", "text": true })
+                    .to_string(),
+            ))
+            .unwrap();
+        let resp = app(dir.path().join("config.toml"))
+            .oneshot(req)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let written: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(written["created"], false);
+
+        // Removed, then removing again is a 404.
+        assert_eq!(
+            delete_row(dir.path(), "application/x-acme-scene").await,
+            StatusCode::NO_CONTENT
+        );
+        assert_eq!(
+            delete_row(dir.path(), "application/x-acme-scene").await,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn each_token_rule_shape_is_accepted() {
+        let dir = tempfile::tempdir().unwrap();
+        for (i, tokens) in [
+            serde_json::json!({ "per_byte": 0.25 }),
+            serde_json::json!({ "per_second": 32 }),
+            serde_json::json!({ "fixed": 1000 }),
+            serde_json::json!({ "per_pixel": 750 }),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let status = put_row(
+                dir.path(),
+                serde_json::json!({ "mime_type": format!("model/x-{i}"), "tokens": tokens }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "rule {i}");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_bad_type_a_bad_rule_and_a_bad_magic_are_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        // A type that is not `type/subtype`.
+        assert_eq!(
+            put_row(dir.path(), serde_json::json!({ "mime_type": "notamime" })).await,
+            StatusCode::BAD_REQUEST
+        );
+        // A token rule that names none of the four.
+        assert_eq!(
+            put_row(
+                dir.path(),
+                serde_json::json!({ "mime_type": "model/x", "tokens": { "max": 5 } })
+            )
+            .await,
+            StatusCode::BAD_REQUEST
+        );
+        // `max` without `per_pixel`.
+        assert_eq!(
+            put_row(
+                dir.path(),
+                serde_json::json!({ "mime_type": "model/x", "tokens": { "per_byte": 0.1, "max": 5 } })
+            )
+            .await,
+            StatusCode::BAD_REQUEST
+        );
+        // A row whose `check` names a script that will not compile fails the
+        // same validation `lev mime add` runs, so nothing is written.
+        assert_eq!(
+            put_row(
+                dir.path(),
+                serde_json::json!({ "mime_type": "model/x", "magic": "nothex" })
+            )
+            .await,
+            StatusCode::BAD_REQUEST
+        );
+        // A malformed type on delete is a 400 before the file is touched.
+        assert_eq!(
+            delete_row(dir.path(), "notamime").await,
+            StatusCode::BAD_REQUEST
+        );
+    }
+}

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -17,6 +17,7 @@ mod events;
 mod fs;
 mod interactions;
 mod mcp;
+mod mime;
 mod polling;
 mod providers;
 mod request_limits;
@@ -505,6 +506,14 @@ async fn execute_with_shutdown(
             // A yolo profile is a grant of permissions, so writing the file is
             // the same category of act as writing the config.
             .route("/api/yolo", put(yolo::put_profiles))
+            // Writing a mime row rewrites `mime_types.toml` beside the config,
+            // the same category of act, and gated the same way: the read half
+            // (`GET /api/mime`) is always mounted, these writes need
+            // `--allow-admin`, and a client learns that from the capability.
+            .route(
+                "/api/mime",
+                put(mime::put_mime_row).delete(mime::delete_mime_row),
+            )
             // The probe makes this host open a connection to any address the
             // caller names, the same act as testing an MCP server, and it
             // exists to precede the write above. Gated with it; there is no
@@ -852,6 +861,7 @@ mod tests {
         ("fs", include_str!("fs.rs")),
         ("interactions", include_str!("interactions.rs")),
         ("mcp", include_str!("mcp.rs")),
+        ("mime", include_str!("mime.rs")),
         ("providers", include_str!("providers.rs")),
         ("runs", include_str!("runs.rs")),
         ("scripts", include_str!("scripts.rs")),

--- a/crates/leviath-cli/src/config/mime.rs
+++ b/crates/leviath-cli/src/config/mime.rs
@@ -130,17 +130,20 @@ pub(crate) const DEFAULT_MAX_PART_BYTES: u64 = 32 * 1024 * 1024;
 /// Bytes of text a part may carry inline before it is stored like a blob.
 pub(crate) const DEFAULT_INLINE_TEXT_BYTES: u64 = 1024 * 1024;
 
-/// Stored parts one model request may carry before the oldest are dropped.
-pub(crate) const DEFAULT_MAX_STORED_PER_REQUEST: usize = 100;
+/// Bytes of stored media one model request may carry before the oldest are
+/// sent as stand-ins instead.
+pub(crate) const DEFAULT_MAX_MEDIA_BYTES_PER_REQUEST: u64 = 64 * 1024 * 1024;
 
 /// `[mime]` in `~/.leviath/config.toml`.
 ///
 /// Three ceilings on typed content. `max_part_bytes` is applied wherever a
 /// part arrives: an upload, a tool result, a `read_file`, a model reply.
 /// `inline_text_bytes` is where a text part stops travelling inside the entry
-/// and is stored by hash like any other. `max_stored_per_request` bounds how
-/// many stored parts one request carries, because every vendor has a cap of
-/// its own and the oldest are the ones to drop.
+/// and is stored by hash like any other. `max_media_bytes_per_request` bounds
+/// the bytes of stored media one request carries, a backstop for the vendor
+/// request-size limits that a token budget cannot see: a token estimate for an
+/// image is a few thousand tokens whatever its byte size, so a request can sit
+/// inside its context window and still be megabytes of media on the wire.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MimeConfig {
     /// Bytes one part may be. Larger is refused where it arrives.
@@ -151,10 +154,10 @@ pub struct MimeConfig {
     #[serde(default = "default_inline_text_bytes")]
     pub inline_text_bytes: u64,
 
-    /// Stored parts one model request carries; the oldest beyond it are
-    /// dropped with a warning.
-    #[serde(default = "default_max_stored_per_request")]
-    pub max_stored_per_request: usize,
+    /// Bytes of stored media one request carries; past it the oldest parts are
+    /// sent as their stand-ins with a warning.
+    #[serde(default = "default_max_media_bytes_per_request")]
+    pub max_media_bytes_per_request: u64,
 }
 
 fn default_max_part_bytes() -> u64 {
@@ -165,8 +168,8 @@ fn default_inline_text_bytes() -> u64 {
     DEFAULT_INLINE_TEXT_BYTES
 }
 
-fn default_max_stored_per_request() -> usize {
-    DEFAULT_MAX_STORED_PER_REQUEST
+fn default_max_media_bytes_per_request() -> u64 {
+    DEFAULT_MAX_MEDIA_BYTES_PER_REQUEST
 }
 
 impl Default for MimeConfig {
@@ -174,7 +177,7 @@ impl Default for MimeConfig {
         Self {
             max_part_bytes: DEFAULT_MAX_PART_BYTES,
             inline_text_bytes: DEFAULT_INLINE_TEXT_BYTES,
-            max_stored_per_request: DEFAULT_MAX_STORED_PER_REQUEST,
+            max_media_bytes_per_request: DEFAULT_MAX_MEDIA_BYTES_PER_REQUEST,
         }
     }
 }
@@ -594,7 +597,7 @@ mod tests {
         assert_eq!(parsed, MimeConfig::default());
         assert_eq!(parsed.max_part_bytes, 32 * 1024 * 1024);
         assert_eq!(parsed.inline_text_bytes, 1024 * 1024);
-        assert_eq!(parsed.max_stored_per_request, 100);
+        assert_eq!(parsed.max_media_bytes_per_request, 64 * 1024 * 1024);
     }
 
     #[test]
@@ -603,10 +606,10 @@ mod tests {
         assert_eq!(parsed.max_part_bytes, 5);
         assert_eq!(parsed.inline_text_bytes, DEFAULT_INLINE_TEXT_BYTES);
         let parsed: MimeConfig =
-            toml::from_str("inline_text_bytes = 7\nmax_stored_per_request = 2\n").unwrap();
+            toml::from_str("inline_text_bytes = 7\nmax_media_bytes_per_request = 2\n").unwrap();
         assert_eq!(parsed.inline_text_bytes, 7);
-        assert_eq!(parsed.max_stored_per_request, 2);
+        assert_eq!(parsed.max_media_bytes_per_request, 2);
         let back = toml::to_string(&parsed).unwrap();
-        assert!(back.contains("max_stored_per_request = 2"));
+        assert!(back.contains("max_media_bytes_per_request = 2"));
     }
 }

--- a/crates/leviath-cli/src/daemon/live_limits.rs
+++ b/crates/leviath-cli/src/daemon/live_limits.rs
@@ -146,7 +146,7 @@ impl LiveLimits {
         ecs.insert_resource(leviath_runtime::blob_store::MimeLimits {
             max_part_bytes: config.mime.max_part_bytes,
             inline_text_bytes: config.mime.inline_text_bytes,
-            max_stored_per_request: config.mime.max_stored_per_request,
+            max_media_bytes_per_request: config.mime.max_media_bytes_per_request,
         });
 
         // Read when a prompt opens, so a prompt already waiting keeps the

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -679,11 +679,6 @@ pub struct RegionDefinition {
     /// [`crate::region::Region::accepts`].
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub accepts: Vec<String>,
-
-    /// The most stored parts the region holds. See
-    /// [`crate::region::Region::max_stored`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_stored: Option<usize>,
 }
 
 impl RegionDefinition {
@@ -709,7 +704,6 @@ impl RegionDefinition {
             volatility: crate::region::Volatility::default(),
             seed: None,
             accepts: Vec::new(),
-            max_stored: None,
         }
     }
 

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -223,7 +223,6 @@ pub(super) fn parse_region_layout(
         // here so a typo is a load error and not a region that refuses every
         // write at runtime.
         let accepts = parse_accepts(region_name, region_value.get("accepts"))?;
-        let max_stored = count("max_stored")?;
 
         // Percentage regions contribute their (unknown) size at resolution, so
         // only absolute budgets add to the summed total here.
@@ -240,7 +239,6 @@ pub(super) fn parse_region_layout(
         def.describe_in_prompt = describe_in_prompt;
         def.volatility = volatility;
         def.accepts = accepts;
-        def.max_stored = max_stored;
         if let Some(f) = compact_at_field {
             def = def.with_compact_at(f);
         }
@@ -463,7 +461,6 @@ pub(super) const REGION_KEYS: &[&str] = &[
     "kind",
     "max_entries",
     "max_items",
-    "max_stored",
     "max_tokens",
     "min_tokens",
     "overflow",

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -2579,13 +2579,13 @@ mode = "autonomous"
 }
 
 #[test]
-fn parse_manifest_region_accepts_and_max_stored() {
+fn parse_manifest_region_accepts() {
     let toml = r#"
 [agent]
 name = "typed-regions"
 
 [context.regions]
-art = { kind = "pinned", accepts = ["Image/*", "text/plain"], max_stored = 4 }
+art = { kind = "pinned", accepts = ["Image/*", "text/plain"] }
 any = { kind = "pinned" }
 "#;
     let bp = parse_manifest(toml).unwrap();
@@ -2596,7 +2596,6 @@ any = { kind = "pinned" }
         .find(|r| r.name == "art")
         .unwrap();
     assert_eq!(art.accepts, vec!["image/*", "text/plain"]);
-    assert_eq!(art.max_stored, Some(4));
     let any = bp
         .context_layout
         .regions
@@ -2604,14 +2603,12 @@ any = { kind = "pinned" }
         .find(|r| r.name == "any")
         .unwrap();
     assert!(any.accepts.is_empty());
-    assert_eq!(any.max_stored, None);
 
     for (bad, needle) in [
         ("accepts = \"image/png\"", "expected a list"),
         ("accepts = [1]", "expected a mime type string"),
         ("accepts = [\"png\"]", "expected type/subtype or type/*"),
         ("accepts = [\"a b/*\"]", "expected type/subtype or type/*"),
-        ("max_stored = -1", "max_stored must not be negative"),
     ] {
         let toml = format!(
             "[agent]\nname = \"typed-regions\"\n\n[context.regions]\nart = {{ kind = \"pinned\", {bad} }}\n"

--- a/crates/leviath-core/src/region/mod.rs
+++ b/crates/leviath-core/src/region/mod.rs
@@ -453,12 +453,6 @@ pub struct Region {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub accepts: Vec<String>,
 
-    /// The most stored parts this region holds across its entries. Past it,
-    /// the oldest entry carrying one is evicted, or the write is refused
-    /// under [`Admission::Reject`]. `None` is unbounded.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_stored: Option<usize>,
-
     /// One line on what this region is for.
     ///
     /// Documentation first: it is what `GET /api/blueprints/{name}` reports and
@@ -501,7 +495,6 @@ impl Region {
             admission: Admission::default(),
             volatility: Volatility::default(),
             accepts: Vec::new(),
-            max_stored: None,
             description: None,
             describe_in_prompt: false,
         }
@@ -526,18 +519,6 @@ impl Region {
     /// How many stored parts the region holds across every entry.
     pub fn stored_count(&self) -> usize {
         self.content.iter().map(|e| e.content.stored_count()).sum()
-    }
-
-    /// Drop the oldest entries carrying stored parts until `excess` stored
-    /// parts are gone. Tokens and taint follow the entries out.
-    fn evict_oldest_stored(&mut self, mut excess: usize) {
-        while excess > 0 {
-            let Some(idx) = self.content.iter().position(|e| e.content.has_stored()) else {
-                return;
-            };
-            excess = excess.saturating_sub(self.content[idx].content.stored_count());
-            self.remove_at(idx);
-        }
     }
 
     /// Enable taint tracking for this region.
@@ -599,30 +580,6 @@ impl Region {
                 ),
             });
         }
-        if let Some(max) = self.max_stored
-            && content.has_stored()
-        {
-            let incoming = content.stored_count();
-            if incoming > max {
-                return Err(crate::error::Error::RegionRefusedWrite {
-                    region: self.name.clone(),
-                    reason: format!(
-                        "it holds at most {max} stored parts and this write carries {incoming}"
-                    ),
-                });
-            }
-            let over = (self.stored_count() + incoming).saturating_sub(max);
-            if over > 0 {
-                if self.admission == Admission::Reject {
-                    return Err(crate::error::Error::RegionRefusedWrite {
-                        region: self.name.clone(),
-                        reason: format!("it already holds {max} stored parts; release one first"),
-                    });
-                }
-                self.evict_oldest_stored(over);
-            }
-        }
-
         if self.current_tokens + tokens > self.max_tokens {
             // Which failure this is depends on whether anything would have been
             // dropped to fit. A region that never evicts reports being full,

--- a/crates/leviath-core/src/region/parts.rs
+++ b/crates/leviath-core/src/region/parts.rs
@@ -429,59 +429,6 @@ mod tests {
     }
 
     #[test]
-    fn max_stored_evicts_the_oldest_stored_entry_or_refuses() {
-        use crate::region::{Admission, Region, RegionKind};
-        let mut region = Region::new("sprites".into(), RegionKind::Temporary, 10_000);
-        region.max_stored = Some(2);
-        region
-            .add_entry(EntryContent::text("just text"), 1)
-            .unwrap();
-        region
-            .add_entry(EntryContent::from_parts(vec![stored("a.png")]), 5)
-            .unwrap();
-        region
-            .add_entry(EntryContent::from_parts(vec![stored("b.png")]), 5)
-            .unwrap();
-        assert_eq!(region.stored_count(), 2);
-        region
-            .add_entry(EntryContent::from_parts(vec![stored("c.png")]), 5)
-            .unwrap();
-        assert_eq!(region.stored_count(), 2);
-        assert_eq!(region.content.len(), 3, "the text entry stays; a.png went");
-        assert_eq!(region.current_tokens, 11);
-        let names: Vec<_> = region
-            .content
-            .iter()
-            .flat_map(|e| e.content.parts().iter().filter_map(|p| p.name.clone()))
-            .collect();
-        assert_eq!(names, vec!["b.png", "c.png"]);
-        let too_many = region
-            .add_entry(
-                EntryContent::from_parts(vec![stored("d.png"), stored("e.png"), stored("f.png")]),
-                5,
-            )
-            .unwrap_err();
-        assert!(too_many.to_string().contains("at most 2"), "{too_many}");
-        region.admission = Admission::Reject;
-        let refused = region
-            .add_entry(EntryContent::from_parts(vec![stored("g.png")]), 5)
-            .unwrap_err();
-        assert!(
-            refused.to_string().contains("release one first"),
-            "{refused}"
-        );
-        assert_eq!(region.stored_count(), 2);
-        region
-            .add_entry(EntryContent::text("text still lands"), 1)
-            .unwrap();
-        // Asked to shed more than it holds, the eviction stops at the last
-        // stored entry rather than looping.
-        region.evict_oldest_stored(10);
-        assert_eq!(region.stored_count(), 0);
-        assert_eq!(region.content.len(), 2, "text entries stay");
-    }
-
-    #[test]
     fn a_region_with_a_schema_takes_text_only() {
         use crate::region::schema::{ContentFormat, RegionSchema};
         use crate::region::{Region, RegionKind};

--- a/crates/leviath-providers/mime/modalities.toml
+++ b/crates/leviath-providers/mime/modalities.toml
@@ -1,0 +1,740 @@
+# Published input and output modalities for the providers whose APIs do not
+# report them per model. Read by `leviath_providers::mime_tables` (longest
+# matching `prefix` wins) and rewritten by `cargo xtask modalities`, which takes
+# the lists from OpenRouter's catalogue architecture block.
+#
+# `source` records where a row came from: `openrouter` for a row the refresh
+# wrote, and `manual` for a row a person wrote, which the refresh never
+# overwrites. A model no row matches falls to the name heuristic in
+# `mime_tables`, which is the floor these rows lift.
+
+read_on = "2026-09-11"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-3-haiku"
+input = ["text/*", "image/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-fable-5"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-fable-5-1"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-haiku-4-5"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-opus-4"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-opus-4-1"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-opus-4-5"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-opus-4-6"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-opus-4-7"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-opus-4-8"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-opus-5"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-sonnet-4"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-sonnet-4-5"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-sonnet-4-6"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "anthropic"
+prefix = "claude-sonnet-5"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-2.5-flash"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-2.5-flash-image"
+input = ["text/*", "image/*"]
+output = ["text/*", "image/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-2.5-flash-lite"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-2.5-pro"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-2.5-pro-preview"
+input = ["text/*", "image/*", "audio/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-2.5-pro-preview-05-06"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3-flash-preview"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3-pro-image"
+input = ["text/*", "image/*"]
+output = ["text/*", "image/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3-pro-image-preview"
+input = ["text/*", "image/*"]
+output = ["text/*", "image/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.1-flash-image"
+input = ["text/*", "image/*"]
+output = ["text/*", "image/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.1-flash-image-preview"
+input = ["text/*", "image/*"]
+output = ["text/*", "image/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.1-flash-lite"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.1-flash-lite-image"
+input = ["text/*", "image/*"]
+output = ["text/*", "image/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.1-flash-lite-preview"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.1-pro-preview"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.1-pro-preview-customtools"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.5-flash"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.5-flash-lite"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.6-flash"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.7-flash"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemini-3.8-flash"
+input = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemma-2-27b-it"
+input = ["text/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemma-3-12b-it"
+input = ["text/*", "image/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemma-3-27b-it"
+input = ["text/*", "image/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemma-3-4b-it"
+input = ["text/*", "image/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemma-4-26b-a4b-it"
+input = ["text/*", "image/*", "video/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "gemma-4-31b-it"
+input = ["text/*", "image/*", "video/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "lyria-3-clip-preview"
+input = ["text/*", "image/*"]
+output = ["text/*", "audio/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "google"
+prefix = "lyria-3-pro-preview"
+input = ["text/*", "image/*"]
+output = ["text/*", "audio/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-3.5-turbo"
+input = ["text/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-3.5-turbo-0613"
+input = ["text/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-3.5-turbo-16k"
+input = ["text/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-3.5-turbo-instruct"
+input = ["text/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4"
+input = ["text/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4-turbo"
+input = ["text/*", "image/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4-turbo-preview"
+input = ["text/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4.1"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4.1-mini"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4.1-nano"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4o"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4o-2024-05-13"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4o-2024-08-06"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4o-2024-11-20"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4o-mini"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-4o-mini-2024-07-18"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5-image"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*", "image/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5-image-mini"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*", "image/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5-mini"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5-nano"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5-pro"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.1"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.1-codex"
+input = ["text/*", "image/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.1-codex-max"
+input = ["text/*", "image/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.1-codex-mini"
+input = ["text/*", "image/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.2"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.2-chat"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.2-codex"
+input = ["text/*", "image/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.2-pro"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.3-codex"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.4"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.4-image-2"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*", "image/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.4-mini"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.4-nano"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.4-pro"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.5"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.5-pro"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.6-luna"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.6-luna-pro"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.6-sol"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.6-sol-pro"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.6-terra"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-5.6-terra-pro"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-6-astra"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-6-astra-pro"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-audio"
+input = ["text/*", "audio/*"]
+output = ["text/*", "audio/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-audio-mini"
+input = ["text/*", "audio/*"]
+output = ["text/*", "audio/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-chat-latest"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-oss-120b"
+input = ["text/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-oss-20b"
+input = ["text/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "gpt-oss-safeguard-20b"
+input = ["text/*"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "o1"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "o1-pro"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "o3"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "o3-mini"
+input = ["text/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "o3-mini-high"
+input = ["text/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "o3-pro"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "o4-mini"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+
+[[modality]]
+provider = "openai"
+prefix = "o4-mini-high"
+input = ["text/*", "image/*", "application/pdf"]
+output = ["text/*"]
+source = "openrouter"
+

--- a/crates/leviath-providers/src/mime.rs
+++ b/crates/leviath-providers/src/mime.rs
@@ -128,9 +128,9 @@ pub fn hydrate_request(request: &mut InferenceRequest, h: &Hydration<'_>) -> Hyd
             MessageContent::Blocks(blocks) => blocks.iter().collect::<Vec<_>>(),
             MessageContent::Text(_) => Vec::new(),
         })
-        .filter_map(|b| match b {
-            ContentBlock::Mime { part, .. } if matches!(fate(b, h), Fate::Bytes) => Some(part.size),
-            _ => None,
+        .map(|b| match (fate(b, h), b) {
+            (Fate::Bytes, ContentBlock::Mime { part, .. }) => part.size,
+            _ => 0,
         })
         .sum();
     let mut to_shed = total_bytes.saturating_sub(h.max_media_bytes);

--- a/crates/leviath-providers/src/mime.rs
+++ b/crates/leviath-providers/src/mime.rs
@@ -55,15 +55,19 @@ pub fn data_uri(mime_type: &MimeType, data: &str) -> String {
     format!("data:{mime_type};base64,{data}")
 }
 
-/// How many stored parts a request may carry, and what fetches their bytes.
+/// How much stored media a request may carry, and what fetches its bytes.
 pub struct Hydration<'a> {
     /// What the model takes.
     pub mime: &'a ModelMime,
     /// The registry, for the text flag.
     pub registry: &'a MimeRegistry,
-    /// The most mime blocks kept with bytes; the oldest beyond it become
-    /// stand-ins.
-    pub max_stored: usize,
+    /// The bytes of stored media the request may carry before the oldest parts
+    /// become stand-ins. This is the raw part size, not the base64 on the wire,
+    /// and it is a backstop for vendor request-size limits a token budget
+    /// cannot see: an image's token estimate is the same whatever its byte
+    /// size, so a request can sit inside its context window and still be
+    /// megabytes of media.
+    pub max_media_bytes: u64,
     /// The bytes for a reference, or `None` when they are missing.
     pub fetch: &'a dyn Fn(&BlobRef) -> Option<Arc<[u8]>>,
 }
@@ -77,7 +81,8 @@ pub struct HydrationReport {
     pub as_text: usize,
     /// Blocks sent as their stand-in because the model does not take them.
     pub stand_ins: usize,
-    /// Blocks sent as their stand-in because the request was over its cap.
+    /// Blocks sent as their stand-in because the request was over its
+    /// media-byte cap.
     pub capped: usize,
     /// Hashes whose bytes could not be read.
     pub missing: Vec<String>,
@@ -112,19 +117,23 @@ fn fate(block: &ContentBlock, h: &Hydration<'_>) -> Fate {
 /// Fill every mime block in `request` with what the model should get.
 pub fn hydrate_request(request: &mut InferenceRequest, h: &Hydration<'_>) -> HydrationReport {
     let mut report = HydrationReport::default();
-    // Count what will be sent natively, so the cap can drop the oldest
-    // first: messages are in conversation order, so the first blocks seen are
-    // the oldest.
-    let total_native = request
+    // Sum the raw bytes that would be sent natively, so the cap can shed the
+    // oldest first: messages are in conversation order, so the first blocks
+    // seen are the oldest. The newest media is the media a stage most likely
+    // still needs, so it is what the cap keeps.
+    let total_bytes: u64 = request
         .messages
         .iter()
         .flat_map(|m| match &m.content {
             MessageContent::Blocks(blocks) => blocks.iter().collect::<Vec<_>>(),
             MessageContent::Text(_) => Vec::new(),
         })
-        .filter(|b| matches!(fate(b, h), Fate::Bytes))
-        .count();
-    let mut to_cap = total_native.saturating_sub(h.max_stored);
+        .filter_map(|b| match b {
+            ContentBlock::Mime { part, .. } if matches!(fate(b, h), Fate::Bytes) => Some(part.size),
+            _ => None,
+        })
+        .sum();
+    let mut to_shed = total_bytes.saturating_sub(h.max_media_bytes);
     for message in &mut request.messages {
         let MessageContent::Blocks(blocks) = &mut message.content else {
             continue;
@@ -141,8 +150,8 @@ pub fn hydrate_request(request: &mut InferenceRequest, h: &Hydration<'_>) -> Hyd
             };
             let (part, name, deliver) = (part.clone(), name.clone(), *deliver);
             let outcome = match fate(block, h) {
-                Fate::Bytes if to_cap > 0 => {
-                    to_cap -= 1;
+                Fate::Bytes if to_shed > 0 => {
+                    to_shed = to_shed.saturating_sub(part.size);
                     report.capped += 1;
                     Fate::StandIn
                 }
@@ -493,7 +502,7 @@ mod tests {
             &Hydration {
                 mime: &vision,
                 registry: &reg(),
-                max_stored: 10,
+                max_media_bytes: 1024,
                 fetch: &fetch,
             },
         );
@@ -512,7 +521,7 @@ mod tests {
             &Hydration {
                 mime: &text_only,
                 registry: &reg(),
-                max_stored: 10,
+                max_media_bytes: 1024,
                 fetch: &fetch,
             },
         );
@@ -536,7 +545,7 @@ mod tests {
             &Hydration {
                 mime: &text_only,
                 registry: &reg(),
-                max_stored: 10,
+                max_media_bytes: 1024,
                 fetch: &fetch,
             },
         );
@@ -551,7 +560,7 @@ mod tests {
             &Hydration {
                 mime: &text_only,
                 registry: &reg(),
-                max_stored: 10,
+                max_media_bytes: 1024,
                 fetch: &fetch,
             },
         );
@@ -566,7 +575,7 @@ mod tests {
             &Hydration {
                 mime: &vision,
                 registry: &reg(),
-                max_stored: 10,
+                max_media_bytes: 1024,
                 fetch: &fetch,
             },
         );
@@ -580,7 +589,7 @@ mod tests {
             &Hydration {
                 mime: &vision,
                 registry: &reg(),
-                max_stored: 10,
+                max_media_bytes: 1024,
                 fetch: &fetch,
             },
         );
@@ -601,7 +610,7 @@ mod tests {
             &Hydration {
                 mime: &vision,
                 registry: &reg(),
-                max_stored: 10,
+                max_media_bytes: 1024,
                 fetch: &none,
             },
         );
@@ -619,7 +628,7 @@ mod tests {
             &Hydration {
                 mime: &vision,
                 registry: &reg(),
-                max_stored: 1,
+                max_media_bytes: 12,
                 fetch: &fetch,
             },
         );
@@ -627,6 +636,63 @@ mod tests {
         assert_eq!(report.sent, 1);
         let blocks = blocks_of(&req.messages[1].content);
         assert!(!blocks[0].is_hydrated_mime() && blocks[2].is_hydrated_mime());
+    }
+
+    #[test]
+    fn the_cap_sheds_by_bytes_not_by_count() {
+        use leviath_core::mime::Blob;
+        // An accepted part of a chosen byte size, so the byte cap can be tested
+        // against real sizes rather than a count.
+        let sized = |n: usize| {
+            let blob =
+                Blob::new(MimeType::parse("image/png").unwrap(), vec![7u8; n]).named("m.png");
+            Part::stored(blob.describe(&reg())).named("m.png")
+        };
+        let fetch = |r: &BlobRef| -> Option<Arc<[u8]>> {
+            Some(Arc::from(vec![7u8; r.size as usize].as_slice()))
+        };
+        let vision = ModelMime::new(&["text/*", "image/*"], &["text/*"]);
+        let small = sized(12);
+        let big = sized(1000);
+
+        // A cap below the large part: the small old part is shed to make room,
+        // the large new part still does not fit, so both go as stand-ins. A
+        // count cap of one would have kept the newest; the byte cap keeps none.
+        let mut req = request(vec![
+            ContentBlock::mime(&small).unwrap(),
+            ContentBlock::mime(&big).unwrap(),
+        ]);
+        let report = hydrate_request(
+            &mut req,
+            &Hydration {
+                mime: &vision,
+                registry: &reg(),
+                max_media_bytes: 500,
+                fetch: &fetch,
+            },
+        );
+        assert_eq!(report.capped, 2);
+        assert_eq!(report.sent, 0);
+
+        // A cap above the large part but below the sum: the small old part is
+        // shed and the large new part is kept - oldest first, by bytes.
+        let mut req = request(vec![
+            ContentBlock::mime(&small).unwrap(),
+            ContentBlock::mime(&big).unwrap(),
+        ]);
+        let report = hydrate_request(
+            &mut req,
+            &Hydration {
+                mime: &vision,
+                registry: &reg(),
+                max_media_bytes: 1000,
+                fetch: &fetch,
+            },
+        );
+        assert_eq!(report.capped, 1);
+        assert_eq!(report.sent, 1);
+        let blocks = blocks_of(&req.messages[1].content);
+        assert!(!blocks[0].is_hydrated_mime() && blocks[1].is_hydrated_mime());
     }
 
     #[test]

--- a/crates/leviath-providers/src/mime_tables.rs
+++ b/crates/leviath-providers/src/mime_tables.rs
@@ -6,6 +6,18 @@
 //! these answers rather than a type name. A listing that says more (as
 //! OpenRouter's does) corrects a row here, and an operator's
 //! `[model_capabilities]` entry corrects both.
+//!
+//! Two layers answer for a vendor whose API stays quiet. The precise one is
+//! `mime/modalities.toml`, a table refreshed from OpenRouter's catalogue by
+//! `cargo xtask modalities`, so a specific model's real lists (`claude-3-haiku`
+//! takes images but not PDFs, say) are used when the catalogue names it. Under
+//! it is the name heuristic below, the floor for a model the catalogue does not
+//! carry - a model published nowhere, or one shaped so differently (a
+//! text-to-speech or image model) that its name is the only signal.
+
+use std::sync::LazyLock;
+
+use serde::Deserialize;
 
 use crate::capabilities::ModelMime;
 
@@ -24,14 +36,19 @@ fn lower(model: &str) -> String {
     model.to_ascii_lowercase()
 }
 
-/// Every Claude model in the current line-up reads images and PDFs and
-/// writes text.
-pub(crate) fn anthropic(_model: &str) -> ModelMime {
-    ModelMime::new(VISION_DOC, TEXT)
+/// Every Claude model reads images and PDFs and writes text, unless the
+/// catalogue names one that takes less (`claude-3-haiku` has no PDF).
+pub(crate) fn anthropic(model: &str) -> ModelMime {
+    published_modality("anthropic", model).unwrap_or_else(|| ModelMime::new(VISION_DOC, TEXT))
 }
 
 /// OpenAI: the chat and reasoning models read images and PDFs; the audio
 /// models also take and return audio; the image models return images.
+///
+/// The name decides the structurally distinct classes - image, audio, speech,
+/// transcription - because the catalogue does not serve them and their name is
+/// the only signal. A chat or reasoning model takes the catalogue's published
+/// lists when it names this one, and the vision-family default otherwise.
 pub(crate) fn openai(model: &str) -> ModelMime {
     let m = lower(model);
     if m.starts_with("gpt-image") || m.starts_with("dall-e") {
@@ -46,6 +63,9 @@ pub(crate) fn openai(model: &str) -> ModelMime {
     if m.contains("transcribe") || m.starts_with("whisper") {
         return ModelMime::new(&["audio/*"], TEXT);
     }
+    if let Some(mime) = published_modality("openai", model) {
+        return mime;
+    }
     let vision = ["gpt-4.1", "gpt-4o", "gpt-5", "o3", "o4", "o1", "chatgpt"];
     if vision.iter().any(|p| m.starts_with(p)) {
         return ModelMime::new(VISION_DOC, TEXT);
@@ -55,6 +75,9 @@ pub(crate) fn openai(model: &str) -> ModelMime {
 
 /// Gemini: the chat models take text, images, audio, video and PDFs; the
 /// image models return images; Imagen and Veo are generators.
+///
+/// As with OpenAI, the name settles the generator and speech models, and the
+/// catalogue's lists refine a chat model the refresh has named.
 pub(crate) fn gemini(model: &str) -> ModelMime {
     let m = lower(model);
     if m.starts_with("imagen") {
@@ -72,7 +95,7 @@ pub(crate) fn gemini(model: &str) -> ModelMime {
     if m.contains("embedding") {
         return ModelMime::text_only();
     }
-    ModelMime::new(GEMINI_INPUT, TEXT)
+    published_modality("google", model).unwrap_or_else(|| ModelMime::new(GEMINI_INPUT, TEXT))
 }
 
 /// Codex: the Responses API takes images beside text.
@@ -140,6 +163,67 @@ pub(crate) fn modality_pattern(word: &str) -> Option<&'static str> {
     }
 }
 
+/// The rows of `mime/modalities.toml`, parsed once.
+///
+/// A parse failure is a panic on first use rather than an error: the file is
+/// compiled in, so a malformed one is a build of this crate that cannot type
+/// any model, and the tests below catch it before it ships.
+static MODALITY_TABLE: LazyLock<ModalityTable> = LazyLock::new(|| {
+    toml::from_str(include_str!("../mime/modalities.toml"))
+        .expect("mime/modalities.toml is well-formed; `cargo xtask modalities` writes it")
+});
+
+/// The shape of `mime/modalities.toml`.
+#[derive(Debug, Deserialize)]
+struct ModalityTable {
+    /// The day the rows were last refreshed, `YYYY-MM-DD`.
+    read_on: String,
+    /// Every row, in file order.
+    #[serde(default)]
+    modality: Vec<PublishedModality>,
+}
+
+/// One row of the shipped modality table: what a family of models takes and
+/// produces, and where the lists came from.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct PublishedModality {
+    /// The provider the row applies to: `anthropic`, `openai` or `google`.
+    pub provider: String,
+    /// The model-id prefix the row covers; the longest matching prefix wins.
+    pub prefix: String,
+    /// Mime patterns the model accepts in a request.
+    pub input: Vec<String>,
+    /// Mime patterns the model can hand back.
+    pub output: Vec<String>,
+    /// Where the row came from: `openrouter` for a row the refresh wrote,
+    /// `manual` for a row a person wrote, which `cargo xtask modalities` never
+    /// overwrites.
+    pub source: String,
+}
+
+/// The day the modality rows in the shipped table were last refreshed.
+///
+/// Shipped with the lists so staleness is visible: a build months old may be
+/// naming an older model's modalities, and the honest thing is to say when.
+pub fn modalities_read_on() -> &'static str {
+    &MODALITY_TABLE.read_on
+}
+
+/// The published modalities for `model` at `provider`, or `None` when no row's
+/// prefix matches and the name heuristic answers instead. The longest matching
+/// prefix wins, so `gpt-5.5` does not swallow a `gpt-5.5-turbo` row.
+pub(crate) fn published_modality(provider: &str, model: &str) -> Option<ModelMime> {
+    MODALITY_TABLE
+        .modality
+        .iter()
+        .filter(|row| row.provider == provider && model.starts_with(&row.prefix))
+        .max_by_key(|row| row.prefix.len())
+        .map(|row| ModelMime {
+            input: row.input.clone(),
+            output: row.output.clone(),
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -157,6 +241,45 @@ mod tests {
         assert!(!m.accepts(&mt("audio/wav")));
         assert!(m.produces(&mt("text/plain")));
         assert!(!m.produces(&mt("image/png")));
+    }
+
+    #[test]
+    fn the_catalogue_table_refines_the_name_heuristic() {
+        // The catalogue names claude-3-haiku with a narrower list than the
+        // family default: images, but no PDF. The precise row wins.
+        let haiku = anthropic("claude-3-haiku");
+        assert!(haiku.accepts(&mt("image/png")));
+        assert!(
+            !haiku.accepts(&mt("application/pdf")),
+            "the table drops the PDF the family default would add"
+        );
+
+        // A model no row names falls to the family default, PDF included.
+        let unlisted = anthropic("claude-nonexistent-zzz");
+        assert!(unlisted.accepts(&mt("application/pdf")));
+
+        // The same fallback for the two vendors whose chat models take more:
+        // a vision-family OpenAI model the catalogue does not name still gets
+        // the vision default, an old completion model falls to text only, and
+        // an unnamed Gemini chat model gets the full Gemini input set.
+        assert!(openai("chatgpt-4o-latest").accepts(&mt("image/png")));
+        assert!(!openai("babbage-002").accepts(&mt("image/png")));
+        assert!(gemini("gemini-9.9-ultra-zzz").accepts(&mt("video/mp4")));
+
+        // The lookup is provider-scoped, and the shipped date reads back.
+        assert!(published_modality("openai", "gpt-3.5-turbo").is_some());
+        assert!(published_modality("openai", "totally-unknown-zzz").is_none());
+        assert!(published_modality("nonprovider", "gpt-5.5").is_none());
+        assert_eq!(modalities_read_on().len(), "YYYY-MM-DD".len());
+
+        // Every shipped row is well-formed: real patterns, real source words.
+        for row in &MODALITY_TABLE.modality {
+            assert!(!row.input.is_empty() && !row.output.is_empty());
+            assert!(matches!(row.source.as_str(), "openrouter" | "manual"));
+            let clone = row.clone();
+            assert_eq!(&clone, row);
+            assert!(format!("{row:?}").contains(&row.prefix));
+        }
     }
 
     #[test]

--- a/crates/leviath-providers/src/mime_tables.rs
+++ b/crates/leviath-providers/src/mime_tables.rs
@@ -272,10 +272,12 @@ mod tests {
         assert!(published_modality("nonprovider", "gpt-5.5").is_none());
         assert_eq!(modalities_read_on().len(), "YYYY-MM-DD".len());
 
-        // Every shipped row is well-formed: real patterns, real source words.
+        // Every shipped row is well-formed: real patterns, and a source the
+        // refresh wrote (a hand-added `manual` row would say so, but the
+        // shipped file carries none, so this pins that).
         for row in &MODALITY_TABLE.modality {
             assert!(!row.input.is_empty() && !row.output.is_empty());
-            assert!(matches!(row.source.as_str(), "openrouter" | "manual"));
+            assert_eq!(row.source, "openrouter");
             let clone = row.clone();
             assert_eq!(&clone, row);
             assert!(format!("{row:?}").contains(&row.prefix));

--- a/crates/leviath-runtime/src/blob_store.rs
+++ b/crates/leviath-runtime/src/blob_store.rs
@@ -154,20 +154,20 @@ impl MimeParams<'_, '_> {
     }
 
     /// The store and the registry `entity`'s run reads, together when both
-    /// are there, and the per-request cap either way.
-    pub fn hydration_inputs(&self, entity: Entity) -> (HydrationSources, usize) {
+    /// are there, and the per-request media-byte cap either way.
+    pub fn hydration_inputs(&self, entity: Entity) -> (HydrationSources, u64) {
         let both = self
             .store
             .as_deref()
             .map(|s| s.0.clone())
             .zip(self.registry_for(entity));
-        let max_stored = self
+        let max_media_bytes = self
             .limits
             .as_deref()
-            .map_or(MimeLimits::default().max_stored_per_request, |l| {
-                l.max_stored_per_request
+            .map_or(MimeLimits::default().max_media_bytes_per_request, |l| {
+                l.max_media_bytes_per_request
             });
-        (both, max_stored)
+        (both, max_media_bytes)
     }
 
     /// The largest part any ingress accepts.
@@ -185,8 +185,9 @@ pub struct MimeLimits {
     pub max_part_bytes: u64,
     /// Bytes of text kept inline in an entry before the part is stored.
     pub inline_text_bytes: u64,
-    /// Stored parts one model request carries before the oldest are dropped.
-    pub max_stored_per_request: usize,
+    /// Bytes of stored media one request carries before the oldest are sent as
+    /// stand-ins.
+    pub max_media_bytes_per_request: u64,
 }
 
 impl Default for MimeLimits {
@@ -194,7 +195,7 @@ impl Default for MimeLimits {
         Self {
             max_part_bytes: 32 * 1024 * 1024,
             inline_text_bytes: 1024 * 1024,
-            max_stored_per_request: 100,
+            max_media_bytes_per_request: 64 * 1024 * 1024,
         }
     }
 }
@@ -478,7 +479,7 @@ mod tests {
         assert_eq!(mime.registry_for(bare).unwrap().info(&obj).family, "model");
         let (sources, max) = mime.hydration_inputs(own);
         assert_eq!(sources.unwrap().1.info(&obj).family, "scene");
-        assert_eq!(max, MimeLimits::default().max_stored_per_request);
+        assert_eq!(max, MimeLimits::default().max_media_bytes_per_request);
     }
 
     #[test]
@@ -586,11 +587,11 @@ mod tests {
             .expect("the parameter validates")
             .hydration_inputs(entity);
         assert!(none.is_none());
-        assert_eq!(cap, 100);
+        assert_eq!(cap, 64 * 1024 * 1024);
         world.insert_resource(BlobStoreHandle(mem.clone()));
         world.insert_resource(MimeRegistryHandle::default());
         world.insert_resource(MimeLimits {
-            max_stored_per_request: 3,
+            max_media_bytes_per_request: 3,
             ..MimeLimits::default()
         });
         let mut state = bevy_ecs::system::SystemState::<MimeParams>::new(&mut world);
@@ -602,7 +603,7 @@ mod tests {
         assert_eq!(cap, 3);
         assert_eq!(limits.max_part_bytes, 32 * 1024 * 1024);
         assert_eq!(limits.inline_text_bytes, 1024 * 1024);
-        assert_eq!(limits.max_stored_per_request, 100);
+        assert_eq!(limits.max_media_bytes_per_request, 64 * 1024 * 1024);
         assert_eq!(limits, limits);
         assert!(format!("{limits:?}").contains("MimeLimits"));
     }

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -37,7 +37,6 @@ pub(crate) fn init_window_seeded(
         region.admission = region_def.admission;
         region.volatility = region_def.volatility;
         region.accepts = region_def.accepts.clone();
-        region.max_stored = region_def.max_stored;
         region.description = region_def.description.clone();
         region.describe_in_prompt = region_def.describe_in_prompt;
         window.add_region(region);
@@ -174,7 +173,6 @@ pub(crate) fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
         new_region.admission = region_def.admission;
         new_region.volatility = region_def.volatility;
         new_region.accepts = region_def.accepts.clone();
-        new_region.max_stored = region_def.max_stored;
         new_region.description = region_def.description.clone();
         new_region.describe_in_prompt = region_def.describe_in_prompt;
 

--- a/crates/leviath-runtime/src/context_setup/parts.rs
+++ b/crates/leviath-runtime/src/context_setup/parts.rs
@@ -4,7 +4,7 @@
 //! crossing happens here, once per run: the bytes are typed by the registry,
 //! written to the run's blob store, and the reference is written into the
 //! region beside whatever caption came with it. A region that refuses the
-//! type (`accepts`) or is full (`max_stored` under `admission = "reject"`)
+//! type (`accepts`) or is full (its token budget under `admission = "reject"`)
 //! refuses the spawn or the message, naming the part, rather than dropping
 //! it where nobody would notice.
 

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -159,7 +159,7 @@ impl Default for RetryPolicy {
 
 /// A unit of inference work the dispatch system hands to the worker pool.
 /// What a job needs to fill its mime blocks with bytes right before sending:
-/// where the bytes are, what the model takes, and how many to send.
+/// where the bytes are, what the model takes, and how much to send.
 #[derive(Clone)]
 pub(crate) struct JobHydration {
     /// The run's blob store.
@@ -170,8 +170,9 @@ pub(crate) struct JobHydration {
     pub registry: Arc<leviath_core::mime::MimeRegistry>,
     /// What the model takes and hands back.
     pub mime: leviath_providers::ModelMime,
-    /// The most stored parts one request carries with their bytes.
-    pub max_stored: usize,
+    /// The bytes of stored media one request carries before the oldest parts
+    /// become stand-ins.
+    pub max_media_bytes: u64,
     /// Mime type patterns the stage sends as text whatever the model takes.
     pub as_text: Vec<String>,
 }
@@ -204,7 +205,7 @@ impl JobHydration {
             &leviath_providers::mime::Hydration {
                 mime: &self.mime,
                 registry: &self.registry,
-                max_stored: self.max_stored,
+                max_media_bytes: self.max_media_bytes,
                 fetch: &fetch,
             },
         );
@@ -1645,7 +1646,7 @@ mod tests {
             run_id: "run-1".to_string(),
             registry,
             mime: ModelMime::new(&["text/*", "image/*"], &["text/*"]),
-            max_stored: 10,
+            max_media_bytes: 64 * 1024 * 1024,
             as_text: Vec::new(),
         };
         hydration.apply(&mut request);

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -540,14 +540,14 @@ pub(crate) fn dispatch_inference(
                 // by this run's registry. Every `PipelineWorld` installs the
                 // store; a world assembled by hand in a test may not, and
                 // then stored parts go out as their stand-ins.
-                let (mime_resources, max_stored) = mime.hydration_inputs(entity);
+                let (mime_resources, max_media_bytes) = mime.hydration_inputs(entity);
                 let hydration =
                     mime_resources.map(|(store, registry)| crate::inference_bridge::JobHydration {
                         store,
                         run_id: state.agent_id.clone(),
                         registry,
                         mime: provider.mime(&si.model),
-                        max_stored,
+                        max_media_bytes,
                         as_text: config.map(|c| c.as_text.clone()).unwrap_or_default(),
                     });
                 let job = InferenceJob {

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -47,6 +47,7 @@ a test, so a client generator or an agent can consume the contract directly.
   | Without `--allow-admin` | Response |
   |---|---|
   | `PUT /api/config` | 405, because `GET /api/config` is mounted |
+  | `PUT /api/mime` · `DELETE /api/mime` | 405, because `GET /api/mime` is mounted |
   | `POST /api/mcp/servers` | 405, because `GET /api/mcp/servers` is mounted |
   | `DELETE /api/mcp/servers/{name}` | 404, because nothing else is mounted on that path |
   | `POST /api/update` | 405, because `GET /api/update` is mounted |
@@ -225,7 +226,7 @@ handle that on all of them rather than on a few. The body is a line of plain tex
 | `POST /api/models/probe` *(admin)* | Ask an OpenAI-compatible server what it serves before writing a gateway for it: `{"base_url", "api_key"?, "headers"?}` → `{"models": [ids]}`, or 502 carrying the server's own error text. See [below](#gateways) |
 | `GET /api/providers` · `POST …/{name}/login` *(admin)* · `/logout` *(admin)* · `/check` *(admin)* | The providers that sign in with a browser instead of taking a key, and the sign-in itself. See [below](#signing-in-to-a-subscription-provider) |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
-| `GET /api/mime` | The effective [mime registry](/docs/mime#the-registry): every type row and where it came from |
+| `GET /api/mime` · `PUT /api/mime` *(admin)* · `DELETE /api/mime` *(admin)* | Read the effective [mime registry](/docs/mime#the-registry), and write to it: `PUT` adds or updates a row in `mime_types.toml` (`{"mime_type", "family"?, "text"?, "tokens"?, "extensions"?, "magic"?, "stand_in"?, "check"?}`, only the fields sent are changed, a bad type or rule is a 400), `DELETE ?mime_type=` takes one out (404 if there is no such row). The writes need admin. See [below](#writing-a-mime-row) |
 | `GET /api/scripts?agent=&include=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks, validators and mime checks, and the global model providers and mime checks. `include=candidates` also lists the files nothing declares yet. Writes need admin. See [below](#tools-and-scripts) |
 | `GET /api/mcp/servers` · `POST …` *(admin)* · `DELETE …/{name}` *(admin)* · `GET …/{name}/status` · `POST …/{name}/login` *(admin)* · `POST …/{name}/test` *(admin)* | List, add, remove, check, log in, test. The writes need admin. A server added or removed here reaches the next run, with no daemon restart |
 | `GET /api/doctor` · `POST /api/doctor/live` *(admin)* | The checks `lev doctor` runs, as data. `GET` is `lev doctor --offline`: config, search and resolve, nothing billed. `POST .../live` runs the whole chain (two billed calls and a throwaway run) and answers 409 while one is already going. A failing check is `ok: false` inside a 200, never an HTTP error |
@@ -1472,6 +1473,7 @@ than that feature, not broken.
 | `runs.files.raw` | `GET /api/agents/{id}/files/raw?path=`, a workdir file's bytes under its own content type |
 | `runs.result.artifacts` | `artifacts` on a run's answer as `{ name, path, mime_type, size, sha256 }` objects rather than paths |
 | `mime.registry` | `GET /api/mime`, the effective mime registry with each row's source |
+| `mime.write` | `PUT /api/mime` and `DELETE /api/mime`, admin-gated, write a row into `mime_types.toml` or take one out |
 | `runs.stages` | `GET /api/agents/{id}/stages`, the per-stage ledger |
 | `runs.stages.cost` | `cost_usd`, `unpriced_calls` and `cost_is_exact` on each stage record, and the `visits` split beneath them. Without it a stage record carries tokens and no price, and the missing field is not a zero |
 | `runs.waiting_on` | `wait_reason` on a run, saying what a parked run is parked on |
@@ -1508,6 +1510,43 @@ than that feature, not broken.
 | `interaction.feedback` | `feedback` beside `approved: false` on `POST /api/agents/{id}/interaction`, and the "Deny with feedback" option on a tool approval. An older daemon drops the field without a word, so a console should only offer the box where this is announced. See [answering a question](#answering-a-question) |
 | `providers.signin` | `GET /api/providers` and the three admin routes under it: the browser sign-in for a provider that has no API key. Without it a console can write `codex_enabled` and has no way to complete the sign-in, which leaves the user enabled and unable to run anything. See [signing in to a subscription provider](#signing-in-to-a-subscription-provider) |
 | `config.health` | `config_error` and `config_mtime` on `GET /api/config`, and the `config_health` frame on the socket. Without it a missing `config_error` means nothing, so a console cannot tell a file that loads from a daemon that would not say. See [when the config file will not load](#when-the-config-file-will-not-load) |
+
+## Writing a mime row
+
+A [custom mime type](/docs/mime#the-registry) is where the registry earns its keep: a family, a
+token rule, extensions, a magic prefix and a byte check turn a format Leviath has never heard of
+into one it types, sizes and validates rather than one that behaves like
+`application/octet-stream`. `GET /api/mime` shows what is there; these two writes change it,
+without leaving the browser for the config file.
+
+`PUT /api/mime` adds a row or updates the one already there, writing `mime_types.toml` beside the
+config, the same file `lev mime add` writes and the operator's own rows live in:
+
+```jsonc
+PUT /api/mime
+{
+  "mime_type": "application/x-acme-scene",
+  "family": "model",
+  "text": false,
+  "tokens": { "per_pixel": 750, "max": 1600 },
+  "extensions": ["scene"],
+  "magic": "41434D45",
+  "stand_in": "[{type} {size}] {name}",
+  "check": "checks/scene.rhai"
+}
+```
+
+Every field but `mime_type` is optional, and only the fields sent are changed, so a later `PUT`
+that carries just `{"mime_type": "...", "extensions": [...]}` adds an extension and leaves the
+rest. `tokens` is one of `{ per_byte }`, `{ per_pixel, max? }`, `{ per_second }` or `{ fixed }`.
+The answer is `{"mime_type", "created"}`, where `created` is false when the row was already there.
+The row is validated the way `lev mime add` validates it before anything is written: a type that
+is not `type/subtype`, a token rule that names none or more than one rate, a `magic` that is not
+hex, or a `check` script that will not compile is a 400, and the file is untouched.
+
+`DELETE /api/mime?mime_type=<type>` takes a row out; a type with no row of its own there is a 404.
+Both need `--allow-admin`, and both are announced as `mime.write`, so a console offers "New
+type…" where it will land and hands over the TOML to paste where it will not.
 
 ## Live updates over WebSocket
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -892,15 +892,18 @@ Ceilings on typed mime parts: the images, audio, video, documents and models tha
 
 ```toml
 [mime]
-max_part_bytes = 33554432        # one part, at every ingress (32 MiB)
-inline_text_bytes = 1048576      # text kept inside the entry before it is stored by hash
-max_stored_per_request = 100     # stored parts one model request carries
+max_part_bytes = 33554432               # one part, at every ingress (32 MiB)
+inline_text_bytes = 1048576             # text kept inside the entry before it is stored by hash
+max_media_bytes_per_request = 67108864  # bytes of stored media one model request carries (64 MiB)
 ```
 
 A part over `max_part_bytes` is refused where it arrives, whether that is an upload, a tool
 result or a model reply. Text longer than `inline_text_bytes` is stored by hash like any other
-part and read back as text when a request is built. Beyond `max_stored_per_request` the oldest
-stored parts are left out of a request, with a warning in the run's log.
+part and read back as text when a request is built. `max_media_bytes_per_request` is a backstop
+for the vendor request-size limits a token budget cannot see: an image's token estimate is the
+same whatever its byte size, so a request can sit inside its context window and still be
+megabytes of media on the wire. Past it, the oldest stored parts are sent as their stand-ins
+instead, with a warning in the run's log.
 
 <a id="mime_typestypesubtype"></a>
 

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -169,7 +169,6 @@ and pass on the first attempt, which looks exactly like a stage that finished it
 | `volatility` | `"rewritten"` | How much the region's contents move between requests, which decides where it sits in the prompt. See [what caching costs](#what-caching-costs) |
 | `admission` | `"evict"` | What happens when a write does not fit. `"reject"` refuses it instead of dropping something. See [letting the agent decide what to forget](#letting-the-agent-decide-what-to-forget) |
 | `accepts` | unset | Mime types the region takes, as `type/subtype` or `type/*`. Unset takes anything. A write carrying another type is refused with this list. See [typed mime](/docs/mime) |
-| `max_stored` | unset | The most stored (non-text) parts the region holds. Past it the oldest entry carrying one is evicted, or refused under `admission = "reject"` |
 | `required_message` | generated | What the model is told when a required region is empty. Supports `{region}` |
 
 **Resolved budget** is the phrase used for the number a region actually gets, once the percentage

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -151,10 +151,9 @@ what order, where it loops back. Between the graph and the task, when the bluepr
 that takes files opens a picker of the working directory, filtered to the types the region
 accepts, so you choose a file from a list rather than typing its name (and never with an `@`); a
 slot for a text region takes a line of text. A file region takes as many files as its token
-budget allows, added and removed in the same picker; the number is bound by the budget, not a
-fixed count, unless the blueprint sets a hard `max_stored` cap, which the picker then honours. The
-slot names what the region takes, its token budget (`≤117k tok`, the region's share of the entry
-model's context window), any hard count cap, and whether it is required. It follows the selection,
+budget allows, added and removed in the same picker; the number is bound by the budget, never a
+fixed count. The slot names what the region takes, its token budget (`≤117k tok`, the region's
+share of the entry model's context window), and whether it is required. It follows the selection,
 previews bundled blueprints that are not
 installed yet from the copy inside the binary, and says so when a manifest cannot be read. It is
 the explorer's canvas showing the whole graph: drag to pan, wheel to zoom; on a screen too short to
@@ -167,7 +166,7 @@ rather than back into the form.
 | `↑` / `↓` | Choose an agent. Any letter filters the list; `Backspace` shortens the filter |
 | `Tab` / `Enter` | Move from the agent list to the inputs, when the agent has any, else to the task |
 | `↑` / `↓` (in the inputs) | Choose a slot. A file slot opens the picker on `Enter` (or `Ctrl+O`); a text slot takes what you type, and `Enter` moves to the next slot and, after the last, to the task. `Tab` to the task; `Shift+Tab` or `Esc` back to the agent list |
-| picker (in a file slot) | `↑` / `↓` move, any letter filters by name, `Space` selects or deselects the highlighted file (a one-file region swaps instead), `Enter` confirms. `Enter` never selects on its own, so a slot can be left empty; `Esc` cancels. The list is the working directory only, so it never offers a file the run could not read, and each file shows its own token cost. The title shows the tokens the choice costs against the region's budget (its share of the model's context window); a file that would overflow the budget is refused with the reason, and a run that would not fit is stopped before it starts |
+| picker (in a file slot) | `↑` / `↓` move, any letter filters by name, `Space` selects or deselects the highlighted file, `Enter` confirms. `Enter` never selects on its own, so a slot can be left empty; `Esc` cancels. The list is the working directory only, so it never offers a file the run could not read, and each file shows its own token cost. The title shows the tokens the choice costs against the region's budget (its share of the model's context window); a file that would overflow the budget is refused with the reason, and a run that would not fit is stopped before it starts |
 | `Ctrl+S` (in the task) | Start the run. `Ctrl+Enter` also starts it, but only a terminal with the kitty keyboard protocol (kitty, WezTerm, Ghostty, foot, recent Alacritty) can tell Ctrl+Enter from Enter; elsewhere it inserts a newline, and `Ctrl+S` or the Start button is the way to submit |
 | `Enter` / `Alt+Enter` | Newline |
 | `Tab` (in the task) | Move to the Start button under the editor. `Enter` or `Space` there starts the run, as does a click on it; `Tab` or `Esc` returns to the agent list, `Shift+Tab` to the task |

--- a/docs/content/mime.md
+++ b/docs/content/mime.md
@@ -219,10 +219,15 @@ with any number of file parts, or a JSON `parts` list naming files already insid
 
 ```toml
 [mime]
-max_part_bytes = 33554432        # one part, at every ingress
-inline_text_bytes = 1048576      # text kept inside the entry before it is stored by hash
-max_stored_per_request = 100     # stored parts one model request carries
+max_part_bytes = 33554432               # one part, at every ingress
+inline_text_bytes = 1048576             # text kept inside the entry before it is stored by hash
+max_media_bytes_per_request = 67108864  # bytes of stored media one model request carries
 ```
+
+`max_media_bytes_per_request` is a backstop for the vendor request-size limits a token budget
+cannot see: an image costs the same few thousand tokens whatever its byte size, so a request
+can sit inside its context window and still be megabytes of media. Past it, the oldest stored
+parts are sent as their stand-ins.
 
 `lev doctor` reports a `[mime_types]` row that will not load, or a `check` it cannot compile;
 the daemon keeps the built-in table until it is fixed.

--- a/docs/content/mime.md
+++ b/docs/content/mime.md
@@ -140,14 +140,14 @@ A region can say what it accepts and how many stored parts it holds:
 ```toml
 [context.regions]
 brief         = { kind = "pinned", seed = "task_input", accepts = ["text/*"] }
-voice_samples = { kind = "pinned", seed = "input", accepts = ["audio/*"], max_stored = 4 }
-storyboard    = { kind = "pinned", seed = "input", accepts = ["image/*"], max_stored = 12 }
+voice_samples = { kind = "pinned", seed = "input", accepts = ["audio/*"] }
+storyboard    = { kind = "pinned", seed = "input", accepts = ["image/*"] }
 ```
 
 A stage's inputs are the regions it can see, so a stage that reads those three has three typed
 inputs and nothing new to declare. A write that does not match `accepts` is refused and says
-what the region does take. `max_stored` evicts the oldest entry carrying a stored part, or
-refuses the write under `admission = "reject"`.
+what the region does take. A region is bounded by its token budget: past it the oldest entry
+is evicted, or the write is refused under `admission = "reject"`.
 
 When a stage lists several models, the one that takes what the stage's regions accept goes
 first, so a stage reading a storyboard lands on the model that can see it. `lev validate` says

--- a/docs/content/mime.md
+++ b/docs/content/mime.md
@@ -98,8 +98,14 @@ what they claim. Without one, a declared type is taken at its word, as every pro
 
 A model declares what it takes, as mime types. Anthropic and OpenAI models list `image/*` and
 `application/pdf`; Gemini adds `audio/*` and `video/*`; a local model you describe in
-`[model_capabilities]` lists whatever it can do. When a request is built, each stored part goes
-one of three ways:
+`[model_capabilities]` lists whatever it can do. Where a provider publishes this per model,
+Leviath reads it: OpenRouter's catalogue carries each model's input and output modalities and
+Ollama's `/api/show` reports vision, and both win over the built-in tables. The vendors whose
+APIs stay quiet (Anthropic, OpenAI, Google direct) are carried in a compiled table refreshed
+from OpenRouter's catalogue by `cargo xtask modalities`, the way `cargo xtask prices` refreshes
+list prices, so `claude-3-haiku`, which takes images but not PDFs, is described precisely rather
+than by a whole-vendor guess. `lev models show` names a model's input and output types.
+When a request is built, each stored part goes one of three ways:
 
 | Delivery | When | What is sent |
 |---|---|---|

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -803,11 +803,6 @@
             "type": "string"
           },
           "description": "Mime types this region takes, each type/subtype or type/*. Absent means anything. A write carrying a part outside the list is refused with the list."
-        },
-        "max_stored": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "The most stored (non-text) parts the region holds across its entries. Past it the oldest entry carrying one is evicted, or the write is refused under admission = \"reject\"."
         }
       }
     },

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -225,9 +225,9 @@ Authorization = "Bearer ${MY_MCP_TOKEN}"
 # Ceilings on typed mime parts (images, audio, video, documents, anything
 # with a mime type). Defaults shown.
 [mime]
-max_part_bytes = 33554432        # one part, at every ingress
-inline_text_bytes = 1048576      # text kept inside the entry before it is stored by hash
-max_stored_per_request = 100     # stored parts one model request carries
+max_part_bytes = 33554432          # one part, at every ingress
+inline_text_bytes = 1048576        # text kept inside the entry before it is stored by hash
+max_media_bytes_per_request = 67108864  # bytes of stored media one model request carries
 
 # Rows added to the mime registry live in mime_types.toml beside this
 # file (`lev mime init` writes an example). A [mime_types] table here

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -846,10 +846,10 @@
           "minimum": 0,
           "description": "Bytes of text kept inline in an entry before the part is stored by hash. Default 1048576."
         },
-        "max_stored_per_request": {
+        "max_media_bytes_per_request": {
           "type": "integer",
           "minimum": 1,
-          "description": "Stored parts one model request carries; the oldest beyond it are dropped. Default 100."
+          "description": "Bytes of stored media one model request carries before the oldest parts are sent as stand-ins; a backstop for vendor request-size limits a token budget cannot see. Default 67108864 (64 MiB)."
         }
       }
     },

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1972,6 +1972,153 @@
             "$ref": "#/components/responses/Overloaded"
           }
         }
+      },
+      "put": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Add or update a mime row",
+        "description": "Write a row into `mime_types.toml` beside the config, or set the given fields on the row already there. Admin-only (needs `--allow-admin`; otherwise 405). Every field but `mime_type` is optional, and only the fields sent are changed. Validated the way `lev mime add` is: a type that is not `type/subtype`, a token rule that names none or more than one of `per_byte`/`per_pixel`/`per_second`/`fixed`, a `magic` that is not hex, or a `check` script that will not compile is a 400 and nothing is written. Announced as `mime.write`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "mime_type"
+                ],
+                "properties": {
+                  "mime_type": {
+                    "type": "string",
+                    "description": "`type/subtype`, or `type/*` for a whole family."
+                  },
+                  "family": {
+                    "type": "string"
+                  },
+                  "text": {
+                    "type": "boolean"
+                  },
+                  "tokens": {
+                    "type": "object",
+                    "description": "One of `{ per_byte }`, `{ per_pixel, max? }`, `{ per_second }` or `{ fixed }`.",
+                    "properties": {
+                      "per_byte": {
+                        "type": "number"
+                      },
+                      "per_pixel": {
+                        "type": "integer"
+                      },
+                      "per_second": {
+                        "type": "integer"
+                      },
+                      "fixed": {
+                        "type": "integer"
+                      },
+                      "max": {
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  "extensions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "magic": {
+                    "type": "string",
+                    "description": "A hex prefix that identifies the bytes."
+                  },
+                  "stand_in": {
+                    "type": "string"
+                  },
+                  "check": {
+                    "type": "string",
+                    "description": "A Rhai check script path; an empty string lifts a broader row's check."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The row was written.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "mime_type": {
+                      "type": "string"
+                    },
+                    "created": {
+                      "type": "boolean",
+                      "description": "True when the row was new, false when it updated one already there."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/NotMounted"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Remove a mime row",
+        "description": "Take a row out of `mime_types.toml` beside the config. Admin-only (needs `--allow-admin`; otherwise 405). A type with no row there is a 404. Announced as `mime.write`.",
+        "parameters": [
+          {
+            "name": "mime_type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "`type/subtype` or `type/*`."
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Removed. No body."
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "405": {
+            "$ref": "#/components/responses/NotMounted"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
+          }
+        }
       }
     },
     "/api/doctor/live": {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,9 +12,12 @@
 //!   `structure --list`          Print every file's production-line count, longest first.
 //!   `prices`                    Refresh the vendor list prices from OpenRouter and LiteLLM.
 //!   `prices --check`            Print the diff and fail if the price table would change.
+//!   `modalities`                Refresh which mime types each model takes, from OpenRouter.
+//!   `modalities --check`        Print the diff and fail if the modality table would change.
 
 mod coverage;
 mod docs;
+mod modalities;
 mod prices;
 mod structure;
 mod version;
@@ -37,6 +40,7 @@ pub fn dispatch(args: &[String]) -> Result<()> {
         docs::run,
         structure::run,
         prices::run,
+        modalities::run,
     )
 }
 
@@ -51,6 +55,7 @@ pub fn dispatch_with(
     run_docs: impl FnOnce(docs::DocsMode) -> Result<()>,
     run_struct: impl FnOnce(structure::StructureMode) -> Result<()>,
     run_prices: impl FnOnce(prices::PricesMode) -> Result<()>,
+    run_mod: impl FnOnce(modalities::ModalitiesMode) -> Result<()>,
 ) -> Result<()> {
     let subcommand = args.first().map(String::as_str).unwrap_or("help");
     match subcommand {
@@ -74,6 +79,10 @@ pub fn dispatch_with(
             let mode = prices::PricesMode::parse(&args[1..])?;
             run_prices(mode)
         }
+        "modalities" => {
+            let mode = modalities::ModalitiesMode::parse(&args[1..])?;
+            run_mod(mode)
+        }
         "help" | "--help" | "-h" => {
             println!("Usage: cargo xtask <subcommand>");
             println!();
@@ -87,6 +96,10 @@ pub fn dispatch_with(
             println!("  docs                      Check docs/content for dead links + frontmatter");
             println!("  prices                    Refresh the vendor list prices (network)");
             println!("  prices --check            Fail if the price table would change (network)");
+            println!("  modalities                Refresh model input/output mime types (network)");
+            println!(
+                "  modalities --check        Fail if the modality table would change (network)"
+            );
             Ok(())
         }
         other => anyhow::bail!("Unknown subcommand: '{other}'. Run `cargo xtask help` for usage."),
@@ -130,6 +143,11 @@ mod tests {
         Ok(())
     }
 
+    /// A `run_mod` stub matching `impl FnOnce(ModalitiesMode) -> Result<()>`.
+    fn mod_ok(_mode: modalities::ModalitiesMode) -> Result<()> {
+        Ok(())
+    }
+
     /// Covers the stub body so tests that pass it without calling it still get
     /// this single coverage hit.
     #[test]
@@ -139,6 +157,7 @@ mod tests {
         assert!(docs_ok(docs::DocsMode::Check).is_ok());
         assert!(struct_ok(structure::StructureMode::Check).is_ok());
         assert!(prices_ok(prices::PricesMode::Check).is_ok());
+        assert!(mod_ok(modalities::ModalitiesMode::Check).is_ok());
     }
 
     /// Build an owned-args slice from string literals (dispatch takes `&[String]`).
@@ -201,6 +220,7 @@ mod tests {
             docs_ok,
             struct_ok,
             prices_ok,
+            mod_ok,
         )
         .unwrap();
         assert_eq!(got, Some(CoverageMode::All));
@@ -219,6 +239,7 @@ mod tests {
             docs_ok,
             struct_ok,
             prices_ok,
+            mod_ok,
         )
         .unwrap();
         assert_eq!(got, Some(CoverageMode::Package("leviath-core".to_owned())));
@@ -233,6 +254,7 @@ mod tests {
             docs_ok,
             struct_ok,
             prices_ok,
+            mod_ok,
         );
         assert!(
             result.is_err(),
@@ -249,6 +271,7 @@ mod tests {
             docs_ok,
             struct_ok,
             prices_ok,
+            mod_ok,
         );
         assert!(result.is_err());
         assert!(
@@ -274,6 +297,7 @@ mod tests {
             },
             struct_ok,
             prices_ok,
+            mod_ok,
         )
         .unwrap();
         assert_eq!(got, Some(docs::DocsMode::Check));
@@ -288,6 +312,7 @@ mod tests {
             docs_ok,
             struct_ok,
             prices_ok,
+            mod_ok,
         );
         assert!(
             result.is_err(),
@@ -310,9 +335,43 @@ mod tests {
                 got = Some(mode);
                 Ok(())
             },
+            mod_ok,
         )
         .unwrap();
         assert_eq!(got, Some(prices::PricesMode::Check));
+    }
+
+    #[test]
+    fn dispatch_with_modalities_parses_check() {
+        let mut got = None;
+        dispatch_with(
+            &args(&["modalities", "--check"]),
+            cov_ok,
+            ver_ok,
+            docs_ok,
+            struct_ok,
+            prices_ok,
+            |mode| {
+                got = Some(mode);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(got, Some(modalities::ModalitiesMode::Check));
+    }
+
+    #[test]
+    fn dispatch_with_modalities_bad_arg_returns_err() {
+        let result = dispatch_with(
+            &args(&["modalities", "--write"]),
+            cov_ok,
+            ver_ok,
+            docs_ok,
+            struct_ok,
+            prices_ok,
+            mod_ok,
+        );
+        assert!(result.is_err(), "an unknown modalities flag must error");
     }
 
     #[test]
@@ -324,6 +383,7 @@ mod tests {
             docs_ok,
             struct_ok,
             prices_ok,
+            mod_ok,
         );
         assert!(
             result.is_err(),
@@ -346,6 +406,7 @@ mod tests {
             docs_ok,
             struct_ok,
             prices_ok,
+            mod_ok,
         )
         .unwrap();
         assert_eq!(got, Some(VersionMode::Set("1.2.3".to_owned())));
@@ -364,6 +425,7 @@ mod tests {
             docs_ok,
             struct_ok,
             prices_ok,
+            mod_ok,
         )
         .unwrap();
         assert_eq!(got, Some(VersionMode::Check));
@@ -378,6 +440,7 @@ mod tests {
             docs_ok,
             struct_ok,
             prices_ok,
+            mod_ok,
         );
         assert!(
             result.is_err(),
@@ -394,6 +457,7 @@ mod tests {
             docs_ok,
             struct_ok,
             prices_ok,
+            mod_ok,
         );
         assert!(
             result

--- a/xtask/src/modalities.rs
+++ b/xtask/src/modalities.rs
@@ -1,0 +1,445 @@
+//! `cargo xtask modalities` - refresh which mime types each model takes and
+//! produces, for the vendors whose direct APIs do not report it per model.
+//!
+//! Anthropic, OpenAI and Google publish no per-model modality list a client
+//! can read, so `crates/leviath-providers/mime/modalities.toml` carries the
+//! lists and the runtime falls to a name heuristic where the file is silent.
+//! Keeping the file current by hand means guessing which of a vendor's models
+//! grew a modality, which is where a wrong row gets in. This command reads the
+//! same source `cargo xtask prices` reads - OpenRouter's public catalogue,
+//! whose `architecture` block names each model's input and output modalities -
+//! and rewrites the file from it.
+//!
+//! The rules are fixed so two runs on the same input write the same file:
+//!
+//! * a model the catalogue lists under a supported vendor is written with
+//!   `source = "openrouter"`, its `input`/`output` mapped from the modality
+//!   words (`text` to `text/*`, `image` to `image/*`, `file` to
+//!   `application/pdf`, `audio` to `audio/*`, `video` to `video/*`);
+//! * a row whose `source` is `manual` is never overwritten;
+//! * a row already in the file that the catalogue no longer lists is kept, so
+//!   a model dropped from the gateway is not silently forgotten;
+//! * a model id is kept as the vendor writes it, minus the `openai/`,
+//!   `anthropic/` or `google/` prefix; OpenRouter spells Anthropic's versions
+//!   with a dot (`claude-opus-4.8`) where the API id has a dash
+//!   (`claude-opus-4-8`), so those are normalised, and variants after a colon
+//!   (`:free`, `:thinking`) are routing options, not models, and are dropped;
+//! * patterns are written in a fixed order, so a row's list is stable.
+//!
+//! This is the modality half of the weekly model refresh; `cargo xtask prices`
+//! is the price half, and both read the one catalogue.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use crate::prices::{Fetch, NetworkError, is_network_error};
+
+/// The file this command owns, relative to the workspace root.
+pub const MODALITIES_FILE: &str = "crates/leviath-providers/mime/modalities.toml";
+
+/// OpenRouter's public catalogue: no key, each model carrying its architecture.
+const OPENROUTER_URL: &str = "https://openrouter.ai/api/v1/models";
+
+/// The wait a single fetch is allowed before it is called a network failure.
+const FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// The vendors whose direct APIs do not report modalities, and whose models
+/// the catalogue carries under these prefixes.
+const PROVIDERS: [&str; 3] = ["anthropic", "google", "openai"];
+
+/// Every pattern a modality word maps to, in the order rows are written.
+const ORDER: [&str; 5] = ["text/*", "image/*", "audio/*", "video/*", "application/pdf"];
+
+/// The header written above the rows, so a reader knows what writes the file.
+const FILE_HEADER: &str = "\
+# Published input and output modalities for the providers whose APIs do not
+# report them per model. Read by `leviath_providers::mime_tables` (longest
+# matching `prefix` wins) and rewritten by `cargo xtask modalities`, which takes
+# the lists from OpenRouter's catalogue architecture block.
+#
+# `source` records where a row came from: `openrouter` for a row the refresh
+# wrote, and `manual` for a row a person wrote, which the refresh never
+# overwrites. A model no row matches falls to the name heuristic in
+# `mime_tables`, which is the floor these rows lift.
+";
+
+// ── CLI argument parsing ─────────────────────────────────────────────────────
+
+/// What `cargo xtask modalities` was asked to do.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ModalitiesMode {
+    /// Fetch, merge, and rewrite the file when the rows changed.
+    Write,
+    /// Fetch, merge, print the diff, and fail if the file would change.
+    Check,
+}
+
+impl ModalitiesMode {
+    /// Parse the arguments after `modalities`.
+    pub fn parse(args: &[String]) -> Result<Self> {
+        match args.first().map(String::as_str) {
+            None => Ok(Self::Write),
+            Some("--check") => Ok(Self::Check),
+            Some(other) => {
+                anyhow::bail!("Unknown `modalities` argument: '{other}'. Try `--check`.")
+            }
+        }
+    }
+}
+
+// ── The table ────────────────────────────────────────────────────────────────
+
+/// One row of `modalities.toml`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct Row {
+    /// `anthropic`, `google` or `openai`.
+    pub provider: String,
+    /// The model-id prefix the row covers.
+    pub prefix: String,
+    /// Mime patterns the model accepts.
+    pub input: Vec<String>,
+    /// Mime patterns the model can produce.
+    pub output: Vec<String>,
+    /// `openrouter` for a row the refresh wrote, `manual` for a hand-written
+    /// row the refresh never overwrites.
+    pub source: String,
+}
+
+impl Row {
+    /// The lists as a compact `in -> out (source)` string for the diff.
+    fn lists(&self) -> String {
+        format!(
+            "[{}] -> [{}] ({})",
+            self.input.join(" "),
+            self.output.join(" "),
+            self.source
+        )
+    }
+}
+
+/// The file as parsed.
+#[derive(Debug, Deserialize)]
+struct ModalityFile {
+    /// `YYYY-MM-DD` of the last refresh.
+    read_on: String,
+    /// The rows, in file order.
+    #[serde(default)]
+    modality: Vec<Row>,
+}
+
+/// The rows keyed by `(provider, prefix)`, which is also the file's order.
+pub type Rows = BTreeMap<(String, String), Row>;
+
+/// The table: the day it was read, and its rows.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Table {
+    /// `YYYY-MM-DD` of the last refresh.
+    pub read_on: String,
+    /// Every row.
+    pub rows: Rows,
+}
+
+/// Parse `modalities.toml`.
+pub fn parse_table(text: &str) -> Result<Table> {
+    let file: ModalityFile = toml::from_str(text).context("modalities.toml does not parse")?;
+    let rows = file
+        .modality
+        .into_iter()
+        .map(|row| ((row.provider.clone(), row.prefix.clone()), row))
+        .collect();
+    Ok(Table {
+        read_on: file.read_on,
+        rows,
+    })
+}
+
+/// Render a table back to the file's text, header and all.
+pub fn render_table(table: &Table) -> String {
+    let mut out = String::from(FILE_HEADER);
+    out.push_str(&format!("\nread_on = \"{}\"\n", table.read_on));
+    for row in table.rows.values() {
+        out.push_str(&format!(
+            "\n[[modality]]\nprovider = \"{}\"\nprefix = \"{}\"\ninput = {}\noutput = {}\nsource = \"{}\"\n",
+            row.provider,
+            row.prefix,
+            toml_list(&row.input),
+            toml_list(&row.output),
+            row.source,
+        ));
+    }
+    out
+}
+
+/// A list of patterns as a TOML array literal.
+fn toml_list(patterns: &[String]) -> String {
+    let inner = patterns
+        .iter()
+        .map(|p| format!("\"{p}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{inner}]")
+}
+
+// ── The catalogue ────────────────────────────────────────────────────────────
+
+/// A modality word as the pattern it maps to, or `None` for a word no built-in
+/// family covers.
+fn modality_pattern(word: &str) -> Option<&'static str> {
+    match word.trim().to_ascii_lowercase().as_str() {
+        "text" => Some("text/*"),
+        "image" => Some("image/*"),
+        "audio" => Some("audio/*"),
+        "video" => Some("video/*"),
+        "file" => Some("application/pdf"),
+        _ => None,
+    }
+}
+
+/// The vendor id as the table spells it. OpenRouter writes Anthropic's versions
+/// with a dot where the API id has a dash.
+fn vendor_id(provider: &str, id: &str) -> String {
+    if provider == "anthropic" {
+        id.replace('.', "-")
+    } else {
+        id.to_string()
+    }
+}
+
+/// The words under `architecture.<key>`, mapped to patterns in the fixed order.
+fn patterns(architecture: Option<&serde_json::Value>, key: &str) -> Vec<String> {
+    let found: Vec<&'static str> = architecture
+        .and_then(|a| a.get(key))
+        .and_then(serde_json::Value::as_array)
+        .map(|words| {
+            words
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .filter_map(modality_pattern)
+                .collect()
+        })
+        .unwrap_or_default();
+    // Filtering the fixed order gives a stable list with no duplicates, since
+    // each pattern appears in `ORDER` exactly once.
+    ORDER
+        .iter()
+        .filter(|p| found.contains(p))
+        .map(|p| (*p).to_string())
+        .collect()
+}
+
+/// Parse the catalogue into the vendors' modality rows.
+pub fn parse_catalogue(body: &str) -> Result<Rows> {
+    let doc: serde_json::Value = serde_json::from_str(body).context("OpenRouter: not JSON")?;
+    let models = doc
+        .get("data")
+        .and_then(serde_json::Value::as_array)
+        .context("OpenRouter: no `data` array")?;
+    let mut out = Rows::new();
+    for model in models {
+        let Some(id) = model.get("id").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let Some((vendor, rest)) = id.split_once('/') else {
+            continue;
+        };
+        if !PROVIDERS.contains(&vendor) || rest.contains(':') {
+            continue;
+        }
+        let architecture = model.get("architecture");
+        let input = patterns(architecture, "input_modalities");
+        let output = patterns(architecture, "output_modalities");
+        if input.is_empty() || output.is_empty() {
+            continue;
+        }
+        out.insert(
+            (vendor.to_owned(), vendor_id(vendor, rest)),
+            Row {
+                provider: vendor.to_owned(),
+                prefix: vendor_id(vendor, rest),
+                input,
+                output,
+                source: "openrouter".to_owned(),
+            },
+        );
+    }
+    Ok(out)
+}
+
+// ── The merge ────────────────────────────────────────────────────────────────
+
+/// What a merge did to one row, for the diff.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Change {
+    /// A row the file did not have.
+    Added(Row),
+    /// A row whose lists moved, old and new.
+    Changed(Row, Row),
+}
+
+impl fmt::Display for Change {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Change::Added(row) => write!(f, "+ {}/{}: {}", row.provider, row.prefix, row.lists()),
+            Change::Changed(old, new) => write!(
+                f,
+                "~ {}/{}: {} -> {}",
+                old.provider,
+                old.prefix,
+                old.lists(),
+                new.lists()
+            ),
+        }
+    }
+}
+
+/// The result of a merge: the table to write, and what to say about it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Merged {
+    /// The table after the merge.
+    pub table: Table,
+    /// What moved, for the diff.
+    pub changes: Vec<Change>,
+}
+
+/// Fold the catalogue rows into the existing file: the catalogue wins except on
+/// a `manual` row, existing rows the catalogue no longer lists are kept, and
+/// `read_on` moves to today only when something changed.
+pub fn merge(existing: &Table, fetched: &Rows, today: &str) -> Merged {
+    let mut rows = existing.rows.clone();
+    let mut changes = Vec::new();
+    for (key, new) in fetched {
+        match rows.get(key) {
+            Some(old) if old.source == "manual" => {}
+            Some(old) if old.input == new.input && old.output == new.output => {}
+            Some(old) => {
+                changes.push(Change::Changed(old.clone(), new.clone()));
+                rows.insert(key.clone(), new.clone());
+            }
+            None => {
+                changes.push(Change::Added(new.clone()));
+                rows.insert(key.clone(), new.clone());
+            }
+        }
+    }
+    let read_on = if changes.is_empty() {
+        existing.read_on.clone()
+    } else {
+        today.to_string()
+    };
+    Merged {
+        table: Table { read_on, rows },
+        changes,
+    }
+}
+
+// ── Running ──────────────────────────────────────────────────────────────────
+
+/// The upshot of a run, for the caller and the tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// Nothing moved; the file is untouched.
+    Unchanged,
+    /// This many rows were written (or, under `--check`, would be).
+    Changed(usize),
+}
+
+/// Fetch, merge, and write or check, reporting on stdout.
+pub fn run_with(mode: ModalitiesMode, fetch: Fetch, path: &Path, today: &str) -> Result<Outcome> {
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let existing = parse_table(&text)?;
+    let fetched = parse_catalogue(&fetch(OPENROUTER_URL)?)?;
+    let merged = merge(&existing, &fetched, today);
+
+    for change in &merged.changes {
+        println!("{change}");
+    }
+    let added = merged
+        .changes
+        .iter()
+        .filter(|c| matches!(c, Change::Added(_)))
+        .count();
+    println!(
+        "modalities: {} rows, {} added, {} changed; openrouter {} models",
+        merged.table.rows.len(),
+        added,
+        merged.changes.len() - added,
+        fetched.len()
+    );
+
+    if merged.changes.is_empty() {
+        println!(
+            "modalities: {} is current as of {}",
+            path.display(),
+            existing.read_on
+        );
+        return Ok(Outcome::Unchanged);
+    }
+    let count = merged.changes.len();
+    match mode {
+        ModalitiesMode::Check => anyhow::bail!(
+            "{} would change ({count} rows); run `cargo xtask modalities`",
+            path.display()
+        ),
+        ModalitiesMode::Write => {
+            std::fs::write(path, render_table(&merged.table))
+                .with_context(|| format!("writing {}", path.display()))?;
+            println!(
+                "modalities: wrote {} rows to {} (read_on {today})",
+                merged.table.rows.len(),
+                path.display()
+            );
+            Ok(Outcome::Changed(count))
+        }
+    }
+}
+
+/// The real fetch: a GET with a bounded wait, any failure a [`NetworkError`].
+fn fetch_http(url: &str) -> Result<String> {
+    let body = reqwest::blocking::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .user_agent("leviath-xtask-modalities")
+        .build()
+        .and_then(|client| client.get(url).send())
+        .and_then(reqwest::blocking::Response::error_for_status)
+        .and_then(reqwest::blocking::Response::text)
+        .map_err(|e| NetworkError(format!("{url}: {e}")))?;
+    Ok(body)
+}
+
+/// The workspace root, from this crate's manifest directory.
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Today as `YYYY-MM-DD`, UTC, so two machines on one day agree.
+fn today() -> String {
+    chrono::Utc::now().format("%Y-%m-%d").to_string()
+}
+
+/// Entry point for `cargo xtask modalities [--check]`.
+///
+/// A network failure exits 2, as `prices` does, so a workflow can tell "could
+/// not check" from "the table is wrong".
+pub fn run(mode: ModalitiesMode) -> Result<()> {
+    let path = workspace_root().join(MODALITIES_FILE);
+    match run_with(mode, fetch_http, &path, &today()) {
+        Ok(_) => Ok(()),
+        Err(err) if is_network_error(&err) => {
+            eprintln!("modalities: {err}");
+            std::process::exit(2);
+        }
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(test)]
+#[path = "modalities_tests.rs"]
+mod tests;

--- a/xtask/src/modalities_tests.rs
+++ b/xtask/src/modalities_tests.rs
@@ -1,0 +1,184 @@
+//! Tests for `cargo xtask modalities`, driven off fixture JSON so no network
+//! is touched.
+
+use super::*;
+
+/// A minimal catalogue body with the fields the parser reads.
+fn catalogue() -> String {
+    serde_json::json!({
+        "data": [
+            {
+                "id": "anthropic/claude-opus-4.8",
+                "architecture": { "input_modalities": ["text", "image", "file"], "output_modalities": ["text"] }
+            },
+            {
+                "id": "openai/gpt-9o",
+                "architecture": { "input_modalities": ["image", "text"], "output_modalities": ["text"] }
+            },
+            {
+                "id": "google/gemini-x-image",
+                "architecture": { "input_modalities": ["text", "image"], "output_modalities": ["image", "text", "smell"] }
+            },
+            { "id": "deepseek/deepseek-v4", "architecture": { "input_modalities": ["text"], "output_modalities": ["text"] } },
+            { "id": "openai/gpt-free:free", "architecture": { "input_modalities": ["text"], "output_modalities": ["text"] } },
+            { "id": "noslash", "architecture": { "input_modalities": ["text"], "output_modalities": ["text"] } },
+            { "id": "openai/gpt-embed", "architecture": { "input_modalities": ["text"], "output_modalities": [] } }
+        ]
+    })
+    .to_string()
+}
+
+fn fixture_fetch(_url: &str) -> Result<String> {
+    Ok(catalogue())
+}
+
+fn failing_fetch(_url: &str) -> Result<String> {
+    Err(NetworkError("openrouter down".into()).into())
+}
+
+fn garbage_fetch(_url: &str) -> Result<String> {
+    Ok("not json".into())
+}
+
+#[test]
+fn mode_parses_write_check_and_rejects_junk() {
+    assert_eq!(ModalitiesMode::parse(&[]).unwrap(), ModalitiesMode::Write);
+    assert_eq!(
+        ModalitiesMode::parse(&["--check".into()]).unwrap(),
+        ModalitiesMode::Check
+    );
+    assert!(ModalitiesMode::parse(&["--nope".into()]).is_err());
+}
+
+#[test]
+fn the_catalogue_maps_words_and_filters_vendors() {
+    let rows = parse_catalogue(&catalogue()).unwrap();
+    // Only the three vendors, no colon variants, no slashless ids, no rows
+    // with an empty output list.
+    assert_eq!(rows.len(), 3);
+    // Anthropic's dotted version is normalised to a dash.
+    let opus = &rows[&("anthropic".into(), "claude-opus-4-8".into())];
+    assert_eq!(opus.input, vec!["text/*", "image/*", "application/pdf"]);
+    assert_eq!(opus.output, vec!["text/*"]);
+    assert_eq!(opus.source, "openrouter");
+    // Words map and reorder into the canonical order; an unknown word is
+    // dropped, and inputs keep their canonical order whatever the source order.
+    let gem = &rows[&("google".into(), "gemini-x-image".into())];
+    assert_eq!(gem.input, vec!["text/*", "image/*"]);
+    assert_eq!(gem.output, vec!["text/*", "image/*"]);
+    assert!(!rows.contains_key(&("openai".into(), "gpt-embed".into())));
+}
+
+#[test]
+fn a_table_round_trips_through_render_and_parse() {
+    let rows = parse_catalogue(&catalogue()).unwrap();
+    let table = Table {
+        read_on: "2026-09-11".into(),
+        rows,
+    };
+    let text = render_table(&table);
+    assert!(text.starts_with("# Published input and output modalities"));
+    let back = parse_table(&text).unwrap();
+    assert_eq!(back, table);
+}
+
+#[test]
+fn a_manual_row_is_kept_and_a_missing_model_is_not_forgotten() {
+    let existing = parse_table(
+        "read_on = \"2026-01-01\"\n\
+         [[modality]]\nprovider = \"anthropic\"\nprefix = \"claude-opus-4-8\"\ninput = [\"text/*\"]\noutput = [\"text/*\"]\nsource = \"manual\"\n\
+         [[modality]]\nprovider = \"openai\"\nprefix = \"legacy-model\"\ninput = [\"text/*\"]\noutput = [\"text/*\"]\nsource = \"openrouter\"\n",
+    )
+    .unwrap();
+    let fetched = parse_catalogue(&catalogue()).unwrap();
+    let merged = merge(&existing, &fetched, "2026-09-11");
+    // The manual opus row is untouched despite the catalogue listing more.
+    let opus = &merged.table.rows[&("anthropic".into(), "claude-opus-4-8".into())];
+    assert_eq!(opus.input, vec!["text/*"]);
+    assert_eq!(opus.source, "manual");
+    // The legacy row the catalogue no longer lists is still there.
+    assert!(
+        merged
+            .table
+            .rows
+            .contains_key(&("openai".into(), "legacy-model".into()))
+    );
+    // The two genuinely new rows are the only changes, both additions.
+    assert_eq!(merged.changes.len(), 2);
+    assert!(merged.changes.iter().all(|c| matches!(c, Change::Added(_))));
+    assert_eq!(merged.table.read_on, "2026-09-11");
+}
+
+#[test]
+fn a_changed_list_is_reported_and_an_unchanged_one_is_not() {
+    let existing = parse_table(
+        "read_on = \"2026-01-01\"\n\
+         [[modality]]\nprovider = \"anthropic\"\nprefix = \"claude-opus-4-8\"\ninput = [\"text/*\"]\noutput = [\"text/*\"]\nsource = \"openrouter\"\n",
+    )
+    .unwrap();
+    let fetched = parse_catalogue(&catalogue()).unwrap();
+    let merged = merge(&existing, &fetched, "2026-09-11");
+    let changed = merged
+        .changes
+        .iter()
+        .find(|c| matches!(c, Change::Changed(_, _)))
+        .unwrap();
+    assert!(format!("{changed}").contains("claude-opus-4-8"));
+    // Re-merging the written table against the same catalogue moves nothing.
+    let again = merge(&merged.table, &fetched, "2026-12-25");
+    assert!(again.changes.is_empty());
+    assert_eq!(again.table.read_on, merged.table.read_on);
+}
+
+#[test]
+fn added_change_prints_a_plus_line() {
+    let row = Row {
+        provider: "openai".into(),
+        prefix: "gpt-9o".into(),
+        input: vec!["text/*".into(), "image/*".into()],
+        output: vec!["text/*".into()],
+        source: "openrouter".into(),
+    };
+    assert!(format!("{}", Change::Added(row)).starts_with("+ openai/gpt-9o"));
+}
+
+#[test]
+fn run_with_writes_then_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("modalities.toml");
+    std::fs::write(&path, "read_on = \"2026-01-01\"\n").unwrap();
+    let outcome = run_with(ModalitiesMode::Write, fixture_fetch, &path, "2026-09-11").unwrap();
+    assert_eq!(outcome, Outcome::Changed(3));
+    let again = run_with(ModalitiesMode::Write, fixture_fetch, &path, "2026-12-25").unwrap();
+    assert_eq!(again, Outcome::Unchanged);
+}
+
+#[test]
+fn run_with_check_fails_when_the_file_would_change() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("modalities.toml");
+    std::fs::write(&path, "read_on = \"2026-01-01\"\n").unwrap();
+    let err = run_with(ModalitiesMode::Check, fixture_fetch, &path, "2026-09-11").unwrap_err();
+    assert!(err.to_string().contains("would change"));
+    assert!(!is_network_error(&err));
+}
+
+#[test]
+fn run_with_surfaces_the_network_and_parse_failures() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("modalities.toml");
+    std::fs::write(&path, "read_on = \"2026-01-01\"\n").unwrap();
+    let err = run_with(ModalitiesMode::Write, failing_fetch, &path, "2026-09-11").unwrap_err();
+    assert!(is_network_error(&err));
+    let err = run_with(ModalitiesMode::Write, garbage_fetch, &path, "2026-09-11").unwrap_err();
+    assert!(!is_network_error(&err));
+    // A missing file is a read error, not a network one.
+    let err = run_with(
+        ModalitiesMode::Write,
+        fixture_fetch,
+        &dir.path().join("gone.toml"),
+        "2026-09-11",
+    )
+    .unwrap_err();
+    assert!(!is_network_error(&err));
+}


### PR DESCRIPTION
Finishes the typed-mime work (#400) for the 0.6.0 alpha and folds in the two feature requests filed alongside it. Five green commits, each passing the full gate.

## What's here

- **Regions are bounded by tokens, not a file count (#400).** The per-region `max_stored` cap counted stored parts and evicted or refused once the count was hit, even when the tokens fit — a second, artificial limit on top of the token budget. Removed everywhere (manifest key, schema, `push_entry` enforcement, the dashboard picker's count cap and single-file swap, the agent-editor field). A region now admits parts until its token budget is reached, then evicts the oldest or refuses under `admission = "reject"`.

- **The per-request media cap is bytes, not a part count (#400).** `max_stored_per_request` (a count) becomes `max_media_bytes_per_request` (default 64 MiB), a byte cap on the stored media one request carries. A token budget already governs how much a request holds, and an image's token estimate is a few thousand tokens whatever its byte size, so the real thing worth guarding is the vendor request-size limit a token budget cannot see — and that is bytes. Hydration sums the raw bytes a model would receive natively and sheds the oldest to stand-ins until the rest fit. Also pins the token estimate the TUI shows before a file is attached to what the daemon charges at ingest and what the HTTP blob listing serves — one `TokenRule::estimate` for all three.

- **Model modalities refresh from the catalogue, like prices (#400).** OpenRouter's catalogue names each model's input/output modalities in its `architecture` block — the same document `cargo xtask prices` reads — so the built-in whole-vendor guess can be a fact. A new `cargo xtask modalities` (and `--check`) writes `mime/modalities.toml` from it, and `mime_tables` reads it (longest prefix wins), falling to the name heuristic for a model no row names. So `claude-3-haiku`, which takes images but not PDFs, is described precisely rather than over-claiming. The runtime still prefers a live listing (OpenRouter's `architecture`, Ollama's `/api/show`) and an operator's `[model_capabilities]` over the table.

- **Write a mime row over HTTP (#814).** `GET /api/mime` read the registry and nothing wrote to it, so a console could show a custom type and never make one. `PUT /api/mime` adds or updates a row and `DELETE /api/mime?mime_type=` takes one out, both writing `mime_types.toml` beside the config through the same `add_row`/`remove_row` and validation `lev mime add`/`remove` use. Admin-gated like `PUT /api/config`, announced as `mime.write`, documented in the API guide and the OpenAPI spec.

- **Changelog tidy.** Reflow two entries whose code spans had drifted across a line break.

## Verification

Every commit passes the pre-commit gate: fmt, `cargo clippy --all-targets --all-features -D warnings`, `cargo xtask coverage` (100% per touched crate), `cargo xtask docs`, `cargo xtask structure`, and the full test suite. New tests pin the byte-cap shedding (bytes, not count), the TUI/ingest token agreement, the modality table refinement over the heuristic, the `cargo xtask modalities` refresh/merge, and the mime write handlers (create/update/remove, bad type/rule/magic, 404). `cargo xtask modalities --check` is clean against the shipped file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kh7J65m1oRXm1WP7vCb7YN
