### PR TITLE
fix(media): fold the system prompt into the user turn by capability, not output type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,12 +370,16 @@ same list.
   the subject it was asked for. Two faults in how typed media crossed a stage
   boundary made an image agent draw the wrong picture and then describe a
   different one:
-  - An image-output model (`google/gemini-2.5-flash-image` and the like) draws
-    whatever is in its user turn, but a stage's prompt lands in the system
-    blocks with a bare `Begin.` user nudge - the convention that makes a text
-    model act - so the model drew the nudge: "draw a rabbit" came back as a
-    generic "start of a journey" landscape. A model that emits images now gets
-    its prompt in the user turn, so it draws the subject.
+  - `google/gemini-2.5-flash-image` ignores the system prompt and generates
+    from its user turn, but a stage's prompt lands in the system blocks with a
+    bare `Begin.` user nudge - the convention that makes a text model act - so
+    the model drew the nudge: "draw a rabbit" came back as a generic "start of
+    a journey" landscape. A model that does not read the system prompt now has
+    it folded into the first user turn, so the model generates the asked
+    subject. Whether a model reads the system prompt is the existing
+    `supports_system_prompt` capability (settable per model in
+    `[model_capabilities]`); no catalogue distinguishes the image model that
+    ignores it from the one that honours it, so that one is a compiled one-off.
   - A model-produced image rode the assistant turn that made it, and a provider
     refuses or ignores an image inside an assistant turn (Anthropic answers
     `400: 'image' blocks are not permitted within assistant turns`), so the

--- a/crates/leviath-providers/src/capabilities.rs
+++ b/crates/leviath-providers/src/capabilities.rs
@@ -157,6 +157,23 @@ pub fn builtin_catalog() -> Vec<CatalogEntry> {
     .collect()
 }
 
+/// Models that ignore the system prompt, so a request built for one folds its
+/// system blocks into the user turn instead of losing them.
+///
+/// No provider reports this - OpenRouter's catalogue does not distinguish a
+/// model that reads the system prompt from one that ignores it (measured:
+/// `gemini-2.5-flash-image` and `gemini-3-pro-image` carry identical
+/// `architecture` and `supported_parameters`, yet the first ignores a system
+/// prompt outright and the second honours it). So it is a hand-maintained
+/// one-off. Matched on the id's last segment, so `gemini-2.5-flash-image`
+/// reached through any route (`openrouter/google/…`, `google/…`, the bare id)
+/// is recognised. An operator can also declare it for any model with
+/// `[model_capabilities."<id>"] supports_system_prompt = false`.
+pub fn ignores_system_prompt(model: &str) -> bool {
+    let name = model.rsplit('/').next().unwrap_or(model);
+    name == "gemini-2.5-flash-image"
+}
+
 /// Capabilities supported by a model.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModelCapabilities {
@@ -281,14 +298,6 @@ impl ModelMime {
     /// Whether the model may hand back a part of `mime_type`.
     pub fn produces(&self, mime_type: &leviath_core::mime::MimeType) -> bool {
         mime_type.matches_any(&self.output)
-    }
-
-    /// Whether the model emits images, so its request is built for image
-    /// generation (the prompt in the user turn) rather than for a text reply.
-    pub fn produces_images(&self) -> bool {
-        self.output
-            .iter()
-            .any(|p| p == "image/*" || p.starts_with("image/"))
     }
 
     /// Whether every pattern in `wanted` is covered by an input pattern.
@@ -455,11 +464,19 @@ mod mime_tests {
         assert!(!m.produces(&mt("image/png")));
         assert!(!m.takes_mime());
         assert!(ModelMime::new(&["text/*", "image/*"], &["text/*"]).takes_mime());
-        // An image generator is known by its output, so its request is built
-        // for drawing (prompt in the user turn) rather than for a text reply.
-        assert!(!m.produces_images());
-        assert!(ModelMime::new(&["text/*"], &["text/*", "image/*"]).produces_images());
-        assert!(ModelMime::new(&["text/*", "image/*"], &["image/png"]).produces_images());
+    }
+
+    #[test]
+    fn the_system_prompt_one_off_is_matched_by_the_id_last_segment() {
+        // Reached through any route, and the bare id.
+        assert!(ignores_system_prompt("gemini-2.5-flash-image"));
+        assert!(ignores_system_prompt("google/gemini-2.5-flash-image"));
+        assert!(ignores_system_prompt(
+            "openrouter/google/gemini-2.5-flash-image"
+        ));
+        // A model not on the list, and a near miss, are not folded.
+        assert!(!ignores_system_prompt("google/gemini-3-pro-image"));
+        assert!(!ignores_system_prompt("claude-sonnet-5"));
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -267,41 +267,19 @@ pub(crate) fn build_request(
     let mut system = hint_blocks(config, &filtered_tools, std::env::consts::OS);
     system.extend(assembled.system_blocks);
 
-    // An image-output model draws whatever is in its user turn. A stage's
-    // prompt lands in the system blocks with a bare "Begin." user nudge (the
-    // convention that makes a text model act), and an image model draws the
-    // nudge - "Begin." becomes generic "start of a journey" scenery, never the
-    // subject. Move the prompt into the user turn so the model draws it. The
-    // system blocks stay: the model may ignore them, and a text-capable image
-    // model still reads them.
+    // A model that does not read a system prompt has the stage's instruction
+    // folded into the user turn instead, or it is lost. It lands in the system
+    // blocks with a bare "Begin." user nudge (the convention that makes a text
+    // model act); a model that ignores the system prompt generates from the
+    // nudge - an image model's "Begin." becomes generic "start of a journey"
+    // scenery, never the asked subject. The capability says whether the model
+    // reads the system prompt; `ignores_system_prompt` is the one-off for a
+    // model no catalogue distinguishes (`gemini-2.5-flash-image`).
     let mut messages = messages;
-    if provider.mime(&stage.model).produces_images() {
-        let prompt: String = system
-            .iter()
-            .map(|block| block.text.as_str())
-            .collect::<Vec<_>>()
-            .join("\n\n");
-        if !prompt.is_empty() {
-            let nudge = messages.iter().position(|m| {
-                m.role == "user"
-                    && matches!(&m.content, leviath_providers::MessageContent::Text(text) if text.trim() == "Begin.")
-            });
-            match nudge {
-                // The bare "Begin." nudge becomes the prompt.
-                Some(index) => {
-                    messages[index].content = leviath_providers::MessageContent::Text(prompt);
-                }
-                // No nudge to replace (an image-edit stage carries an input
-                // image in the conversation): the prompt follows as its own
-                // user turn, which an image model reads as its instruction.
-                None => messages.push(leviath_providers::Message {
-                    role: "user".to_string(),
-                    content: leviath_providers::MessageContent::Text(prompt),
-                    cache_breakpoint: false,
-                    reasoning: None,
-                }),
-            }
-        }
+    let reads_system = caps.supports_system_prompt
+        && !leviath_providers::capabilities::ignores_system_prompt(&stage.model);
+    if !reads_system {
+        fold_system_into_user(&mut system, &mut messages);
     }
 
     let request = InferenceRequest {
@@ -315,6 +293,46 @@ pub(crate) fn build_request(
         request_timeout_secs: config.and_then(|c| c.request_timeout_secs),
     };
     (request, system_hash, block_hashes)
+}
+
+/// Fold the system blocks into the first user turn and clear them, for a model
+/// that does not read a system prompt. Done into the *first* user message, once,
+/// so a multi-turn conversation keeps its shape: the bare "Begin." nudge is
+/// replaced outright, a real text turn is prefixed, and a turn that carries
+/// blocks (an input image) gains the text ahead of them. With no user turn at
+/// all the folded system becomes one.
+pub(crate) fn fold_system_into_user(
+    system: &mut Vec<leviath_providers::SystemBlock>,
+    messages: &mut Vec<leviath_providers::Message>,
+) {
+    let text = system
+        .iter()
+        .map(|block| block.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if text.is_empty() {
+        return;
+    }
+    system.clear();
+    match messages.iter_mut().find(|m| m.role == "user") {
+        Some(first) => match &mut first.content {
+            leviath_providers::MessageContent::Text(existing) => {
+                *existing = match existing.trim() == "Begin." {
+                    true => text,
+                    false => format!("{text}\n\n{existing}"),
+                };
+            }
+            leviath_providers::MessageContent::Blocks(blocks) => {
+                blocks.insert(0, leviath_providers::ContentBlock::Text { text });
+            }
+        },
+        None => messages.push(leviath_providers::Message {
+            role: "user".to_string(),
+            content: leviath_providers::MessageContent::Text(text),
+            cache_breakpoint: false,
+            reasoning: None,
+        }),
+    }
 }
 
 /// Build the [`RetryPolicy`] for a job from the operator's `[limits]` retry

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -55,16 +55,6 @@ impl Provider for Cfg {
             ..Default::default()
         }
     }
-    fn mime(&self, model: &str) -> leviath_providers::ModelMime {
-        // A model named for image output draws; everything else is text, the
-        // default. Keyed on the name so only the test that wants it triggers
-        // the image-request shaping.
-        if model.contains("image-out") {
-            leviath_providers::ModelMime::new(&["text/*"], &["text/*", "image/*"])
-        } else {
-            leviath_providers::ModelMime::text_only()
-        }
-    }
 }
 
 fn window() -> ContextWindow {
@@ -213,12 +203,13 @@ fn a_model_without_tools_gets_its_history_as_prose_and_no_tools() {
     assert!(!format!("{:?}", req.messages).contains("ToolUse"));
 }
 
-/// An image-output model draws its user turn, so the prompt (which a text
-/// stage leaves in the system blocks with a bare "Begin." nudge) is moved into
-/// the user turn - otherwise the model draws the nudge, "Begin." becoming
-/// generic scenery rather than the subject.
+/// A model that does not read a system prompt has the stage's instruction
+/// folded into the user turn. A stage leaves it in the system blocks with a
+/// bare "Begin." nudge - the convention that makes a text model act - and a
+/// model that ignores the system prompt (an image generator) would generate
+/// from the nudge, never the subject, so the fold rescues it.
 #[test]
-fn an_image_model_gets_its_prompt_in_the_user_turn() {
+fn a_model_that_ignores_the_system_prompt_gets_it_folded_into_the_user_turn() {
     let mut w = ContextWindow::new(10_000);
     w.add_region(Region::new("task".to_string(), RegionKind::Pinned, 1000));
     w.add_typed_entry(
@@ -234,17 +225,24 @@ fn an_image_model_gets_its_prompt_in_the_user_turn() {
         supports_tools: false,
     }) as Arc<dyn Provider>;
 
-    // An image model: the prompt is in a user turn, the "Begin." nudge gone.
+    // gemini-2.5-flash-image ignores the system prompt (the one-off): the whole
+    // system, the task included, folds into the user turn, the nudge replaced,
+    // and the system is left empty.
     let req = build_request(
         &w,
         None,
-        &stage("image-out-drawer", vec![], None),
+        &stage("google/gemini-2.5-flash-image", vec![], None),
         &prov,
         "draw",
         0,
         crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
+    assert!(
+        req.system.is_empty(),
+        "system folded away: {:?}",
+        req.system
+    );
     let user_text = req
         .messages
         .iter()
@@ -258,83 +256,34 @@ fn an_image_model_gets_its_prompt_in_the_user_turn() {
     );
     assert!(!user_text.contains("Begin."), "nudge replaced: {user_text}");
 
-    // A text model on the same window keeps the prompt in system and the nudge.
+    // A model that reads the system prompt keeps it there, with the nudge.
     let text = build_request(
         &w,
         None,
-        &stage("plain-text-model", vec![], None),
+        &stage("some-text-model", vec![], None),
         &prov,
         "draw",
         0,
         crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
-    let text_user = text
-        .messages
-        .iter()
-        .filter(|m| m.role == "user")
-        .map(|m| m.content.as_text())
-        .collect::<Vec<_>>()
-        .join(" ");
     assert!(
-        text_user.contains("Begin."),
-        "text model nudged: {text_user}"
+        text.messages
+            .iter()
+            .any(|m| m.content.as_text().contains("Begin.")),
+        "text model nudged"
     );
     assert!(
         format!("{:?}", text.system).contains("draw a picture of a rabbit"),
         "text model keeps the prompt in system"
     );
 
-    // An image-edit stage: the conversation already holds a user turn (the
-    // input image), so there is no "Begin." nudge to replace and the prompt is
-    // appended as its own user turn.
-    let mut edit = ContextWindow::new(10_000);
-    edit.add_region(Region::new("task".to_string(), RegionKind::Pinned, 1000));
-    edit.add_typed_entry(
-        "task",
-        leviath_core::EntryKind::Text,
-        "add a hat".to_string(),
-        5,
-    )
-    .unwrap();
-    edit.add_region(Region::new(
-        "conversation".to_string(),
-        RegionKind::SlidingWindow {
-            max_items: 20,
-            eviction_strategy: leviath_core::EvictionStrategy::PerItem,
-        },
-        5000,
-    ));
-    edit.add_typed_entry(
-        "conversation",
-        leviath_core::EntryKind::UserMessage,
-        "the source photo".to_string(),
-        5,
-    )
-    .unwrap();
-    let req = build_request(
-        &edit,
-        None,
-        &stage("image-out-editor", vec![], None),
-        &prov,
-        "edit",
-        0,
-        crate::pipeline::inference::PriorCalls::default(),
-    )
-    .0;
-    assert_eq!(req.messages.last().unwrap().role, "user");
-    assert_eq!(
-        req.messages.last().unwrap().content.as_text(),
-        "## task\nadd a hat"
-    );
-
-    // An image model with an empty window has no prompt to move, and builds a
-    // request without incident.
+    // An empty window has nothing to fold; the request still builds.
     let empty = ContextWindow::new(10_000);
     let req = build_request(
         &empty,
         None,
-        &stage("image-out-drawer", vec![], None),
+        &stage("google/gemini-2.5-flash-image", vec![], None),
         &prov,
         "draw",
         0,
@@ -343,6 +292,62 @@ fn an_image_model_gets_its_prompt_in_the_user_turn() {
     .0;
     assert!(req.system.is_empty());
     assert_eq!(req.messages.last().unwrap().content.as_text(), "Begin.");
+}
+
+/// The fold, on the turn shapes `build_request` cannot produce on its own: a
+/// first user turn carrying blocks (an input image), a real text turn (prefixed
+/// not replaced), and no user turn at all (the system becomes one).
+#[test]
+fn folding_the_system_covers_blocks_a_prefix_and_no_user_turn() {
+    use crate::pipeline::inference::fold_system_into_user;
+    use leviath_providers::{ContentBlock, Message, MessageContent, SystemBlock};
+    let sys = || {
+        vec![SystemBlock {
+            text: "PROMPT".to_string(),
+            cache_hint: leviath_core::CacheHint::Always,
+            volatility: leviath_core::Volatility::Stable,
+            region: String::new(),
+        }]
+    };
+    let user = |content: MessageContent| Message {
+        role: "user".to_string(),
+        content,
+        cache_breakpoint: false,
+        reasoning: None,
+    };
+
+    // A first user turn carrying blocks: the text is inserted ahead, image kept.
+    let mut system = sys();
+    let mut messages = vec![user(MessageContent::Blocks(vec![ContentBlock::Text {
+        text: "img".to_string(),
+    }]))];
+    fold_system_into_user(&mut system, &mut messages);
+    assert!(system.is_empty());
+    assert_eq!(
+        messages[0].content,
+        MessageContent::Blocks(vec![
+            ContentBlock::Text {
+                text: "PROMPT".to_string()
+            },
+            ContentBlock::Text {
+                text: "img".to_string()
+            },
+        ])
+    );
+
+    // A real text turn is prefixed, not replaced.
+    let mut system = sys();
+    let mut messages = vec![user(MessageContent::Text("hello".to_string()))];
+    fold_system_into_user(&mut system, &mut messages);
+    assert_eq!(messages[0].content.as_text(), "PROMPT\n\nhello");
+
+    // No user turn at all: the folded system becomes one.
+    let mut system = sys();
+    let mut messages: Vec<Message> = vec![];
+    fold_system_into_user(&mut system, &mut messages);
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].role, "user");
+    assert_eq!(messages[0].content.as_text(), "PROMPT");
 }
 
 // ── build_request branch coverage ──


### PR DESCRIPTION
Refines the image-prompt half of #818 based on review — you were right on both counts.

## The problem with #818's approach

#818 moved the prompt into the user turn for any model whose *output* was an image. Two flaws:
- **Wrong signal.** Producing images ≠ ignoring the system prompt. I tested five image models on OpenRouter: `gemini-2.5-flash-image` (your agent's model) **ignores** the system prompt (style details in system came back photoreal), but `gemini-3-pro-image`, `gemini-3.1-flash-image`, `gpt-5-image` and `gpt-5-image-mini` all **honour** it. So it's model-specific, not media-wide.
- **Multi-turn hazard.** It appended a fresh user turn when there was no `Begin.` nudge — which would corrupt a back-and-forth conversation.

## This change

The real question is whether a model **reads the system prompt** — which is the existing `supports_system_prompt` capability (it was declared but never consumed). When a model doesn't read it, the system blocks are **folded into the *first* user turn**, once, so a multi-turn conversation keeps its shape:
- a bare `Begin.` nudge is replaced,
- a real text turn is prefixed,
- a turn carrying an input image gets the text ahead of the image,
- with no user turn at all, the folded system becomes one.

Whether the flag is set is per-model. **OpenRouter does not report it** — `gemini-2.5-flash-image` and `gemini-3-pro-image` carry identical `architecture` and `supported_parameters`, yet one ignores the system prompt and the other honours it — so `gemini-2.5-flash-image` is a compiled **one-off** in `ignores_system_prompt`. Any other model can be flagged by an operator with `[model_capabilities."<id>"] supports_system_prompt = false`.

`produces_images` is removed. The assistant-turn media lift from #818 is unchanged, and still carries a produced part **of any type** (image, audio, video, 3D, document) into a user turn — so an audio/video/3D generator's output reaches the next stage the same way.

## What the tables from the investigation showed

| Model | Reads system prompt? | Honors a reference image (user turn)? |
|---|---|---|
| `gemini-2.5-flash-image` | ❌ no | ✅ yes |
| `gemini-3-pro-image` | ✅ yes | ✅ yes |
| `gemini-3.1-flash-image` | ✅ yes | ✅ yes |
| `gpt-5-image` | ✅ yes | ✅ yes |
| `gpt-5-image-mini` | ✅ yes | ✅ yes |

## Validation

End to end on the current build: "draw a picture of a rabbit" draws a rabbit and is then described accurately (the meadow, dandelions and sunset that only a model seeing the image could name). 100% coverage on `leviath-providers` and `leviath-runtime`; tests cover the fold's every turn shape (nudge, text-prefix, blocks, no user turn) and the one-off matching.

Leaving this **open for your review**, as before. v0.6.0 stays held until you're happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kh7J65m1oRXm1WP7vCb7YN
