### PR TITLE
feat(mime): route produced parts to regions, and emit them as artifacts (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,26 @@ same list.
 
 ### Added
 
+- A stage can route the parts a model produces to regions of their own, by mime
+  type. `[stages.<name>.output_routing]` maps a mime pattern to a region
+  (`"image/*" = "artwork"`); a reply that mixes text and other parts is split
+  part by part, each part going to the most specific matching pattern's region,
+  and the text and any unmatched part staying in `conversation`. The point is to
+  hand a produced file (a picture from an image model, a document a generator
+  returns) to a later stage or the user instead of leaving it in the transcript,
+  so unlike `tool_routing` the target need only be a region the blueprint
+  declares. It is mime types throughout, so the same table routes audio, video
+  or any registered type (#400).
+- A stage can empty regions when it is entered, for a clean slate.
+  `[stages.<name>.context] reset = ["conversation"]` clears the named regions on
+  entry (the content is gone, not merely hidden), so a stage starts with only
+  what its visible regions hold. Unlike `hide`, `reset` may name `conversation`
+  (#400).
+- `submit_output` can name a file the run produced but never wrote to disk (a
+  picture from an image model, which lives in the run's store) as an artifact.
+  When the path is not a workdir file, the name, then a sha256 prefix, is
+  resolved against the run's produced parts, and a match is written to that path
+  before it is recorded, so the user and any later stage get a real file (#400).
 - A run's file listing types each entry. `GET /api/agents/{id}/files` entries
   carry a `mime_type`, resolved by the run's registry from the file's name, so
   a console can decide whether to render a file, or offer it to a region that

--- a/crates/leviath-cli/src/blueprint_edit/doc.rs
+++ b/crates/leviath-cli/src/blueprint_edit/doc.rs
@@ -189,6 +189,12 @@ pub(crate) struct StageView {
     /// `[stages.<name>.tool_accepts]`: each tool and what it may be handed,
     /// in document order.
     pub tool_accepts: Vec<(String, Vec<String>)>,
+    /// `[stages.<name>.output_routing]`: the mime patterns the model's
+    /// produced parts are routed by, each to a region, in document order.
+    pub output_routing: Vec<(String, String)>,
+    /// `[stages.<name>.context] reset`: the regions emptied when the stage is
+    /// entered, in the order written.
+    pub context_reset: Vec<String>,
 }
 
 /// When a path is taken.
@@ -570,8 +576,29 @@ fn stage_view(name: &str, item: &Item) -> StageView {
             artifacts: super::mime::artifacts_of(item),
             output_format: super::mime::output_format_of(item),
             tool_accepts: super::mime::tool_limits_of(item),
+            output_routing: output_routing_of(item),
+            context_reset: child(item, "context")
+                .map(|c| get_strings(c, "reset"))
+                .unwrap_or_default(),
         }
     }
+}
+
+/// `[stages.<name>.output_routing]`: mime pattern to region, in document
+/// order. An entry whose value is not a string is left out (and left alone).
+fn output_routing_of(item: &Item) -> Vec<(String, String)> {
+    child(item, "output_routing")
+        .map(|routing| {
+            routing
+                .iter()
+                .filter_map(|(pattern, region)| {
+                    region
+                        .as_str()
+                        .map(|r| (pattern.to_string(), r.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 impl ManifestDoc {

--- a/crates/leviath-cli/src/blueprint_edit/regions.rs
+++ b/crates/leviath-cli/src/blueprint_edit/regions.rs
@@ -341,6 +341,69 @@ impl ManifestDoc {
         Ok(())
     }
 
+    /// Rewrite `[stages.<name>.output_routing]` from `entries` (mime pattern to
+    /// region). An empty list removes the table. The whole table is rebuilt
+    /// rather than diffed, since the editor edits it as one field.
+    pub(crate) fn set_output_routing(
+        &mut self,
+        stage: &str,
+        entries: &[(String, String)],
+    ) -> Result<(), EditError> {
+        let stage_item = self
+            .stage_item_mut(stage)
+            .ok_or_else(|| EditError::NoSuchStage(stage.to_string()))?;
+        if entries.is_empty() {
+            stage_item
+                .as_table_like_mut()
+                .expect("a stage is a table")
+                .remove("output_routing");
+            return Ok(());
+        }
+        let routing = ensure_child(stage_item, "output_routing")?;
+        let table = routing.as_table_like_mut().expect("ensure_child checked");
+        let stale: Vec<String> = table.iter().map(|(k, _)| k.to_string()).collect();
+        for key in stale {
+            table.remove(&key);
+        }
+        for (pattern, region) in entries {
+            set_str(table, pattern, region);
+        }
+        Ok(())
+    }
+
+    /// Set `[stages.<name>.context] reset`; an empty list deletes the key, and
+    /// the `context` table with it when nothing else is left there.
+    pub(crate) fn set_context_reset(
+        &mut self,
+        stage: &str,
+        regions: &[String],
+    ) -> Result<(), EditError> {
+        let stage_item = self
+            .stage_item_mut(stage)
+            .ok_or_else(|| EditError::NoSuchStage(stage.to_string()))?;
+        if regions.is_empty() {
+            if let Some(context) = child_mut(stage_item, "context")
+                && remove_and_report_empty(
+                    context.as_table_like_mut().expect("child_mut checked"),
+                    "reset",
+                )
+            {
+                stage_item
+                    .as_table_like_mut()
+                    .expect("a stage is a table")
+                    .remove("context");
+            }
+            return Ok(());
+        }
+        let context = ensure_parent(stage_item, "context")?;
+        set_strings(
+            context.as_table_like_mut().expect("ensure_parent checked"),
+            "reset",
+            regions,
+        );
+        Ok(())
+    }
+
     /// The scope's `regions` item, mutably, when it exists.
     fn regions_item_mut(&mut self, scope: &RegionScope) -> Option<&mut Item> {
         let parent: &mut Item = match scope {

--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -2082,3 +2082,123 @@ fn renaming_an_agent_moves_its_directory_and_the_name_in_its_manifest() {
     assert!(moved.contains("name = \"mine\""), "{moved}");
     let _ = std::fs::remove_dir_all(&root);
 }
+
+#[test]
+fn output_routing_and_context_reset_round_trip_through_the_manifest() {
+    let toml = r#"
+[agent]
+name = "draw"
+
+[context.regions]
+artwork = { kind = "pinned" }
+conversation = { kind = "sliding_window" }
+
+[stages.draw]
+mode = "autonomous"
+
+[stages.describe]
+mode = "autonomous"
+"#;
+    let mut doc = ManifestDoc::parse(toml).unwrap();
+
+    // A ghost stage is refused for both setters.
+    assert_eq!(
+        doc.set_output_routing("ghost", &[("image/*".into(), "artwork".into())]),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    assert_eq!(
+        doc.set_context_reset("ghost", &["conversation".into()]),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+
+    // output_routing: written in the given order, read back, then rewritten.
+    doc.set_output_routing(
+        "draw",
+        &[
+            ("image/*".into(), "artwork".into()),
+            ("application/pdf".into(), "artwork".into()),
+        ],
+    )
+    .unwrap();
+    assert_eq!(
+        doc.stage("draw").unwrap().output_routing,
+        [
+            ("image/*".to_string(), "artwork".to_string()),
+            ("application/pdf".to_string(), "artwork".to_string()),
+        ]
+    );
+    assert!(
+        doc.to_toml().contains("[stages.draw.output_routing]"),
+        "{}",
+        doc.to_toml()
+    );
+    runtime_ok(&doc);
+    // Rewriting replaces the whole table.
+    doc.set_output_routing("draw", &[("image/*".into(), "artwork".into())])
+        .unwrap();
+    assert_eq!(
+        doc.stage("draw").unwrap().output_routing,
+        [("image/*".to_string(), "artwork".to_string())]
+    );
+    // Empty clears the table entirely.
+    doc.set_output_routing("draw", &[]).unwrap();
+    assert!(doc.stage("draw").unwrap().output_routing.is_empty());
+    assert!(
+        !doc.to_toml().contains("output_routing"),
+        "{}",
+        doc.to_toml()
+    );
+
+    // context.reset: set, read back, then cleared.
+    doc.set_context_reset("describe", &["conversation".into()])
+        .unwrap();
+    assert_eq!(
+        doc.stage("describe").unwrap().context_reset,
+        ["conversation"]
+    );
+    assert!(doc.to_toml().contains("reset"), "{}", doc.to_toml());
+    runtime_ok(&doc);
+    doc.set_context_reset("describe", &[]).unwrap();
+    assert!(doc.stage("describe").unwrap().context_reset.is_empty());
+    // With nothing else in the context table, clearing reset takes the table
+    // with it.
+    assert!(
+        !doc.to_toml().contains("[stages.describe.context]"),
+        "{}",
+        doc.to_toml()
+    );
+}
+
+#[test]
+fn output_routing_and_context_reset_refuse_odd_content_and_keep_a_shared_table() {
+    // A non-table `output_routing` or `context` is refused, not clobbered.
+    let mut odd = ManifestDoc::parse(
+        "[agent]\nname = \"o\"\n[stages.a]\noutput_routing = 3\ncontext = \"nope\"\n",
+    )
+    .unwrap();
+    assert_eq!(
+        odd.set_output_routing("a", &[("image/*".into(), "art".into())]),
+        Err(EditError::NotATable("output_routing".into()))
+    );
+    assert_eq!(
+        odd.set_context_reset("a", &["conversation".into()]),
+        Err(EditError::NotATable("context".into()))
+    );
+
+    // Clearing reset leaves a context table that still holds a layout: the
+    // table stays, only `reset` goes.
+    let mut doc = ManifestDoc::parse(
+        "[agent]\nname = \"k\"\n\n[stages.work]\nmode = \"autonomous\"\n\n\
+         [stages.work.context]\nreset = [\"conversation\"]\n\n\
+         [stages.work.context.regions]\nnotes = { kind = \"pinned\" }\n",
+    )
+    .unwrap();
+    assert_eq!(doc.stage("work").unwrap().context_reset, ["conversation"]);
+    doc.set_context_reset("work", &[]).unwrap();
+    assert!(doc.stage("work").unwrap().context_reset.is_empty());
+    assert!(
+        doc.to_toml().contains("[stages.work.context.regions]"),
+        "the layout keeps the context table: {}",
+        doc.to_toml()
+    );
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
@@ -366,6 +366,16 @@ impl Dashboard {
                 let stage = self.editor().panel_stage().expect("a stage field");
                 self.editor_mutate(|d| d.set_output_format(&stage, &text));
             }
+            FieldId::OutputRouting => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let entries = super::inspector::parse_routing(&text);
+                self.editor_mutate(|d| d.set_output_routing(&stage, &entries));
+            }
+            FieldId::ContextReset => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let regions = super::inspector::parse_region_list(&text);
+                self.editor_mutate(|d| d.set_context_reset(&stage, &regions));
+            }
             FieldId::ArtifactName | FieldId::ArtifactDescription => {
                 let Some((stage, i)) = self.panel_artifact() else {
                     return;

--- a/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
@@ -177,6 +177,14 @@ pub(in crate::commands::dashboard) enum FieldId {
     /// What one of the stage's tools may be handed (a chooser); `x` lifts
     /// the limit.
     ToolLimitRow(String),
+    /// `[stages.<name>.output_routing]`: where the model's produced parts go
+    /// by mime type, edited as `pattern = region` pairs. Enter opens the
+    /// editor; an empty box clears the map.
+    OutputRouting,
+    /// `[stages.<name>.context] reset`: the regions emptied on entry, edited
+    /// as a list of region names. Enter opens the editor; an empty box clears
+    /// the list.
+    ContextReset,
 }
 
 /// What a field holds and how it edits.
@@ -610,6 +618,14 @@ fn stage_fields(doc: &ManifestDoc, name: &str, tab: StageTab) -> Vec<Field> {
                 FieldValue::Button,
                 "Send one tool's results to a region of their own.",
             ));
+            out.push(Field::new(
+                FieldId::ContextReset,
+                "Clear on entry",
+                FieldValue::Text(stage.context_reset.join(", ")),
+                "Regions emptied when this stage is entered, comma separated, so it starts on a \
+                 clean slate. conversation may be named here (unlike hiding). Enter edits, an \
+                 empty box clears.",
+            ));
             out
         }
         StageTab::Io => io_fields(doc, name, &stage),
@@ -702,6 +718,58 @@ fn io_fields(
         "A named file the stage must hand back (asks its name); the run checks it is there \
          and of the type.",
     ));
+    out.push(Field::new(
+        FieldId::OutputRouting,
+        "Route parts",
+        FieldValue::Text(join_routing(&stage.output_routing)),
+        "Where the parts the model produces go, by mime type: `image/* = artwork`, comma \
+         separated. Each goes to the most specific match's region; text stays in the \
+         conversation. Enter edits, an empty box clears.",
+    ));
+    out
+}
+
+/// The `output_routing` map as one editable line: `pattern = region` pairs,
+/// comma separated. Empty when there is no routing.
+fn join_routing(entries: &[(String, String)]) -> String {
+    entries
+        .iter()
+        .map(|(pattern, region)| format!("{pattern} = {region}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Parse the `output_routing` edit line back into `pattern = region` pairs.
+/// Commas or newlines separate entries; the first `=` splits each; blank
+/// entries and those with no `=` or an empty side are dropped, so a
+/// half-typed line never writes a broken row.
+pub(in crate::commands::dashboard) fn parse_routing(text: &str) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    for entry in text.split([',', '\n']) {
+        let Some((pattern, region)) = entry.split_once('=') else {
+            continue;
+        };
+        let pattern = pattern.trim().to_ascii_lowercase();
+        let region = region.trim().to_string();
+        if pattern.is_empty() || region.is_empty() || out.iter().any(|(p, _)| p == &pattern) {
+            continue;
+        }
+        out.push((pattern, region));
+    }
+    out
+}
+
+/// Parse a `context.reset` edit line into region names. Commas, spaces or
+/// newlines separate them; blanks and repeats are dropped. Case is kept,
+/// since a region name is an identifier the author chose, not a mime type.
+pub(in crate::commands::dashboard) fn parse_region_list(text: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for name in text.split([',', ' ', '\t', '\n']) {
+        let name = name.trim();
+        if !name.is_empty() && !out.iter().any(|n| n == name) {
+            out.push(name.to_string());
+        }
+    }
     out
 }
 

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -2816,3 +2816,89 @@ fn the_tools_chooser_offers_groups_first_and_labels_sources() {
     assert_eq!(rest, sorted);
     let _ = std::fs::remove_dir_all(&root);
 }
+
+#[test]
+fn output_routing_and_context_reset_edit_in_the_stage_panel() {
+    let (mut dash, root) = dashboard("routing_panel");
+    let routing = |dash: &mut Dashboard| {
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work")
+            .unwrap()
+            .output_routing
+    };
+    let reset = |dash: &mut Dashboard| {
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work")
+            .unwrap()
+            .context_reset
+    };
+    // The I/O tab routes the model's produced parts, edited as pattern =
+    // region pairs. It starts empty (join of nothing is nothing).
+    open_stage(&mut dash, "own", "work", StageTab::Io);
+    let screen = text(&mut dash);
+    assert!(screen.contains("Route parts"), "{screen}");
+    goto(&mut dash, FieldId::OutputRouting);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.as_ref().unwrap().line.is_some());
+    type_str(
+        &mut dash,
+        "image/* = conversation, application/pdf = conversation",
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        routing(&mut dash),
+        [
+            ("image/*".to_string(), "conversation".to_string()),
+            ("application/pdf".to_string(), "conversation".to_string()),
+        ]
+    );
+    // Reopened, the row shows the joined map.
+    let screen = text(&mut dash);
+    assert!(screen.contains("image/* = conversation"), "{screen}");
+
+    // The Context tab empties regions on entry, edited as a list of names.
+    // Switch tabs in place so the in-memory edit above is not reloaded away.
+    {
+        let editor = dash.agents().editor.as_mut().unwrap();
+        editor.panel = Panel::Stage {
+            name: "work".to_string(),
+            tab: StageTab::Context,
+        };
+        editor.cursor = 0;
+        editor.focus = Focus::Inspector;
+    }
+    goto(&mut dash, FieldId::ContextReset);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.as_ref().unwrap().line.is_some());
+    type_str(&mut dash, "conversation");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(reset(&mut dash), ["conversation"]);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn routing_edit_lines_parse_leniently() {
+    use super::inspector::{parse_region_list, parse_routing};
+    // Pairs split on the first `=`; blanks, a missing `=`, an empty side and a
+    // duplicate pattern are dropped; the pattern lowercases, the region keeps
+    // its case.
+    assert_eq!(
+        parse_routing("Image/* = Art, , bad, = nope, text/* =, image/* = other"),
+        [("image/*".to_string(), "Art".to_string())]
+    );
+    assert!(parse_routing("").is_empty());
+    // Region lists split on commas and spaces, keep case, and drop repeats.
+    assert_eq!(
+        parse_region_list("conversation, Notes  conversation"),
+        ["conversation".to_string(), "Notes".to_string()]
+    );
+    assert!(parse_region_list("  ").is_empty());
+}

--- a/crates/leviath-cli/src/commands/serve/blueprint_types.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprint_types.rs
@@ -1,0 +1,33 @@
+//! The wire shape of a blueprint's per-stage typed-content routing.
+//!
+//! In a file of its own rather than beside the rest of the blueprint response
+//! types so `types.rs` stays under its production-line cap.
+
+use serde::Serialize;
+
+/// One mime pattern routed to a region, in a [`StageRoutingInfo`].
+#[derive(Debug, Serialize)]
+pub(super) struct RoutePair {
+    /// The mime pattern the model's produced parts are matched against
+    /// (`image/*`, `application/pdf`, `*/*`).
+    pub(super) pattern: String,
+    /// The region a matching part is written to.
+    pub(super) region: String,
+}
+
+/// A stage's typed-content routing, so a console need not parse the manifest
+/// to show or check it. Only stages that route produced parts or reset a
+/// region on entry appear; a stage with neither is left out.
+#[derive(Debug, Serialize)]
+pub(super) struct StageRoutingInfo {
+    /// The stage's name.
+    pub(super) stage: String,
+    /// `output_routing`: where the model's produced parts go, by mime pattern,
+    /// ordered by pattern. Empty (and omitted) when the stage routes none.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) output_routing: Vec<RoutePair>,
+    /// `context.reset`: the regions the stage empties on entry. Empty (and
+    /// omitted) when it resets none.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) context_reset: Vec<String>,
+}

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -8,6 +8,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::Json;
 
+use super::blueprint_types::{RoutePair, StageRoutingInfo};
 use super::types::*;
 use leviath_core::manifest::parse_manifest;
 
@@ -325,12 +326,37 @@ pub(super) async fn get_blueprint(
         })
         .unwrap_or_default();
     let fan_outs = parsed.as_ref().map(fan_out_infos).unwrap_or_default();
+    let stage_routing = parsed.as_ref().map(stage_routing_infos).unwrap_or_default();
     Ok(Json(BlueprintDetail {
         info,
         regions,
         fan_outs,
+        stage_routing,
         manifest,
     }))
+}
+
+/// The stages that route produced parts (`output_routing`) or empty a region
+/// on entry (`context.reset`), so the detail route carries them structured. A
+/// stage that does neither is left out, the way `fan_out_infos` lists only
+/// fan-out stages.
+fn stage_routing_infos(bp: &leviath_core::blueprint::Blueprint) -> Vec<StageRoutingInfo> {
+    bp.stages
+        .iter()
+        .filter(|stage| !stage.output_routing.is_empty() || !stage.context_reset.is_empty())
+        .map(|stage| StageRoutingInfo {
+            stage: stage.name.clone(),
+            output_routing: stage
+                .output_routing
+                .iter()
+                .map(|(pattern, region)| RoutePair {
+                    pattern: pattern.clone(),
+                    region: region.clone(),
+                })
+                .collect(),
+            context_reset: stage.context_reset.clone(),
+        })
+        .collect()
 }
 
 /// The fan-out stages of a blueprint, with their limits resolved.
@@ -1106,6 +1132,66 @@ findings = { kind = "clearable", max_tokens = 4000 }
                     "max_workers": leviath_core::blueprint::DEFAULT_MAX_WORKERS,
                     "max_items": null,
                     "on_worker_failure": "continue",
+                },
+            ])
+        );
+    }
+
+    /// The detail route reports each stage's produced-part routing and its
+    /// entry resets, so a console shows them without parsing the manifest. A
+    /// stage that does neither (here, none of the fan-out blueprint's) is left
+    /// out.
+    #[tokio::test]
+    async fn the_detail_route_reports_stage_routing() {
+        let manifest = r#"
+[agent]
+name = "drawer"
+
+[context.regions]
+artwork = { kind = "pinned" }
+conversation = { kind = "sliding_window" }
+
+[stages.draw]
+system_prompt = "Draw"
+
+[stages.draw.output_routing]
+"image/*" = "artwork"
+
+[stages.describe]
+system_prompt = "Describe"
+
+[stages.describe.context]
+reset = ["conversation"]
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join("drawer");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("agent.leviath"), manifest).unwrap();
+
+        let state = test_state_with_path(dir.path().to_path_buf());
+        let app = Router::new()
+            .route("/api/blueprints/{name}", get(get_blueprint))
+            .with_state(state);
+        let req = Request::builder()
+            .uri("/api/blueprints/drawer")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let bp: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            bp["stage_routing"],
+            serde_json::json!([
+                {
+                    "stage": "draw",
+                    "output_routing": [{ "pattern": "image/*", "region": "artwork" }],
+                },
+                {
+                    "stage": "describe",
+                    "context_reset": ["conversation"],
                 },
             ])
         );

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -302,6 +302,11 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // `max_items`. A console that has this can show and edit the caps without
     // re-implementing the parser's defaults.
     "blueprints.fan_outs",
+    // `stage_routing` on the detail route: the stages that route the model's
+    // produced parts by mime type (`output_routing`) or empty a region on
+    // entry (`context.reset`), so a console shows or checks them without
+    // parsing the manifest.
+    "blueprints.stage_routing",
     "tools.list",
     // `GET /api/update`: how this copy was installed, and the command that
     // upgrades it. Announced because the fallback is guessing, and the console

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -7,6 +7,7 @@ mod agents;
 mod artifact_types;
 mod auth;
 mod blobs;
+mod blueprint_types;
 mod blueprints;
 mod config;
 mod config_health;

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -544,6 +544,9 @@ pub(super) struct BlueprintDetail {
     /// The blueprint's fan-out stages, with their limits as the daemon will
     /// apply them. Empty for a blueprint that never fans out.
     pub(super) fan_outs: Vec<FanOutInfo>,
+    /// The stages that route produced parts (`output_routing`) or reset a
+    /// region on entry (`context.reset`); empty when the blueprint does neither.
+    pub(super) stage_routing: Vec<super::blueprint_types::StageRoutingInfo>,
     /// The manifest exactly as it is on disk.
     ///
     /// Without this a console has no way to read what it is editing: naming

--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -445,6 +445,19 @@ impl Blueprint {
                 }
             }
 
+            // `reset` empties a region on entry. `conversation` and the other
+            // always-visible regions can be reset (that is the point - a stage
+            // starting on a clean conversation), but a name no layout declares
+            // is the same silent typo `hide` guards against.
+            for name in &stage.context_reset {
+                if !known.contains(name.as_str()) {
+                    return Err(bad(format!(
+                        "context.reset names region '{name}', which no layout in this \
+                         blueprint declares"
+                    )));
+                }
+            }
+
             if let Some(routing) = &stage.tool_result_routing {
                 // Routing is checked against what *this* stage can see, not
                 // against every name in the blueprint. A stage that omits a
@@ -472,6 +485,24 @@ impl Blueprint {
                     if !visible.contains(region.as_str()) {
                         return Err(dead_drop(&format!("overrides.{tool}"), region));
                     }
+                }
+            }
+
+            // `output_routing` sends the model's produced parts to a region a
+            // *later* stage usually reads, so unlike `tool_routing` above it is
+            // checked against every region the blueprint declares, not only the
+            // ones this stage can see. A target no layout declares is still a
+            // dead drop - the part would land nowhere - so it is refused.
+            for (pattern, region) in &stage.output_routing {
+                if !known.contains(region.as_str()) {
+                    return Err(ValidationError::Stage {
+                        stage: stage.name.clone(),
+                        message: format!(
+                            "output_routing.\"{pattern}\" sends produced parts to region \
+                             '{region}', which no layout in this blueprint declares. Add it to a \
+                             [context.regions] table, or route to a region that exists."
+                        ),
+                    });
                 }
             }
 

--- a/crates/leviath-core/src/blueprint/stage.rs
+++ b/crates/leviath-core/src/blueprint/stage.rs
@@ -544,6 +544,17 @@ pub struct Stage {
     #[serde(default)]
     pub context_hide: Vec<String>,
 
+    /// Regions emptied when this stage is entered
+    /// (`[stages.<name>.context] reset = ["conversation"]`). Unlike
+    /// [`Self::context_hide`], which only stops a region being shown here, this
+    /// clears it, so the stage starts with a clean slate where a previous
+    /// stage's turns would otherwise carry forward - an image-describe stage
+    /// reading its picture from a region of its own, say, with none of the
+    /// drawing stage's scaffolding in the conversation. The content is gone,
+    /// not hidden, so a re-entered stage clears it again each visit.
+    #[serde(default)]
+    pub context_reset: Vec<String>,
+
     /// Custom configuration for this stage
     pub config: HashMap<String, serde_json::Value>,
 
@@ -644,6 +655,21 @@ pub struct Stage {
     #[serde(default)]
     pub tool_result_routing: Option<ToolResultRouting>,
 
+    /// Where the model's produced parts go, by mime type
+    /// (`[stages.<name>.output_routing]`: `"image/*" = "artwork"`). Keys are
+    /// mime patterns (`image/png`, `image/*`, `*/*`), values are region names.
+    ///
+    /// A reply that carries more than text is split part by part: each part
+    /// (an image the model drew, a `submit_output` artifact) whose mime type
+    /// matches goes to the region of the *most specific* matching pattern
+    /// (`image/png` beats `image/*` beats `*/*`), and text and any unmatched
+    /// part stay in `conversation` as before. The whole point is to hand a
+    /// produced file to a *later* stage or to the user, so unlike
+    /// [`Self::tool_result_routing`] the target need not be a region this
+    /// stage reads back - only one some layout in the blueprint declares.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub output_routing: BTreeMap<String, String>,
+
     /// What shape this stage's final output should take, narrowing the
     /// agent-level `[agent.output]`. Whoever starts the run overrides both.
     ///
@@ -696,6 +722,17 @@ pub struct Stage {
     pub hooks: StageHooks,
 }
 
+/// How specific a mime routing pattern is, so the most specific match wins:
+/// an exact `type/subtype` (2) beats a family `type/*` (1) beats the catch-all
+/// `*/*` (0). Mirrors the resolution order the mime registry itself uses.
+fn mime_pattern_specificity(pattern: &str) -> u8 {
+    match pattern {
+        "*/*" => 0,
+        p if p.ends_with("/*") => 1,
+        _ => 2,
+    }
+}
+
 impl Stage {
     /// Create a new stage with the specified configuration.
     pub fn new(name: String, model: ModelConfig) -> Self {
@@ -710,6 +747,7 @@ impl Stage {
             mode: StageMode::Autonomous,
             context_layout: None,
             context_hide: Vec::new(),
+            context_reset: Vec::new(),
             config: HashMap::new(),
             tool_permissions: HashMap::new(),
             requires_children: false,
@@ -726,6 +764,7 @@ impl Stage {
             nudge: None,
             sandbox: None,
             tool_result_routing: None,
+            output_routing: BTreeMap::new(),
             output: None,
             input_accepts: Vec::new(),
             input_as_text: Vec::new(),
@@ -733,6 +772,20 @@ impl Stage {
             require_output: false,
             hooks: StageHooks::default(),
         }
+    }
+
+    /// The region a produced part of `mime_type` routes to under
+    /// [`Self::output_routing`], or `None` to leave it in `conversation`.
+    ///
+    /// The most specific matching pattern wins, so a table with both
+    /// `image/png` and `image/*` sends a PNG to the first and every other
+    /// image to the second, whatever order they appear in.
+    pub fn route_for_mime(&self, mime_type: &crate::mime::MimeType) -> Option<&str> {
+        self.output_routing
+            .iter()
+            .filter(|(pattern, _)| mime_type.matches(pattern))
+            .max_by_key(|(pattern, _)| mime_pattern_specificity(pattern))
+            .map(|(_, region)| region.as_str())
     }
 
     /// Add tools to this stage.

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -35,6 +35,7 @@ pub(super) const STAGE_KEYS: &[&str] = &[
     "nudge",
     "on_worker_failure",
     "output",
+    "output_routing",
     "require_output",
     "required_tools",
     "requires_children",
@@ -60,7 +61,7 @@ pub(super) const STAGE_KEYS: &[&str] = &[
 /// regions from an otherwise inherited one. Either way what is left out is
 /// hidden rather than destroyed. An author who guesses any other key hears
 /// about it instead of quietly carrying the region they meant to drop.
-pub(super) const CONTEXT_KEYS: &[&str] = &["regions", "hide"];
+pub(super) const CONTEXT_KEYS: &[&str] = &["regions", "hide", "reset"];
 
 /// The hooks this build implements, in the order the refusal names them.
 /// `parse_stage_hooks` matches on each, and the schema guard in `tests.rs`
@@ -380,6 +381,30 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
         stage.tool_result_routing = Some(routing);
     }
 
+    // `[stages.<name>.output_routing]`: where the model's produced parts go by
+    // mime type. Each key is a mime pattern and each value a region name. The
+    // pattern is validated here (shape only); that the region exists is checked
+    // in `Blueprint::validate`, once every layout is known.
+    if let Some(routing_table) = table_of(stage_value, "output_routing") {
+        for (pattern, region_val) in routing_table {
+            crate::mime::MimeType::parse(pattern).map_err(|_| {
+                Error::Other(format!(
+                    "stage '{stage_name}': output_routing key '{pattern}' is not a mime type \
+                     or pattern, e.g. \"image/*\" or \"application/pdf\""
+                ))
+            })?;
+            let region = region_val.as_str().ok_or_else(|| {
+                Error::Other(format!(
+                    "stage '{stage_name}': output_routing.\"{pattern}\" must be a region name, \
+                     e.g. \"{pattern}\" = \"artwork\""
+                ))
+            })?;
+            stage
+                .output_routing
+                .insert(pattern.clone(), region.to_string());
+        }
+    }
+
     // Parse requires_children flag
     if let Some(rc) = bool_of(stage_value, "requires_children") {
         stage.requires_children = rc;
@@ -603,6 +628,26 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
                     ))
                 })?;
             stage.context_hide = names;
+        }
+        // `reset = ["conversation"]`: the regions this stage empties on entry.
+        // Names are checked against the blueprint in `Blueprint::validate`;
+        // here only the shape is.
+        if let Some(reset) = context_table.get("reset") {
+            let names = reset
+                .as_array()
+                .and_then(|items| {
+                    items
+                        .iter()
+                        .map(|v| v.as_str().map(str::to_string))
+                        .collect::<Option<Vec<_>>>()
+                })
+                .ok_or_else(|| {
+                    Error::Other(format!(
+                        "stage '{stage_name}': context.reset must be a list of region names, \
+                         e.g. reset = [\"conversation\"]"
+                    ))
+                })?;
+            stage.context_reset = names;
         }
     }
 

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -3971,6 +3971,238 @@ mode = "autonomous"
 }
 
 #[test]
+fn parse_stage_output_routing_maps_mime_patterns_to_regions() {
+    let toml = r#"
+[agent]
+name = "draw"
+
+[context.regions]
+artwork = { kind = "pinned" }
+notes = { kind = "pinned" }
+
+[stages.draw]
+mode = "autonomous"
+
+[stages.draw.output_routing]
+"image/*" = "artwork"
+"application/pdf" = "notes"
+"#;
+    let bp = parse_manifest(toml).unwrap();
+    let draw = bp.find_stage("draw").unwrap();
+    assert_eq!(draw.output_routing.get("image/*").unwrap(), "artwork");
+    assert_eq!(draw.output_routing.get("application/pdf").unwrap(), "notes");
+}
+
+#[test]
+fn parse_stage_output_routing_rejects_a_key_that_is_not_a_mime_pattern() {
+    let toml = r#"
+[agent]
+name = "draw"
+
+[context.regions]
+artwork = { kind = "pinned" }
+
+[stages.draw]
+mode = "autonomous"
+
+[stages.draw.output_routing]
+"not a mime" = "artwork"
+"#;
+    let err = parse_manifest(toml).expect_err("the key is not a mime type");
+    assert!(err.to_string().contains("output_routing"), "{err}");
+}
+
+#[test]
+fn parse_stage_output_routing_rejects_a_non_string_region() {
+    let toml = r#"
+[agent]
+name = "draw"
+
+[stages.draw]
+mode = "autonomous"
+
+[stages.draw.output_routing]
+"image/*" = 7
+"#;
+    let err = parse_manifest(toml).expect_err("the region must be a string");
+    assert!(err.to_string().contains("must be a region name"), "{err}");
+}
+
+#[test]
+fn output_routing_to_a_region_no_layout_declares_is_refused() {
+    let toml = r#"
+[agent]
+name = "draw"
+
+[context.regions]
+conversation = { kind = "sliding_window" }
+
+[stages.draw]
+mode = "autonomous"
+
+[stages.draw.output_routing]
+"image/*" = "artwork"
+"#;
+    let err = parse_manifest(toml)
+        .expect("shape is fine")
+        .validate()
+        .expect_err("artwork is not declared anywhere");
+    let msg = err.to_string();
+    assert!(msg.contains("artwork"), "{msg}");
+    assert!(msg.contains("output_routing"), "{msg}");
+}
+
+#[test]
+fn output_routing_to_a_declared_region_validates() {
+    let toml = r#"
+[agent]
+name = "draw"
+
+[context.regions]
+artwork = { kind = "pinned" }
+
+[stages.draw]
+mode = "autonomous"
+
+[stages.draw.output_routing]
+"image/*" = "artwork"
+"#;
+    parse_manifest(toml)
+        .expect("shape is fine")
+        .validate()
+        .expect("artwork is declared, so the route is valid");
+}
+
+#[test]
+fn context_reset_must_be_a_list() {
+    let toml = r#"
+[agent]
+name = "draw"
+
+[stages.describe]
+mode = "autonomous"
+
+[stages.describe.context]
+reset = "conversation"
+"#;
+    let err = parse_manifest(toml).expect_err("reset must be a list, not a string");
+    assert!(
+        err.to_string().contains("context.reset must be a list"),
+        "{err}"
+    );
+}
+
+#[test]
+fn route_for_mime_picks_the_most_specific_pattern() {
+    use crate::mime::MimeType;
+    let toml = r#"
+[agent]
+name = "draw"
+
+[context.regions]
+pngs = { kind = "pinned" }
+images = { kind = "pinned" }
+anything = { kind = "pinned" }
+
+[stages.draw]
+mode = "autonomous"
+
+[stages.draw.output_routing]
+"image/png" = "pngs"
+"image/*" = "images"
+"*/*" = "anything"
+"#;
+    let bp = parse_manifest(toml).unwrap();
+    let draw = bp.find_stage("draw").unwrap();
+    let png = MimeType::parse("image/png").unwrap();
+    let jpeg = MimeType::parse("image/jpeg").unwrap();
+    let pdf = MimeType::parse("application/pdf").unwrap();
+    assert_eq!(draw.route_for_mime(&png), Some("pngs"));
+    assert_eq!(draw.route_for_mime(&jpeg), Some("images"));
+    assert_eq!(draw.route_for_mime(&pdf), Some("anything"));
+}
+
+#[test]
+fn route_for_mime_is_none_when_nothing_matches() {
+    use crate::mime::MimeType;
+    let toml = r#"
+[agent]
+name = "draw"
+
+[context.regions]
+artwork = { kind = "pinned" }
+
+[stages.draw]
+mode = "autonomous"
+
+[stages.draw.output_routing]
+"image/*" = "artwork"
+"#;
+    let bp = parse_manifest(toml).unwrap();
+    let draw = bp.find_stage("draw").unwrap();
+    let text = MimeType::parse("text/plain").unwrap();
+    assert_eq!(draw.route_for_mime(&text), None);
+}
+
+#[test]
+fn parse_stage_context_reset_lists_the_regions_to_empty() {
+    let toml = r#"
+[agent]
+name = "draw"
+
+[context.regions]
+artwork = { kind = "pinned" }
+
+[stages.describe]
+mode = "autonomous"
+
+[stages.describe.context]
+reset = ["conversation", "artwork"]
+"#;
+    let bp = parse_manifest(toml).unwrap();
+    let describe = bp.find_stage("describe").unwrap();
+    assert_eq!(describe.context_reset, vec!["conversation", "artwork"]);
+}
+
+#[test]
+fn context_reset_may_name_the_conversation() {
+    // Unlike hide, reset is allowed on the always-visible regions.
+    let toml = r#"
+[agent]
+name = "draw"
+
+[stages.describe]
+mode = "autonomous"
+
+[stages.describe.context]
+reset = ["conversation"]
+"#;
+    parse_manifest(toml)
+        .expect("shape is fine")
+        .validate()
+        .expect("resetting the conversation is allowed");
+}
+
+#[test]
+fn context_reset_of_an_unknown_region_is_refused() {
+    let toml = r#"
+[agent]
+name = "draw"
+
+[stages.describe]
+mode = "autonomous"
+
+[stages.describe.context]
+reset = ["ghost"]
+"#;
+    let err = parse_manifest(toml)
+        .expect("shape is fine")
+        .validate()
+        .expect_err("ghost is not declared");
+    assert!(err.to_string().contains("context.reset"), "{err}");
+}
+
+#[test]
 fn parse_stage_tool_routing_with_overrides_only() {
     let toml = r#"
 [agent]

--- a/crates/leviath-runtime/src/components/context_window/mime.rs
+++ b/crates/leviath-runtime/src/components/context_window/mime.rs
@@ -7,9 +7,25 @@
 //! so the assembled request stays small and every lane that skips hydration
 //! still sends a correct, text-only version of the same turn.
 
-use leviath_core::mime::PartBody;
+use leviath_core::mime::{Part, PartBody};
 use leviath_core::region::{EntryContent, Region};
 use leviath_providers::{ContentBlock, MessageContent};
+
+impl super::ContextWindow {
+    /// Every stored part anywhere in the window, cloned. What `submit_output`
+    /// searches to let a stage name a part the run produced (a picture from an
+    /// image model, which lives in the store, not on disk) as an artifact to
+    /// emit. Lives here, beside the other mime assembly, to keep the parent
+    /// file under its production-line cap.
+    pub(crate) fn stored_parts(&self) -> Vec<Part> {
+        self.regions
+            .iter()
+            .flat_map(|r| &r.content)
+            .flat_map(|e| e.content.stored())
+            .cloned()
+            .collect()
+    }
+}
 
 /// Every part of `content` as blocks, in order.
 pub(super) fn content_blocks(content: &EntryContent) -> Vec<ContentBlock> {

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -1182,6 +1182,7 @@ mod tests {
             accepts_messages: true,
             context_layout: None,
             context_hide: Vec::new(),
+            context_reset: Vec::new(),
             system_prompt: None,
         }
     }

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -201,6 +201,7 @@ fn setup() -> StageSetup {
         accepts_messages: true,
         context_layout: None,
         context_hide: Vec::new(),
+        context_reset: Vec::new(),
         system_prompt: None,
     }
 }

--- a/crates/leviath-runtime/src/output_tool.rs
+++ b/crates/leviath-runtime/src/output_tool.rs
@@ -229,7 +229,11 @@ pub(crate) fn handle_output_tool(
     // quietly lost an entry sends the caller looking for a file that was named
     // and then forgotten.
     let declared = spec.map(|s| s.artifacts.as_slice()).unwrap_or_default();
-    let ingested = match artifacts::resolve(args, workdir, declared, sink) {
+    // The parts the run has already produced, so a submission can name one (an
+    // image a model drew) as an artifact even though it never touched the
+    // workdir: `resolve` writes it to the named path before recording it.
+    let produced = window.stored_parts();
+    let ingested = match artifacts::resolve(args, workdir, declared, &produced, sink) {
         Ok(ingested) => ingested,
         Err(message) => return (message, None),
     };

--- a/crates/leviath-runtime/src/output_tool/artifacts.rs
+++ b/crates/leviath-runtime/src/output_tool/artifacts.rs
@@ -81,11 +81,54 @@ fn listed(args: &serde_json::Value) -> Result<Vec<Named>, String> {
     Ok(out)
 }
 
+/// Resolve `name_or_sha` against the parts the run has already produced and,
+/// when it names one, write that part's bytes to `dest` so the submission has a
+/// real file to record. Matches the part's name (exact, then its file name),
+/// then a sha256 prefix. Returns the bytes written, or the same shape of error
+/// the caller gives for a missing workdir file.
+fn materialize_produced(
+    name_or_sha: &str,
+    dest: &std::path::Path,
+    produced: &[Part],
+    sink: Option<&PartSink<'_>>,
+) -> Result<Vec<u8>, String> {
+    let missing = || {
+        format!(
+            "[error] artifact '{name_or_sha}' is neither a file in the working directory nor a \
+             part this run produced. Write the file before naming it, or name a produced part."
+        )
+    };
+    let basename = std::path::Path::new(name_or_sha)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string());
+    let is_match = |p: &&Part| {
+        let by_name = p.name.as_deref() == Some(name_or_sha)
+            || (basename.is_some() && p.name.as_deref() == basename.as_deref());
+        let by_sha =
+            name_or_sha.len() >= 8 && p.blob().is_some_and(|b| b.sha256.starts_with(name_or_sha));
+        by_name || by_sha
+    };
+    let blob = produced.iter().find(is_match).and_then(Part::blob);
+    let (Some(blob), Some(sink)) = (blob, sink) else {
+        return Err(missing());
+    };
+    let bytes = sink.store.read(sink.run_id, &blob.sha256).map_err(|e| {
+        format!("[error] artifact '{name_or_sha}' could not be read from the run's store: {e}")
+    })?;
+    // Written to the path as given, whose directory must exist - the same as a
+    // regular artifact, which is a file already on disk. A name with a missing
+    // parent fails here with the reason, rather than silently making the tree.
+    std::fs::write(dest, bytes.as_ref())
+        .map_err(|e| format!("[error] artifact '{name_or_sha}' could not be written: {e}"))?;
+    Ok(bytes.to_vec())
+}
+
 /// Check, type, hash and store the artifacts a submission names.
 pub(super) fn resolve(
     args: &serde_json::Value,
     workdir: Option<&std::path::Path>,
     declared: &[ArtifactSpec],
+    produced: &[Part],
     sink: Option<&PartSink<'_>>,
 ) -> Result<Ingested, String> {
     let named = listed(args)?;
@@ -137,6 +180,13 @@ pub(super) fn resolve(
         }
         let bytes = match std::fs::read(&full) {
             Ok(b) => b,
+            // Not a file in the workdir. It may still be a part the run
+            // produced (an image a model drew) that never touched disk: name,
+            // then sha, resolves it, and it is written to the named path so
+            // the user and any later stage get a real file.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                materialize_produced(&item.path, &full, produced, sink)?
+            }
             Err(e) => {
                 return Err(format!(
                     "[error] artifact '{}' could not be read: {e}. Write the file before \
@@ -238,7 +288,7 @@ mod tests {
             "big.bin",
             "",
         ]});
-        let out = resolve(&args, Some(dir.path()), &specs(), Some(&sink)).unwrap();
+        let out = resolve(&args, Some(dir.path()), &specs(), &[], Some(&sink)).unwrap();
         let names: Vec<&str> = out.records.iter().map(|r| r.name.as_str()).collect();
         assert_eq!(names, ["final", "notes.md", "notes", "big.bin"]);
         assert_eq!(out.records[0].mime_type.as_str(), "video/mp4");
@@ -259,10 +309,10 @@ mod tests {
         let args = json!({"artifacts": [
             {"name": "final", "path": "cut.mp4"}, {"name": "final", "path": "cut.mp4"}
         ]});
-        let out = resolve(&args, Some(dir.path()), &specs(), Some(&sink)).unwrap();
+        let out = resolve(&args, Some(dir.path()), &specs(), &[], Some(&sink)).unwrap();
         assert_eq!(out.records.len(), 1);
         // Without a sink: typed by the built-in registry, nothing stored.
-        let out = resolve(&args, Some(dir.path()), &[], None).unwrap();
+        let out = resolve(&args, Some(dir.path()), &[], &[], None).unwrap();
         assert_eq!(out.records[0].mime_type.as_str(), "video/mp4");
         assert!(out.parts.is_empty());
     }
@@ -271,8 +321,13 @@ mod tests {
     fn every_refusal_names_the_artifact() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("notes.md"), "# shots").unwrap();
+        // A directory reads with an error that is not NotFound, so it does not
+        // fall through to the produced-part resolution: it is a plain read
+        // failure with the original wording.
+        std::fs::create_dir(dir.path().join("adir")).unwrap();
         let cases = [
             (json!({}), "must submit these artifacts: final"),
+            (json!({"artifacts": ["adir"]}), "could not be read"),
             (
                 json!({"artifacts": ["notes.md"]}),
                 "missing these required artifacts: final",
@@ -291,17 +346,17 @@ mod tests {
                 json!({"artifacts": ["../etc/passwd"]}),
                 "does not resolve inside",
             ),
-            (json!({"artifacts": ["missing.mp4"]}), "could not be read"),
+            (json!({"artifacts": ["missing.mp4"]}), "neither a file"),
         ];
         for (args, expect) in cases {
-            let err = resolve(&args, Some(dir.path()), &specs(), None).unwrap_err();
+            let err = resolve(&args, Some(dir.path()), &specs(), &[], None).unwrap_err();
             assert!(err.contains(expect), "{args}: {err}");
         }
-        let err = resolve(&json!({"artifacts": ["notes.md"]}), None, &[], None).unwrap_err();
+        let err = resolve(&json!({"artifacts": ["notes.md"]}), None, &[], &[], None).unwrap_err();
         assert!(err.contains("working directory"), "{err}");
         // Nothing declared, nothing named: nothing to check.
         assert!(
-            resolve(&json!({}), None, &[], None)
+            resolve(&json!({}), None, &[], &[], None)
                 .unwrap()
                 .records
                 .is_empty()
@@ -340,6 +395,7 @@ mod tests {
         let out = resolve(
             &json!({"artifacts": ["notes.md"]}),
             Some(dir.path()),
+            &[],
             &[],
             Some(&sink),
         )

--- a/crates/leviath-runtime/src/output_tool/tests.rs
+++ b/crates/leviath-runtime/src/output_tool/tests.rs
@@ -1041,3 +1041,296 @@ fn stored_artifacts_are_mirrored_beside_the_answer() {
             .starts_with("artifact 'final':")
     );
 }
+
+/// An image a model produced lives in the store, not the workdir. Naming it as
+/// an artifact writes it to the named path (a real file for the user and any
+/// later stage) and records it beside the answer.
+#[test]
+fn a_produced_part_named_as_an_artifact_is_written_to_disk() {
+    use leviath_core::mime::{Blob, BlobStore, MemoryBlobStore, MimeRegistry, MimeType, Part};
+    let dir = tempfile::tempdir().expect("temp dir");
+    let store = MemoryBlobStore::new();
+    let registry = MimeRegistry::builtin();
+    // A produced image, stored but never written to disk.
+    let bytes = b"\x89PNG\r\n\x1a\n produced pixels".to_vec();
+    let blob = Blob::new(MimeType::parse("image/png").unwrap(), bytes).named("image-1.png");
+    let reference = store.put("run-1", &blob, &registry).expect("stored");
+    let part = Part::stored(reference).named("image-1.png");
+
+    let mut w = win();
+    w.add_region(Region::new(
+        "artwork".to_string(),
+        RegionKind::Pinned,
+        100_000,
+    ));
+    let content = leviath_core::region::EntryContent::from_parts(vec![part]);
+    let tokens = content.tokens_hint();
+    w.add_assistant_turn_content(
+        "artwork",
+        leviath_core::EntryKind::Text,
+        content,
+        tokens,
+        None,
+    )
+    .expect("stored in artwork");
+
+    let sink = crate::context_setup::PartSink {
+        store: &store,
+        registry: &registry,
+        run_id: "run-1",
+        max_part_bytes: 1024,
+    };
+    assert!(
+        !dir.path().join("image-1.png").exists(),
+        "precondition: the file is not on disk"
+    );
+    let (ack, output) = handle_output_tool(
+        &json!({
+            "content": "a pelican on a bike",
+            "artifacts": [{"name": "image", "path": "image-1.png"}],
+        }),
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "describe",
+            stage_names: &[],
+            workdir: Some(dir.path()),
+            sink: Some(&sink),
+        },
+        0,
+        &mut w,
+    );
+    let output = output.expect("accepted");
+    assert!(
+        dir.path().join("image-1.png").exists(),
+        "the produced part was written to the workdir"
+    );
+    assert_eq!(output.artifacts.len(), 1);
+    assert_eq!(output.artifacts[0].name, "image");
+    assert!(ack.contains("image"), "{ack}");
+}
+
+/// Naming an artifact that is neither on disk nor a produced part is refused
+/// with a message that says both places were checked.
+#[test]
+fn an_artifact_that_is_neither_a_file_nor_a_produced_part_is_refused() {
+    use leviath_core::mime::{MemoryBlobStore, MimeRegistry};
+    let dir = tempfile::tempdir().expect("temp dir");
+    let store = MemoryBlobStore::new();
+    let registry = MimeRegistry::builtin();
+    let sink = crate::context_setup::PartSink {
+        store: &store,
+        registry: &registry,
+        run_id: "run-1",
+        max_part_bytes: 1024,
+    };
+    let mut w = win();
+    let (message, output) = handle_output_tool(
+        &json!({
+            "content": "done",
+            "artifacts": [{"name": "image", "path": "ghost.png"}],
+        }),
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "describe",
+            stage_names: &[],
+            workdir: Some(dir.path()),
+            sink: Some(&sink),
+        },
+        0,
+        &mut w,
+    );
+    assert!(output.is_none());
+    assert!(message.contains("neither a file"), "{message}");
+    assert!(message.contains("ghost.png"), "{message}");
+}
+
+/// A produced part in the window with a store behind it, for the resolution
+/// tests below. Returns the window (with the part in `artwork`), the store and
+/// the registry so the caller can build a sink.
+fn window_with_produced_png(
+    name: &str,
+) -> (
+    ContextWindow,
+    leviath_core::mime::MemoryBlobStore,
+    leviath_core::mime::MimeRegistry,
+    leviath_core::mime::BlobRef,
+) {
+    use leviath_core::mime::{Blob, BlobStore, MemoryBlobStore, MimeRegistry, MimeType, Part};
+    let store = MemoryBlobStore::new();
+    let registry = MimeRegistry::builtin();
+    let bytes = b"\x89PNG\r\n\x1a\n produced pixels".to_vec();
+    let blob = Blob::new(MimeType::parse("image/png").unwrap(), bytes).named(name);
+    let reference = store.put("run-1", &blob, &registry).expect("stored");
+    let mut w = win();
+    w.add_region(Region::new(
+        "artwork".to_string(),
+        RegionKind::Pinned,
+        100_000,
+    ));
+    let content = leviath_core::region::EntryContent::from_parts(vec![
+        Part::stored(reference.clone()).named(name),
+    ]);
+    let tokens = content.tokens_hint();
+    w.add_assistant_turn_content(
+        "artwork",
+        leviath_core::EntryKind::Text,
+        content,
+        tokens,
+        None,
+    )
+    .expect("stored in artwork");
+    (w, store, registry, reference)
+}
+
+/// The part name need not match the artifact path exactly: the path's file name
+/// resolves it, so `./image-1.png` finds the part named `image-1.png`.
+#[test]
+fn a_produced_part_resolves_by_its_file_name() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let (mut w, store, registry, _) = window_with_produced_png("image-1.png");
+    let sink = crate::context_setup::PartSink {
+        store: &store,
+        registry: &registry,
+        run_id: "run-1",
+        max_part_bytes: 1024,
+    };
+    let (_, output) = handle_output_tool(
+        &json!({
+            "content": "described",
+            "artifacts": [{"name": "image", "path": "./image-1.png"}],
+        }),
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "describe",
+            stage_names: &[],
+            workdir: Some(dir.path()),
+            sink: Some(&sink),
+        },
+        0,
+        &mut w,
+    );
+    assert!(output.is_some(), "the file name resolved the part");
+    assert!(dir.path().join("image-1.png").exists());
+}
+
+/// A part can also be named by a prefix of its sha256, for when the model was
+/// shown the hash rather than a file name.
+#[test]
+fn a_produced_part_resolves_by_sha_prefix() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let (mut w, store, registry, reference) = window_with_produced_png("unnamed.png");
+    let sink = crate::context_setup::PartSink {
+        store: &store,
+        registry: &registry,
+        run_id: "run-1",
+        max_part_bytes: 1024,
+    };
+    let prefix = reference
+        .sha256
+        .get(..16)
+        .expect("a sha256 is 64 hex chars");
+    let (_, output) = handle_output_tool(
+        &json!({
+            "content": "described",
+            "artifacts": [{"name": "image", "path": prefix}],
+        }),
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "describe",
+            stage_names: &[],
+            workdir: Some(dir.path()),
+            sink: Some(&sink),
+        },
+        0,
+        &mut w,
+    );
+    assert!(output.is_some(), "the sha prefix resolved the part");
+    assert!(dir.path().join(prefix).exists());
+}
+
+/// A store that cannot read the part's bytes refuses the submission, saying so.
+#[test]
+fn a_produced_part_whose_store_read_fails_is_refused() {
+    use leviath_core::mime::{Blob, BlobRef, BlobStore, MimeRegistry};
+    struct Broken;
+    impl BlobStore for Broken {
+        fn put(&self, _: &str, _: &Blob, _: &MimeRegistry) -> std::io::Result<BlobRef> {
+            Err(std::io::Error::other("no"))
+        }
+        fn read(&self, _: &str, _: &str) -> std::io::Result<std::sync::Arc<[u8]>> {
+            Err(std::io::Error::other("disk gone"))
+        }
+        fn copy(&self, _: &str, _: &str, _: &str) -> std::io::Result<()> {
+            Err(std::io::Error::other("no"))
+        }
+        fn list(&self, _: &str) -> std::io::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+    }
+    let dir = tempfile::tempdir().expect("temp dir");
+    let (mut w, _store, registry, _) = window_with_produced_png("image-1.png");
+    let broken = Broken;
+    let sink = crate::context_setup::PartSink {
+        store: &broken,
+        registry: &registry,
+        run_id: "run-1",
+        max_part_bytes: 1024,
+    };
+    let (message, output) = handle_output_tool(
+        &json!({
+            "content": "described",
+            "artifacts": [{"name": "image", "path": "image-1.png"}],
+        }),
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "describe",
+            stage_names: &[],
+            workdir: Some(dir.path()),
+            sink: Some(&sink),
+        },
+        0,
+        &mut w,
+    );
+    assert!(output.is_none());
+    assert!(
+        message.contains("could not be read from the run's store"),
+        "{message}"
+    );
+}
+
+/// Writing a resolved part to a path whose directory does not exist fails with
+/// the reason rather than making the tree.
+#[test]
+fn a_produced_part_written_to_a_missing_directory_is_refused() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let (mut w, store, registry, _) = window_with_produced_png("image-1.png");
+    let sink = crate::context_setup::PartSink {
+        store: &store,
+        registry: &registry,
+        run_id: "run-1",
+        max_part_bytes: 1024,
+    };
+    let (message, output) = handle_output_tool(
+        &json!({
+            "content": "described",
+            "artifacts": [{"name": "image", "path": "nope/image-1.png"}],
+        }),
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "describe",
+            stage_names: &[],
+            workdir: Some(dir.path()),
+            sink: Some(&sink),
+        },
+        0,
+        &mut w,
+    );
+    assert!(output.is_none());
+    assert!(message.contains("could not be written"), "{message}");
+}

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -119,6 +119,7 @@ pub(crate) use tools::{
 pub use tools::{DynamicTools, ToolProgress, ToolService, noop_progress};
 #[cfg(test)]
 pub(crate) use tools::{barrier_then, cut_off_arguments_refusal, invalid_args_refusal};
+mod part_routing;
 mod response;
 pub use response::StageLedger;
 #[cfg(test)]

--- a/crates/leviath-runtime/src/pipeline/part_routing.rs
+++ b/crates/leviath-runtime/src/pipeline/part_routing.rs
@@ -1,0 +1,175 @@
+//! Splitting a reply's produced parts across regions by their mime type.
+//!
+//! A stage declares `[stages.<name>.output_routing]` (`"image/*" = "artwork"`)
+//! to send the parts a model produces somewhere other than `conversation` -
+//! an image the model drew into a region a later stage reads, say, leaving the
+//! turn's text where it always went. This module answers the one question both
+//! recording paths ([`super::response::store_reply`] for a reply with no tool
+//! calls, [`super::tool_results::apply_tool_results_with_parts`] for one with
+//! them) ask: of the parts the model produced, which stay in the conversation
+//! and which are routed, and to where.
+
+use std::collections::BTreeMap;
+
+use leviath_core::blueprint::Stage;
+use leviath_core::mime::Part;
+
+use crate::components::ContextWindow;
+
+/// A reply's produced parts, split into those that stay in the conversation and
+/// those routed to other regions.
+pub(crate) struct RoutedParts {
+    /// Parts no routing rule matched: they belong to the conversation turn,
+    /// beside the reply's text.
+    pub(crate) kept: Vec<Part>,
+    /// The routed parts, grouped by target region. Ordered by region name so
+    /// the same reply always writes its regions in the same order. Empty in
+    /// the common case: no `output_routing`, or none of it matched.
+    pub(crate) routed: Vec<(String, Vec<Part>)>,
+}
+
+/// Split `parts` by `stage`'s [`Stage::output_routing`]. A part whose mime type
+/// matches a rule goes to that rule's region (most specific pattern wins); the
+/// rest are kept for the conversation. With no stage, or no matching rule,
+/// every part is kept.
+pub(crate) fn split(stage: Option<&Stage>, parts: &[Part]) -> RoutedParts {
+    let mut kept = Vec::new();
+    let mut groups: BTreeMap<String, Vec<Part>> = BTreeMap::new();
+    for part in parts {
+        match stage.and_then(|s| s.route_for_mime(&part.mime_type)) {
+            Some(region) => groups
+                .entry(region.to_string())
+                .or_default()
+                .push(part.clone()),
+            None => kept.push(part.clone()),
+        }
+    }
+    RoutedParts {
+        kept,
+        routed: groups.into_iter().collect(),
+    }
+}
+
+/// Write each routed group into its region as one entry. Text belongs to the
+/// conversation turn, so a routed entry carries only produced parts and is
+/// plain [`EntryKind::Text`](leviath_core::EntryKind::Text): a pinned region
+/// lifts its stored parts into the leading user turn, and a sliding window
+/// renders them as a user message, so either way the next stage's model sees
+/// the bytes. A region the write cannot reach (unknown, over budget) is
+/// skipped rather than fatal - the conversation still recorded the reply.
+pub(crate) fn store_routed(window: &mut ContextWindow, routed: &RoutedParts) {
+    for (region, parts) in &routed.routed {
+        let content = leviath_core::region::EntryContent::from_parts(parts.clone());
+        let tokens = content.tokens_hint();
+        if let Err(e) = window.add_assistant_turn_content(
+            region,
+            leviath_core::EntryKind::Text,
+            content,
+            tokens,
+            None,
+        ) {
+            tracing::warn!(region = %region, "[mime] produced parts not routed: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::blueprint::ModelConfig;
+    use leviath_core::mime::{Blob, MimeRegistry, MimeType};
+
+    fn stored_part(mime: &str, name: &str) -> Part {
+        let reg = MimeRegistry::builtin();
+        let blob = Blob::new(MimeType::parse(mime).unwrap(), vec![1, 2, 3]).named(name);
+        Part::stored(blob.describe(&reg)).named(name)
+    }
+
+    fn stage_routing(rules: &[(&str, &str)]) -> Stage {
+        let mut stage = Stage::new(
+            "draw".to_string(),
+            ModelConfig::new("openrouter".to_string(), "m".to_string()),
+        );
+        for (pattern, region) in rules {
+            stage
+                .output_routing
+                .insert((*pattern).to_string(), (*region).to_string());
+        }
+        stage
+    }
+
+    #[test]
+    fn no_stage_keeps_every_part() {
+        let parts = vec![stored_part("image/png", "a.png"), Part::text("hi")];
+        let routed = split(None, &parts);
+        assert!(routed.routed.is_empty());
+        assert_eq!(routed.kept.len(), 2);
+    }
+
+    #[test]
+    fn a_matching_rule_routes_the_part_and_keeps_the_rest() {
+        let stage = stage_routing(&[("image/*", "artwork")]);
+        let parts = vec![
+            Part::text("here it is"),
+            stored_part("image/png", "hero.png"),
+        ];
+        let routed = split(Some(&stage), &parts);
+        assert!(!routed.routed.is_empty());
+        assert_eq!(routed.kept.len(), 1, "the text stays in the conversation");
+        assert_eq!(routed.kept[0].inline_text(), Some("here it is"));
+        assert_eq!(routed.routed.len(), 1);
+        let (region, parts) = &routed.routed[0];
+        assert_eq!(region, "artwork");
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].name.as_deref(), Some("hero.png"));
+    }
+
+    #[test]
+    fn store_routed_writes_each_group_into_its_region() {
+        use leviath_core::region::{Region, RegionKind};
+        let mut window = ContextWindow::new(100_000);
+        window.add_region(Region::new(
+            "artwork".to_string(),
+            RegionKind::Pinned,
+            100_000,
+        ));
+        let routed = RoutedParts {
+            kept: Vec::new(),
+            routed: vec![(
+                "artwork".to_string(),
+                vec![stored_part("image/png", "a.png")],
+            )],
+        };
+        store_routed(&mut window, &routed);
+        let region = window.get_region("artwork").unwrap();
+        assert_eq!(region.content.len(), 1);
+        assert_eq!(region.content[0].content.stored_count(), 1);
+    }
+
+    #[test]
+    fn store_routed_skips_a_region_the_window_does_not_carry() {
+        // A target no region declares is a warning, not a panic: the reply's
+        // conversation entry has already been recorded.
+        let mut window = ContextWindow::new(100_000);
+        let routed = RoutedParts {
+            kept: Vec::new(),
+            routed: vec![("ghost".to_string(), vec![stored_part("image/png", "a.png")])],
+        };
+        store_routed(&mut window, &routed);
+        assert!(window.get_region("ghost").is_none());
+    }
+
+    #[test]
+    fn parts_for_two_regions_group_by_region_name() {
+        let stage = stage_routing(&[("image/*", "artwork"), ("application/pdf", "docs")]);
+        let parts = vec![
+            stored_part("application/pdf", "spec.pdf"),
+            stored_part("image/png", "hero.png"),
+        ];
+        let routed = split(Some(&stage), &parts);
+        assert!(routed.kept.is_empty());
+        // Ordered by region name: artwork before docs.
+        assert_eq!(routed.routed[0].0, "artwork");
+        assert_eq!(routed.routed[1].0, "docs");
+    }
+}

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -844,7 +844,7 @@ pub(crate) fn handle_empty_response(
             && progress.cut_off_nudges < MAX_CUT_OFF_NUDGES
         {
             progress.cut_off_nudges += 1;
-            store_reply(&mut window, infer, infer.reasoning.clone());
+            store_reply(&mut window, infer, infer.reasoning.clone(), stage);
             inject_system_nudge(&mut window, &cut_off_nudge(cut_off_at));
             commands
                 .entity(entity)
@@ -861,14 +861,14 @@ pub(crate) fn handle_empty_response(
             // told "you have not written the file yet" with its own unwritten
             // draft in front of it can split it; one with nothing in front of
             // it drafts the whole thing again.
-            store_reply(&mut window, infer, infer.reasoning.clone());
+            store_reply(&mut window, infer, infer.reasoning.clone(), stage);
             commands
                 .entity(entity)
                 .remove::<ReadyForTransition>()
                 .insert(ResolveTransition);
         } else {
             progress.text_only_nudges += 1;
-            store_reply(&mut window, infer, infer.reasoning.clone());
+            store_reply(&mut window, infer, infer.reasoning.clone(), stage);
             let stage_name = stage.map(|s| s.name.as_str()).unwrap_or("");
             let regions = stage
                 .and_then(|s| s.context_layout.as_ref())
@@ -923,18 +923,24 @@ fn store_reply(
     window: &mut ContextWindow,
     infer: &crate::components::InferenceResult,
     reasoning: Option<String>,
+    stage: Option<&leviath_core::blueprint::Stage>,
 ) {
-    let Some(content) = reply_content(&infer.response, &infer.parts) else {
-        return;
-    };
-    let tokens = content.tokens_hint();
-    let _ = window.add_assistant_turn_content(
-        "conversation",
-        leviath_core::EntryKind::AssistantTurn { tool_calls: vec![] },
-        content,
-        tokens,
-        reasoning,
-    );
+    // The stage may send some produced parts to regions of their own
+    // (`output_routing`). The reply's text and any unrouted part stay in the
+    // conversation as the assistant turn; the routed parts land in their
+    // regions as separate entries.
+    let routed = super::part_routing::split(stage, &infer.parts);
+    if let Some(content) = reply_content(&infer.response, &routed.kept) {
+        let tokens = content.tokens_hint();
+        let _ = window.add_assistant_turn_content(
+            "conversation",
+            leviath_core::EntryKind::AssistantTurn { tool_calls: vec![] },
+            content,
+            tokens,
+            reasoning,
+        );
+    }
+    super::part_routing::store_routed(window, &routed);
 }
 
 /// A reply's text and produced parts as one entry's content, or `None` when

--- a/crates/leviath-runtime/src/pipeline/spawn.rs
+++ b/crates/leviath-runtime/src/pipeline/spawn.rs
@@ -160,6 +160,7 @@ pub(crate) fn stage_setup_from(
         accepts_messages: stage.accepts_messages,
         context_layout: stage.context_layout.clone(),
         context_hide: stage.context_hide.clone(),
+        context_reset: stage.context_reset.clone(),
         system_prompt,
     }
 }
@@ -565,6 +566,7 @@ mod stage_instructions_fit_tests {
             accepts_messages: true,
             context_layout: None,
             context_hide: Vec::new(),
+            context_reset: Vec::new(),
             system_prompt: Some(prompt),
         };
         crate::pipeline::transition::apply_stage_context(&setup, &mut window)
@@ -634,6 +636,7 @@ mod stage_instructions_fit_tests {
             accepts_messages: true,
             context_layout: None,
             context_hide: Vec::new(),
+            context_reset: Vec::new(),
             system_prompt: Some(prompt),
         };
         crate::pipeline::transition::apply_stage_context(&setup, &mut window)
@@ -721,6 +724,7 @@ mod stage_instructions_fit_tests {
             accepts_messages: true,
             context_layout: None,
             context_hide: Vec::new(),
+            context_reset: Vec::new(),
             system_prompt: Some(prompt),
         };
         let err = crate::pipeline::transition::apply_stage_context(&setup, &mut window)
@@ -801,6 +805,7 @@ mod stage_instructions_fit_tests {
             accepts_messages: true,
             context_layout: Some(scoped),
             context_hide: Vec::new(),
+            context_reset: Vec::new(),
             system_prompt: Some(prompt),
         };
         crate::pipeline::transition::apply_stage_context(&setup, &mut window)

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -7546,6 +7546,7 @@ fn setup() -> StageSetup {
         accepts_messages: true,
         context_layout: None,
         context_hide: Vec::new(),
+        context_reset: Vec::new(),
         system_prompt: None,
     }
 }
@@ -16391,6 +16392,44 @@ fn setup_carrying_prompt(prompt: &str) -> StageSetup {
     }
 }
 
+/// `context.reset` empties the named regions on entry, so a stage starts on a
+/// clean slate; a region left out of the list keeps its content.
+#[test]
+fn context_reset_empties_the_named_region_on_entry() {
+    let mut window = instructions_window(&["conversation", "task"]);
+    window
+        .add_to_region("conversation", "a turn from the last stage".to_string(), 5)
+        .expect("fits");
+    window
+        .add_to_region("task", "the task".to_string(), 2)
+        .expect("fits");
+
+    let setup = StageSetup {
+        // `ghost` is not in this window: a reset name the window does not carry
+        // is skipped, not an error.
+        context_reset: vec!["conversation".to_string(), "ghost".to_string()],
+        ..setup()
+    };
+    apply_stage_context(&setup, &mut window).expect("fits");
+
+    assert!(
+        window
+            .get_region("conversation")
+            .unwrap()
+            .content
+            .is_empty(),
+        "the reset region is emptied"
+    );
+    assert!(
+        window.get_region("ghost").is_none(),
+        "a reset name the window lacks is simply skipped"
+    );
+    assert!(
+        !window.get_region("task").unwrap().content.is_empty(),
+        "a region not named in reset keeps its content"
+    );
+}
+
 /// Without a declared region the prompt still lands in the first pinned one, so
 /// every blueprint written before this keeps working unchanged.
 #[test]
@@ -18047,6 +18086,7 @@ fn a_stage_hides_what_it_names_and_the_next_stage_starts_clean() {
     let _ = window.add_to_region("sources", "a page".to_string(), 2);
     let hiding = StageSetup {
         context_hide: vec!["sources".to_string(), "conversation".to_string()],
+        context_reset: Vec::new(),
         ..setup_carrying_prompt("polish")
     };
     apply_stage_context(&hiding, &mut window).expect("fits");
@@ -18731,6 +18771,7 @@ mod model_parts {
             Reply {
                 text: "drawn",
                 parts: std::slice::from_ref(&stored),
+                stage: None,
             },
             &[tc("c1", "render")],
             &[("c1".to_string(), "ok".to_string().into())],
@@ -18746,5 +18787,42 @@ mod model_parts {
             conv.content[0].kind,
             leviath_core::EntryKind::AssistantTurn { .. }
         ));
+    }
+
+    #[test]
+    fn output_routing_sends_a_produced_image_to_its_region_not_the_conversation() {
+        let stored =
+            Part::stored(png("hero.png").describe(&leviath_core::mime::MimeRegistry::builtin()))
+                .named("hero.png");
+        let mut stage = leviath_core::blueprint::Stage::new(
+            "draw".to_string(),
+            leviath_core::blueprint::ModelConfig::new("openrouter".to_string(), "m".to_string()),
+        );
+        stage
+            .output_routing
+            .insert("image/*".to_string(), "artwork".to_string());
+
+        let mut w = ctx(&[("conversation", 100_000), ("artwork", 100_000)]);
+        apply_tool_results_with_parts(
+            &mut w,
+            Reply {
+                text: "drawn",
+                parts: std::slice::from_ref(&stored),
+                stage: Some(&stage),
+            },
+            &[tc("c1", "render")],
+            &[("c1".to_string(), "ok".to_string().into())],
+            None,
+            None,
+            None,
+        );
+        // The conversation keeps the text and the tool call, but not the image.
+        let conv = w.get_region("conversation").unwrap();
+        assert_eq!(conv.content[0].content.stored_count(), 0);
+        assert!(conv.content[0].content.as_str().starts_with("drawn"));
+        // The image lands in artwork instead.
+        let artwork = w.get_region("artwork").unwrap();
+        assert_eq!(artwork.content.len(), 1);
+        assert_eq!(artwork.content[0].content.stored_count(), 1);
     }
 }

--- a/crates/leviath-runtime/src/pipeline/tool_results.rs
+++ b/crates/leviath-runtime/src/pipeline/tool_results.rs
@@ -138,6 +138,8 @@ pub(crate) fn apply_tool_results(
         Reply {
             text: response_content,
             parts: &[],
+            // No produced parts here, so there is nothing to route.
+            stage: None,
         },
         tool_calls,
         tool_results,
@@ -154,6 +156,10 @@ pub(crate) struct Reply<'a> {
     pub(crate) text: &'a str,
     /// The mime it produced, already stored.
     pub(crate) parts: &'a [leviath_core::mime::Part],
+    /// The stage this reply came from, when its `output_routing` should send
+    /// some produced parts to regions of their own. `None` keeps every part
+    /// in the conversation.
+    pub(crate) stage: Option<&'a leviath_core::blueprint::Stage>,
 }
 
 /// [`apply_tool_results`] for a reply that produced mime beside its tool
@@ -167,7 +173,13 @@ pub(crate) fn apply_tool_results_with_parts(
     sensitivities: Option<&std::collections::HashMap<String, leviath_core::TaintLevel>>,
     reasoning: Option<String>,
 ) {
-    let content = super::response::reply_content(reply.text, reply.parts)
+    // The stage may route some produced parts to regions of their own
+    // (`output_routing`). The assistant turn keeps the reply's text, its
+    // unrouted parts and its tool calls; the routed parts land in their
+    // regions as separate entries (written after the turn, since they go
+    // elsewhere than the conversation).
+    let routed = super::part_routing::split(reply.stage, reply.parts);
+    let content = super::response::reply_content(reply.text, &routed.kept)
         .unwrap_or_else(|| leviath_core::region::EntryContent::text(reply.text));
     let response_tokens = content.tokens_hint();
     let serialized: Vec<leviath_core::SerializedToolCall> = tool_calls
@@ -188,6 +200,7 @@ pub(crate) fn apply_tool_results_with_parts(
         response_tokens,
         reasoning,
     );
+    super::part_routing::store_routed(window, &routed);
 
     for (tool_call_id, result) in tool_results {
         let tool_name = tool_calls

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -418,6 +418,13 @@ pub(crate) fn dispatch_tools(
             continue; // paused / waiting / cancelled - don't start new work
         }
 
+        // This stage, for routing the parts a reply produces to regions of
+        // their own (`output_routing`). Computed once so both apply paths below
+        // share it.
+        let routing_stage = blueprint
+            .zip(cursor)
+            .and_then(|(bp, cur)| bp.0.stages.get(cur.index));
+
         // Apply context_* tools inline (they need world access); collect the rest
         // for the async lane. A taint-gated agent's outbound call that would leak
         // over-cleared data (and isn't allowlisted) is blocked - either returned
@@ -758,6 +765,7 @@ pub(crate) fn dispatch_tools(
                 super::tool_results::Reply {
                     text: &result.response,
                     parts: &result.parts,
+                    stage: routing_stage,
                 },
                 &result.tool_calls,
                 &merged,
@@ -798,6 +806,7 @@ pub(crate) fn dispatch_tools(
                 super::tool_results::Reply {
                     text: &result.response,
                     parts: &result.parts,
+                    stage: routing_stage,
                 },
                 &result.tool_calls,
                 &merged,

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -44,6 +44,8 @@ pub(crate) struct StageSetup {
     pub context_layout: Option<leviath_core::ContextLayout>,
     /// Regions this stage leaves out of its prompt (`[stages.<name>.context] hide`).
     pub context_hide: Vec<String>,
+    /// Regions this stage empties on entry (`[stages.<name>.context] reset`).
+    pub context_reset: Vec<String>,
     /// Optional stage instructions injected as pinned context on entry.
     pub system_prompt: Option<String>,
 }
@@ -780,6 +782,15 @@ pub(crate) fn apply_stage_context(
     for name in &setup.context_hide {
         if !leviath_core::blueprint::ALWAYS_VISIBLE_REGIONS.contains(&name.as_str()) {
             window.hidden.insert(name.clone());
+        }
+    }
+    // `reset` empties a region as the stage is entered, so it starts on a clean
+    // slate - a describe stage reading its image from a region of its own with
+    // none of the drawing stage's conversation carried in. Emptied, not
+    // hidden: a later stage sees the fresh region, not the old turns.
+    for name in &setup.context_reset {
+        if let Some(region) = window.regions.iter_mut().find(|r| &r.name == name) {
+            region.clear();
         }
     }
 

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -373,6 +373,7 @@ mod tests {
             accepts_messages: true,
             context_layout: None,
             context_hide: Vec::new(),
+            context_reset: Vec::new(),
             system_prompt: None,
         }
     }

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -1354,6 +1354,7 @@ mod tests {
             accepts_messages: true,
             context_layout: None,
             context_hide: Vec::new(),
+            context_reset: Vec::new(),
             system_prompt: None,
         }
     }

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -776,6 +776,33 @@ which are errors rather than quiet fallbacks. The workers still share the daemon
 (`[limits] max_concurrent_inferences`, 8 by default), so an unlimited fan-out queues at the model
 rather than running away.
 
+### Stage routing
+
+`GET /api/blueprints/{name}` also carries `stage_routing`: one entry per stage that routes the
+model's produced parts to a region by mime type (`output_routing`), or empties a region when it is
+entered (`context.reset`), so a console shows or checks them without parsing the manifest.
+
+```json
+{
+  "stage_routing": [
+    {
+      "stage": "draw",
+      "output_routing": [{ "pattern": "image/*", "region": "artwork" }]
+    },
+    {
+      "stage": "describe",
+      "context_reset": ["conversation"]
+    }
+  ]
+}
+```
+
+`output_routing` is ordered by pattern, and a part goes to the most specific match's region. Only
+stages that do one or the other appear; a stage that does neither is left out, and a blueprint that
+does neither has an empty list. Changing either is a manifest write through `PUT
+/api/blueprints/{name}`. `blueprints.stage_routing` in the `capabilities` list on `GET /api/config`
+says the daemon reports this.
+
 ## Yolo profiles
 
 The profiles a run can be launched under with `--yolo=<name>` live in
@@ -1495,6 +1522,7 @@ than that feature, not broken.
 | `blueprints.manifest` | The manifest itself on the blueprint detail route |
 | `blueprints.validate.name` | `POST /api/blueprints/validate` accepting an installed name, not only a body |
 | `blueprints.fan_outs` | `fan_outs` on the detail route. See [fan-out limits](#fan-out-limits) |
+| `blueprints.stage_routing` | `stage_routing` on the detail route: `output_routing` and `context.reset` per stage. See [stage routing](#stage-routing) |
 | `tools.list` | `GET /api/tools?agent=`, what an agent here can actually call |
 | `update.plan` | `GET /api/update`, how this copy was installed and the command that upgrades it. See [asking how to upgrade](#asking-how-to-upgrade) |
 | `update.apply` | `POST /api/update` and `GET /api/update/jobs/{id}`, carrying that plan out. Says this build serves them; whether *this* daemon mounts them is `--allow-admin`, which you find out by calling one. See [pressing the button](#pressing-the-button) |

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -670,6 +670,56 @@ result when it applies. Without one, a large file went into its region whole and
 truncated or dropped as `[result omitted]` depending on how full the region already was. That is a
 cliff rather than a limit.
 
+## Routing produced parts
+
+`tool_routing` moves *tool results*. A model can also **produce parts of its own** - a picture from
+an image model, audio from a speech model, a document a generator returns - and those default to the
+conversation, riding the assistant turn like its text. `output_routing` sends them somewhere else,
+**by mime type**, so a produced file lands in a region a later stage reads instead of in the running
+transcript:
+
+```toml
+[context.regions]
+artwork      = { kind = "pinned", accepts = ["image/*"], max_stored = 4 }
+conversation = { kind = "sliding_window", budget = "50%" }
+
+[stages.draw.output_routing]
+"image/*"         = "artwork"
+"application/pdf" = "handouts"
+```
+
+Each key is a mime pattern (`image/png`, `image/*`, `*/*`) and each value a region. A reply that
+mixes text and other parts is split part by part: every part goes to the region of the **most
+specific** matching pattern (`image/png` beats `image/*` beats `*/*`), and the reply's text, plus
+any part no rule matched, stays in `conversation` as before. Nothing here names a family in code -
+it is mime types all the way down, so the same table routes audio, video, 3D models or any type you
+register the same way it routes images.
+
+Unlike `tool_routing`, the target need not be a region *this* stage reads back - the whole point is
+usually to hand a produced file forward - so it is checked against every region the blueprint
+declares, not just the ones the producing stage can see. A target no layout declares is refused by
+`lev validate`.
+
+A pinned target lifts its stored parts into the leading user turn, and a sliding window renders them
+as a user message, so the next stage's model sees the bytes either way (subject to that model taking
+the type; otherwise it sees the stand-in, as anywhere else).
+
+### A clean slate for the next stage
+
+Routing the produced part out of the conversation is half of handing it on; the other half is the
+receiving stage not inheriting the producing stage's transcript. `conversation` cannot be hidden -
+the model's own turns live there - but a stage can **empty** a region as it is entered:
+
+```toml
+[stages.describe.context]
+reset = ["conversation"]
+```
+
+`reset` clears the named regions on entry (the content is gone, not merely hidden from this stage),
+so the stage starts on a clean conversation with only what its visible regions hold - the routed
+image in `artwork`, say. A re-entered stage clears them again each visit. Unlike `hide`, `reset` may
+name `conversation`; like `hide`, a name no layout declares is refused.
+
 ## Requests are measured before they are sent
 
 The window sizes what it holds with a byte estimate, corrected by what earlier calls in the run

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -364,6 +364,14 @@ hashed, and stored as a part of the run when it fits `[mime] max_part_bytes`, so
 sees it in the `final_output` region the way it sees any other part. The answer records
 `name`, `path`, `mime_type`, `size` and `sha256` per file.
 
+A file the run **produced** but never wrote to disk - a picture from an image model, say, which
+lives in the run's store - can be named the same way. When the path is not a file in the working
+directory, the name (then a sha256 prefix) is resolved against the parts the run has produced, and a
+match is written to that path before it is recorded. So a describe-the-image stage can attach the
+picture it was handed with `artifacts: [{ name: "image", path: "image-1.png" }]` (the file name is
+shown beside the part in its region), and the user gets a real file. A name that is neither a file
+nor a produced part is refused, saying both places were checked.
+
 A stage can say up front which files it hands back:
 
 ```toml

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -122,6 +122,8 @@ somewhere else.
 | `input.accepts` | the visible regions' `accepts` | The mime types the stage takes as [parts](/docs/mime), used to prefer a model that can see them and by `lev validate` |
 | `input.as_text` | `[]` | Mime types whose parts reach this stage's model as text whatever the model takes |
 | `output.artifacts` | `[]` | The files the stage hands back beside its answer, by name and type. See [Final outputs](/docs/outputs#large-results) |
+| `output_routing` | `{}` | Where the model's produced parts go, by mime type: `"image/*" = "artwork"`. See [Routing produced parts](/docs/context#routing-produced-parts) |
+| `context.reset` | `[]` | Regions emptied when the stage is entered, for a clean slate. See [A clean slate for the next stage](/docs/context#a-clean-slate-for-the-next-stage) |
 | `tool_accepts` | `{}` | What each tool may be handed at this stage, as `tool = ["image/*"]`: a stored part outside the list is out of that tool's reach here. See [Mime](/docs/mime#what-a-tool-may-be-handed) |
 
 Three of those need a sentence more.

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -534,6 +534,13 @@
             }
           }
         },
+        "output_routing": {
+          "type": "object",
+          "description": "Where the model's produced parts go, by mime type: a mime pattern (image/png, image/*, */*) to a region name. A reply that mixes text and media is split part by part; each part goes to the most specific matching pattern's region, and text and unmatched parts stay in conversation. The target need only be a region some layout declares, so a stage can hand a produced file to a later stage or to the user.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "context": {
           "type": "object",
           "additionalProperties": false,
@@ -547,6 +554,13 @@
             "hide": {
               "type": "array",
               "description": "Regions this stage leaves out of its prompt. Hidden, not destroyed: the content is kept and every other stage sees it. Names must be declared by a layout in this blueprint, and the always-visible regions (conversation, tool_results, final_output, stage_instructions) cannot be hidden.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "reset": {
+              "type": "array",
+              "description": "Regions emptied when this stage is entered, so it starts on a clean slate. Unlike hide, this clears the content (gone, not hidden); a re-entered stage clears it each visit. conversation can be reset. Names must be declared by a layout in this blueprint.",
               "items": {
                 "type": "string"
               }

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -266,7 +266,7 @@
           "blueprints"
         ],
         "summary": "Fetch one blueprint",
-        "description": "The catalog entry plus the manifest text, the context regions, and fan_outs: one entry per fan-out stage with its worker source, merge stage and both caps (max_workers, max_items) resolved as the daemon applies them, null meaning unlimited.",
+        "description": "The catalog entry plus the manifest text, the context regions, fan_outs (one entry per fan-out stage with its worker source, merge stage and both caps resolved as the daemon applies them, null meaning unlimited), and stage_routing (one entry per stage that routes the model's produced parts by mime type via output_routing, or empties a region on entry via context.reset).",
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"


### PR DESCRIPTION
Fixes the image-gen breakage you found: the describe stage was reading a polluted conversation and could not emit the image as a file. This makes typed content flow from a stage to regions, to disk, and on to the next stage — by **mime type**, nothing hardcoded to images.

## What was wrong

On the run you tested, the describe stage inherited the draw stage's whole conversation (its `[System]` nudges, the iteration-cap warning, its tool scaffolding), and the generated image lived only as a run blob — so `submit_output(artifacts:["image-1.png"])` failed with "No such file or directory". Produced parts were hardcoded to the `conversation` region with no way to steer them.

## What this adds

- **`[stages.<name>.output_routing]`** — a mime pattern → region map (`"image/*" = "artwork"`). A reply that mixes text and other parts is split part by part: each goes to the most specific matching pattern's region (`image/png` beats `image/*` beats `*/*`), text and unmatched parts stay in `conversation`. The target need only be a region the blueprint declares, since the point is to feed a *later* stage. Routes audio, PDFs, 3D models — any registered type — the same way.
- **`[stages.<name>.context] reset = ["conversation"]`** — empties named regions on entry, so a stage starts clean. Unlike `hide`, `reset` may name `conversation`.
- **Artifacts from produced parts** — `submit_output` can name a part the run produced (an image in the store, never on disk); the name, then a sha prefix, resolves it and it is written to the named path — a real file for the user and the next stage.

## Validated end to end

Rebuilt image-gen: draw routes its picture to an `artwork` region; describe reads it there on a clean conversation and writes it back as an image artifact. On "a pelican riding a bike" the describe model returned:

> A pelican wearing a small helmet balances on a vintage cruiser bicycle (complete with a fish riding in its front basket) on a beachside boardwalk at golden hour, wings outstretched as onlookers lean over the railing to photograph it...

— detail only a model actually seeing the image could give. `image-1.png` was written to the workdir. The run's `context.json` shows the image in `artwork` and a conversation with none of the draw stage's scaffolding.

## Tests / gates

100% coverage on `leviath-core` and `leviath-runtime`; clippy clean (`-D warnings`, no `#[allow]`); docs and structure pass. Unit tests cover the routing split, the most-specific match, `context.reset` (including reset of `conversation`), and artifact resolution by name / sha / the refusal and error paths.

## Still to come (per your ask)

TUI editor rows and structured HTTP exposure for defining `output_routing` / `context.reset` are the follow-up. The read/write HTTP path already carries both today (they are manifest keys, returned by `GET /api/blueprints/{name}` and settable via create/update).

**Leaving this open for your review** — v0.6.0 stays held (#811) until you are happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kh7J65m1oRXm1WP7vCb7YN
