### PR TITLE
fix(media): image stages draw the asked subject and the next stage sees the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,22 @@ same list.
 
 ### Fixed
 
+- An image a stage drew reached the next stage, and an image-output model drew
+  the subject it was asked for. Two faults in how typed media crossed a stage
+  boundary made an image agent draw the wrong picture and then describe a
+  different one:
+  - An image-output model (`google/gemini-2.5-flash-image` and the like) draws
+    whatever is in its user turn, but a stage's prompt lands in the system
+    blocks with a bare `Begin.` user nudge - the convention that makes a text
+    model act - so the model drew the nudge: "draw a rabbit" came back as a
+    generic "start of a journey" landscape. A model that emits images now gets
+    its prompt in the user turn, so it draws the subject.
+  - A model-produced image rode the assistant turn that made it, and a provider
+    refuses or ignores an image inside an assistant turn (Anthropic answers
+    `400: 'image' blocks are not permitted within assistant turns`), so the
+    next stage never saw it and described the task text instead of the picture.
+    A produced image is now lifted into a following user turn, where the next
+    stage's model actually sees it.
 - A run's `modified_files` missed a file a `shell` command created. Only a
   modifying tool that names a `path` (`write_file`, `edit_file`) was recorded,
   so an agent whose whole job was to draw a chart or build an artifact with a

--- a/crates/leviath-providers/src/capabilities.rs
+++ b/crates/leviath-providers/src/capabilities.rs
@@ -283,6 +283,14 @@ impl ModelMime {
         mime_type.matches_any(&self.output)
     }
 
+    /// Whether the model emits images, so its request is built for image
+    /// generation (the prompt in the user turn) rather than for a text reply.
+    pub fn produces_images(&self) -> bool {
+        self.output
+            .iter()
+            .any(|p| p == "image/*" || p.starts_with("image/"))
+    }
+
     /// Whether every pattern in `wanted` is covered by an input pattern.
     ///
     /// `image/png` is covered by `image/png`, `image/*` or `*/*`; `image/*`
@@ -447,6 +455,11 @@ mod mime_tests {
         assert!(!m.produces(&mt("image/png")));
         assert!(!m.takes_mime());
         assert!(ModelMime::new(&["text/*", "image/*"], &["text/*"]).takes_mime());
+        // An image generator is known by its output, so its request is built
+        // for drawing (prompt in the user turn) rather than for a text reply.
+        assert!(!m.produces_images());
+        assert!(ModelMime::new(&["text/*"], &["text/*", "image/*"]).produces_images());
+        assert!(ModelMime::new(&["text/*", "image/*"], &["image/png"]).produces_images());
     }
 
     #[test]

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -741,15 +741,25 @@ impl ContextWindow {
                                 });
                             }
                             EntryKind::AssistantTurn { tool_calls } => {
+                                // Media a stage produced (an image a model drew)
+                                // cannot ride the assistant turn that made it: a
+                                // provider rejects an image inside an assistant
+                                // turn (Anthropic answers 400), so a later stage
+                                // that should see it never would. The assistant
+                                // turn keeps its text and the stand-ins that name
+                                // the media; the bytes follow in a user turn.
+                                let lifted_media = mime::mime_blocks(&entry.content);
                                 if tool_calls.is_empty() {
                                     messages.push(leviath_providers::Message {
                                         role: "assistant".to_string(),
-                                        content: mime::message_content(&entry.content),
+                                        content: leviath_providers::MessageContent::Text(
+                                            entry.content.to_string(),
+                                        ),
                                         cache_breakpoint: false,
                                         reasoning: entry.reasoning.clone(),
                                     });
                                 } else {
-                                    let mut blocks = mime::content_blocks(&entry.content);
+                                    let mut blocks = mime::text_blocks(&entry.content);
                                     for tc in tool_calls {
                                         blocks.push(leviath_providers::ContentBlock::ToolUse {
                                             id: tc.id.clone(),
@@ -763,6 +773,21 @@ impl ContextWindow {
                                         content: leviath_providers::MessageContent::Blocks(blocks),
                                         cache_breakpoint: false,
                                         reasoning: entry.reasoning.clone(),
+                                    });
+                                }
+                                // Only when the turn has no tool calls: inserting
+                                // a user turn between a tool_use and its
+                                // tool_result would break the pairing a provider
+                                // requires, and that rare turn's media stays a
+                                // stand-in rather than risk it.
+                                if tool_calls.is_empty() && !lifted_media.is_empty() {
+                                    messages.push(leviath_providers::Message {
+                                        role: "user".to_string(),
+                                        content: leviath_providers::MessageContent::Blocks(
+                                            lifted_media,
+                                        ),
+                                        cache_breakpoint: false,
+                                        reasoning: None,
                                     });
                                 }
                             }

--- a/crates/leviath-runtime/src/components/context_window/mime.rs
+++ b/crates/leviath-runtime/src/components/context_window/mime.rs
@@ -42,6 +42,17 @@ pub(super) fn mime_blocks(content: &EntryContent) -> Vec<ContentBlock> {
         .collect()
 }
 
+/// [`content_blocks`] with the mime blocks left out: inline text and the
+/// stand-in for each stored part, but not the bytes. For an assistant turn,
+/// whose media is lifted into a following user turn because a provider rejects
+/// an image inside an assistant turn.
+pub(super) fn text_blocks(content: &EntryContent) -> Vec<ContentBlock> {
+    content_blocks(content)
+        .into_iter()
+        .filter(|b| !matches!(b, ContentBlock::Mime { .. }))
+        .collect()
+}
+
 /// A message's content for `content`: plain text when every part is text,
 /// which is the shape every provider has always seen, and blocks otherwise.
 pub(super) fn message_content(content: &EntryContent) -> MessageContent {
@@ -117,6 +128,12 @@ mod tests {
             message_content(&content),
             MessageContent::Blocks(blocks.clone())
         );
+        // `text_blocks` keeps the inline text and the stand-in pointer but not
+        // the mime block, for an assistant turn whose media is lifted away.
+        let text = text_blocks(&content);
+        assert_eq!(text.len(), 2);
+        assert!(text.iter().all(|b| !matches!(b, ContentBlock::Mime { .. })));
+        assert_eq!(text[0], ContentBlock::Text { text: "see".into() });
     }
 
     #[test]
@@ -197,17 +214,25 @@ mod tests {
         // The user turn carries its text, the stand-in and the mime block.
         let user = blocks_of(&messages[1].content);
         assert_eq!(user.len(), 3);
-        // The assistant turn keeps its mime before the tool call.
+        // The assistant turn that also called a tool keeps its text and the
+        // stand-in naming any media it made, but not the media block: that turn
+        // cannot carry bytes, and a user turn between its tool_use and the
+        // tool_result would break the pairing a provider requires, so the rare
+        // tool-and-media turn keeps only the stand-in.
         let assistant = blocks_of(&messages[2].content);
-        assert!(assistant[2].stand_in().is_some());
+        assert!(
+            assistant
+                .iter()
+                .all(|b| !matches!(b, ContentBlock::Mime { .. }))
+        );
         assert_eq!(
-            assistant[3],
-            ContentBlock::ToolUse {
+            assistant.last(),
+            Some(&ContentBlock::ToolUse {
                 id: "c1".into(),
                 name: "render".into(),
                 input: serde_json::json!({}),
                 thought_signature: None,
-            }
+            })
         );
         // The tool result's mime follows the result block in the same turn.
         let result = blocks_of(&messages[3].content);
@@ -233,6 +258,51 @@ mod tests {
                 .flat_map(|m| blocks_of(&m.content))
                 .all(|b| !b.is_hydrated_mime())
         );
+    }
+
+    #[test]
+    fn a_produced_image_is_lifted_off_the_assistant_turn_into_a_user_turn() {
+        use crate::components::ContextWindow;
+        use leviath_core::EntryKind;
+        let mut window = ContextWindow::new(100_000);
+        window.add_region(Region::new(
+            "conversation".into(),
+            RegionKind::SlidingWindow {
+                max_items: 50,
+                eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+            },
+            50_000,
+        ));
+        let conv = window.get_region_mut("conversation").unwrap();
+        // The draw stage's reply: some text and the image it drew, no tool call.
+        conv.add_typed_entry(
+            EntryContent::from_parts(vec![Part::text("here it is"), stored("image-1.png")]),
+            5,
+            EntryKind::AssistantTurn { tool_calls: vec![] },
+        )
+        .unwrap();
+
+        let messages = window.assemble().messages;
+        let blocks_of = |content: &MessageContent| -> Vec<ContentBlock> {
+            match content {
+                MessageContent::Blocks(b) => b.clone(),
+                MessageContent::Text(_) => Vec::new(),
+            }
+        };
+        // The assistant turn keeps its text and the stand-in, no bytes.
+        assert_eq!(messages[0].role, "assistant");
+        assert_eq!(
+            messages[0].content,
+            MessageContent::Text("here it is\n[image/png, 3 B] image-1.png".to_string())
+        );
+        assert!(blocks_of(&messages[0].content).is_empty());
+        // The image follows in a user turn, where a provider will actually
+        // show it - an image inside the assistant turn is refused (Anthropic
+        // 400s) or ignored, so the next stage would never see it.
+        assert_eq!(messages[1].role, "user");
+        let lifted = blocks_of(&messages[1].content);
+        assert_eq!(lifted.len(), 1);
+        assert!(lifted[0].stand_in().is_some() && !lifted[0].is_hydrated_mime());
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -267,6 +267,43 @@ pub(crate) fn build_request(
     let mut system = hint_blocks(config, &filtered_tools, std::env::consts::OS);
     system.extend(assembled.system_blocks);
 
+    // An image-output model draws whatever is in its user turn. A stage's
+    // prompt lands in the system blocks with a bare "Begin." user nudge (the
+    // convention that makes a text model act), and an image model draws the
+    // nudge - "Begin." becomes generic "start of a journey" scenery, never the
+    // subject. Move the prompt into the user turn so the model draws it. The
+    // system blocks stay: the model may ignore them, and a text-capable image
+    // model still reads them.
+    let mut messages = messages;
+    if provider.mime(&stage.model).produces_images() {
+        let prompt: String = system
+            .iter()
+            .map(|block| block.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        if !prompt.is_empty() {
+            let nudge = messages.iter().position(|m| {
+                m.role == "user"
+                    && matches!(&m.content, leviath_providers::MessageContent::Text(text) if text.trim() == "Begin.")
+            });
+            match nudge {
+                // The bare "Begin." nudge becomes the prompt.
+                Some(index) => {
+                    messages[index].content = leviath_providers::MessageContent::Text(prompt);
+                }
+                // No nudge to replace (an image-edit stage carries an input
+                // image in the conversation): the prompt follows as its own
+                // user turn, which an image model reads as its instruction.
+                None => messages.push(leviath_providers::Message {
+                    role: "user".to_string(),
+                    content: leviath_providers::MessageContent::Text(prompt),
+                    cache_breakpoint: false,
+                    reasoning: None,
+                }),
+            }
+        }
+    }
+
     let request = InferenceRequest {
         system,
         messages,

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -55,6 +55,16 @@ impl Provider for Cfg {
             ..Default::default()
         }
     }
+    fn mime(&self, model: &str) -> leviath_providers::ModelMime {
+        // A model named for image output draws; everything else is text, the
+        // default. Keyed on the name so only the test that wants it triggers
+        // the image-request shaping.
+        if model.contains("image-out") {
+            leviath_providers::ModelMime::new(&["text/*"], &["text/*", "image/*"])
+        } else {
+            leviath_providers::ModelMime::text_only()
+        }
+    }
 }
 
 fn window() -> ContextWindow {
@@ -201,6 +211,138 @@ fn a_model_without_tools_gets_its_history_as_prose_and_no_tools() {
     .0;
     assert!(req.tools.is_empty());
     assert!(!format!("{:?}", req.messages).contains("ToolUse"));
+}
+
+/// An image-output model draws its user turn, so the prompt (which a text
+/// stage leaves in the system blocks with a bare "Begin." nudge) is moved into
+/// the user turn - otherwise the model draws the nudge, "Begin." becoming
+/// generic scenery rather than the subject.
+#[test]
+fn an_image_model_gets_its_prompt_in_the_user_turn() {
+    let mut w = ContextWindow::new(10_000);
+    w.add_region(Region::new("task".to_string(), RegionKind::Pinned, 1000));
+    w.add_typed_entry(
+        "task",
+        leviath_core::EntryKind::Text,
+        "draw a picture of a rabbit".to_string(),
+        5,
+    )
+    .unwrap();
+    let prov = Arc::new(Cfg {
+        supports_temperature: true,
+        max_output: 1000,
+        supports_tools: false,
+    }) as Arc<dyn Provider>;
+
+    // An image model: the prompt is in a user turn, the "Begin." nudge gone.
+    let req = build_request(
+        &w,
+        None,
+        &stage("image-out-drawer", vec![], None),
+        &prov,
+        "draw",
+        0,
+        crate::pipeline::inference::PriorCalls::default(),
+    )
+    .0;
+    let user_text = req
+        .messages
+        .iter()
+        .filter(|m| m.role == "user")
+        .map(|m| m.content.as_text())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        user_text.contains("draw a picture of a rabbit"),
+        "prompt in the user turn: {user_text}"
+    );
+    assert!(!user_text.contains("Begin."), "nudge replaced: {user_text}");
+
+    // A text model on the same window keeps the prompt in system and the nudge.
+    let text = build_request(
+        &w,
+        None,
+        &stage("plain-text-model", vec![], None),
+        &prov,
+        "draw",
+        0,
+        crate::pipeline::inference::PriorCalls::default(),
+    )
+    .0;
+    let text_user = text
+        .messages
+        .iter()
+        .filter(|m| m.role == "user")
+        .map(|m| m.content.as_text())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        text_user.contains("Begin."),
+        "text model nudged: {text_user}"
+    );
+    assert!(
+        format!("{:?}", text.system).contains("draw a picture of a rabbit"),
+        "text model keeps the prompt in system"
+    );
+
+    // An image-edit stage: the conversation already holds a user turn (the
+    // input image), so there is no "Begin." nudge to replace and the prompt is
+    // appended as its own user turn.
+    let mut edit = ContextWindow::new(10_000);
+    edit.add_region(Region::new("task".to_string(), RegionKind::Pinned, 1000));
+    edit.add_typed_entry(
+        "task",
+        leviath_core::EntryKind::Text,
+        "add a hat".to_string(),
+        5,
+    )
+    .unwrap();
+    edit.add_region(Region::new(
+        "conversation".to_string(),
+        RegionKind::SlidingWindow {
+            max_items: 20,
+            eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+        },
+        5000,
+    ));
+    edit.add_typed_entry(
+        "conversation",
+        leviath_core::EntryKind::UserMessage,
+        "the source photo".to_string(),
+        5,
+    )
+    .unwrap();
+    let req = build_request(
+        &edit,
+        None,
+        &stage("image-out-editor", vec![], None),
+        &prov,
+        "edit",
+        0,
+        crate::pipeline::inference::PriorCalls::default(),
+    )
+    .0;
+    assert_eq!(req.messages.last().unwrap().role, "user");
+    assert_eq!(
+        req.messages.last().unwrap().content.as_text(),
+        "## task\nadd a hat"
+    );
+
+    // An image model with an empty window has no prompt to move, and builds a
+    // request without incident.
+    let empty = ContextWindow::new(10_000);
+    let req = build_request(
+        &empty,
+        None,
+        &stage("image-out-drawer", vec![], None),
+        &prov,
+        "draw",
+        0,
+        crate::pipeline::inference::PriorCalls::default(),
+    )
+    .0;
+    assert!(req.system.is_empty());
+    assert_eq!(req.messages.last().unwrap().content.as_text(), "Begin.");
 }
 
 // ── build_request branch coverage ──


### PR DESCRIPTION
Investigated run `image-gen-1789114443-d2b4275ef115` and found **two** deterministic bugs in how typed media crosses a stage boundary — the draw stage drew the wrong picture, and the describe stage then described a different one. Both are root-caused with hard evidence and fixed, and the fix is validated end-to-end against real image generation.

## What was happening

The `image-gen` agent (`draw` an image with `google/gemini-2.5-flash-image`, then `describe` it with `claude-sonnet-5`) drew a landscape for "draw a rabbit" and described a rabbit that wasn't there. Two independent causes:

### 1. The image model drew the "Begin." nudge, not the prompt

An image-output model draws whatever is in its **user** turn. A stage's prompt lands in the **system** blocks with a bare `Begin.` user nudge (the convention that makes a text model act), so the image model drew the nudge — "draw a rabbit" came back as generic "start of a journey" scenery (hikers, mountains, sunsets), **every time**.

Proven by replaying leviath's exact request to OpenRouter: **3/3 landscapes** with the prompt in system + `Begin.` user; **3/3 correct rabbits** with the prompt moved to the user turn.

**Fix:** `build_request` moves the prompt into the user turn for a model that produces images (new `ModelMime::produces_images`), replacing the `Begin.` nudge — or, for an image-edit stage that already holds an input image, appending it. The system blocks stay for a text-capable image model.

### 2. The produced image rode an assistant turn the next stage couldn't see

A model-produced image was replayed on the **assistant** turn that made it. A provider refuses or ignores an image inside an assistant turn — Anthropic answers `400: 'image' blocks are not permitted within assistant turns` — so the describe stage never saw the picture and described the task text instead. A landscape came back described as "a cute rabbit".

Proven with a direct Anthropic call: the same image in a **user** turn is described perfectly; in an **assistant** turn it's a hard 400.

**Fix:** the assembly lifts a produced image off the assistant turn into a following **user** turn, where the next stage's model actually sees it; the assistant turn keeps the stand-in that names it. A turn that also called a tool keeps only the stand-in (a user turn between its `tool_use` and `tool_result` would break the pairing).

## Validation

Ran the real agent end-to-end on the current build after the fix, three varied prompts:

| task | drew | described |
|---|---|---|
| a rabbit | ✅ a rabbit in a wildflower meadow | ✅ accurately, incl. the meadow/wildflowers |
| a red bicycle leaning on a brick wall | ✅ a red bicycle + wicker basket on a brick wall | ✅ incl. the basket and cobblestones |
| a slice of chocolate cake on a white plate | ✅ a chocolate cake slice on a white plate | ✅ incl. the ganache and layers |

The describe outputs name details only a model that actually saw the image could — confirming both fixes.

`cargo xtask coverage` passes at 100% for `leviath-providers` and `leviath-runtime`; new tests cover `produces_images`, the assistant-turn media lift (and the tool-turn stand-in path), and the image-model prompt placement (replace / append / empty).

## Note

Leaving this **open for your review** rather than merging, since you asked to take a look. It's green and ready to merge on your OK. The v0.6.0 version bump stays held until you confirm this is good to go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kh7J65m1oRXm1WP7vCb7YN
