### PR TITLE
feat(core,cli): available_global_tools stage key advertises installed Rhai tools

### DIFF
--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -312,7 +312,32 @@ fn print_success(blueprint: &leviath_core::Blueprint) {
         let entry = blueprint.resolve_entry_stage_name();
         println!("  Graph mode: entry stage '{}'", entry);
 
-        for stage in &blueprint.stages {
+        for line in stage_lines(blueprint) {
+            println!("{line}");
+        }
+    } else {
+        println!(
+            "  Linear mode: {}",
+            blueprint
+                .stages
+                .iter()
+                .map(|s| format!("{}{}", s.name, global_tools_suffix(s)))
+                .collect::<Vec<_>>()
+                .join(" → ")
+        );
+    }
+}
+
+/// The per-stage lines of a graph-mode success report: where each stage can
+/// go, its revisit cap, and whether it draws on the global tools directory.
+///
+/// Returned rather than printed so the formatting is assertable without
+/// capturing stdout.
+fn stage_lines(blueprint: &leviath_core::Blueprint) -> Vec<String> {
+    blueprint
+        .stages
+        .iter()
+        .map(|stage| {
             let transitions_info = match &stage.transitions {
                 Some(t) if !t.is_empty() => {
                     let targets: Vec<&str> = t.keys().map(|k| k.as_str()).collect();
@@ -325,18 +350,26 @@ fn print_success(blueprint: &leviath_core::Blueprint) {
                 .max_revisits
                 .map(|n| format!(" (max_revisits: {})", n))
                 .unwrap_or_default();
-            println!("  - {}{}{}", stage.name, transitions_info, revisits);
-        }
+            format!(
+                "  - {}{}{}{}",
+                stage.name,
+                transitions_info,
+                revisits,
+                global_tools_suffix(stage)
+            )
+        })
+        .collect()
+}
+
+/// The marker a stage line carries when the stage set `available_global_tools`:
+/// its advertised set is wider than its `available_tools` says, by whatever is
+/// installed in `~/.leviath/tools/` at spawn, and a reader of the report should
+/// know that from the line rather than from the manifest.
+fn global_tools_suffix(stage: &leviath_core::Stage) -> &'static str {
+    if stage.available_global_tools {
+        " (global tools)"
     } else {
-        println!(
-            "  Linear mode: {}",
-            blueprint
-                .stages
-                .iter()
-                .map(|s| s.name.as_str())
-                .collect::<Vec<_>>()
-                .join(" → ")
-        );
+        ""
     }
 }
 
@@ -1547,6 +1580,54 @@ max_iterations = 5
         // map) -> exercises the "(terminal)" formatting branch.
         let b = bp.find_stage("b").unwrap();
         assert!(matches!(&b.transitions, Some(t) if t.is_empty()));
+        print_success(&bp);
+    }
+
+    /// A stage that set `available_global_tools` is marked on its report line,
+    /// in graph mode and in the linear listing alike, and a stage that did not
+    /// is not.
+    #[test]
+    fn print_success_marks_stages_that_draw_on_global_tools() {
+        let toml = make_blueprint_toml(
+            r#"
+[stages.a]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+description = "A"
+max_iterations = 5
+available_tools = ["read_file"]
+available_global_tools = true
+[stages.a.transitions]
+b = "true"
+
+[stages.b]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+description = "B"
+max_iterations = 5
+[stages.b.transitions]
+"#,
+        );
+        let bp = parse(&toml);
+        let lines = stage_lines(&bp);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], "  - a → b (global tools)");
+        assert_eq!(lines[1], "  - b (terminal)");
+        print_success(&bp);
+
+        // The linear listing carries the same marker on the stage name.
+        let linear = make_blueprint_toml(
+            r#"
+[stages.main]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-4-6" }
+description = "Main"
+max_iterations = 5
+available_global_tools = true
+"#,
+        );
+        let bp = parse(&linear);
+        assert_eq!(global_tools_suffix(&bp.stages[0]), " (global tools)");
         print_success(&bp);
     }
 

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -539,8 +539,10 @@ fn build_agent_inner(
         .flatten()
         .filter(|name| !name.is_empty());
 
-    // 1. Load the blueprint (the client resolves the manifest path).
-    let (content, blueprint) = load_blueprint(args, deps.config)?;
+    // 1. Load the blueprint (the client resolves the manifest path). Mutable
+    // because step 2d writes each stage's global tool grants into it before the
+    // runtime resolves the stages from it.
+    let (content, mut blueprint) = load_blueprint(args, deps.config)?;
 
     // 2a. Entry stage + per-stage sandbox resolution. Each stage's effective
     // sandbox cascades stage → agent → global (`resolve_sandbox`); building the
@@ -652,6 +654,29 @@ fn build_agent_inner(
     );
     all_tool_defs.extend(script_defs);
 
+    // 2d. Global tool grants. `available_tools` is exact-match, so a tool an
+    // earlier run installed into `~/.leviath/tools/` is invisible to a stage
+    // that does not name it; a stage with `available_global_tools` asks for
+    // every such tool. The expansion is written into the blueprint itself,
+    // before stage resolution, because that is where the runtime reads each
+    // stage's grant list from - and the `stage_available` snapshot taken
+    // below inherits it, so a `dynamic_tools` refresh re-filters against the
+    // same expanded list. Only scripts discovered from the global directory
+    // count (see `global_tool_names`): a workdir or agent-dir script that
+    // shadows a global name is never granted this way.
+    let global_tools_dir = leviath_core::tools_dir();
+    let global_names = global_tool_names(
+        &script_tools,
+        &script_tool_names,
+        global_tools_dir.as_deref(),
+    );
+    for stage in &mut blueprint.stages {
+        if stage.available_global_tools {
+            stage.available_tools =
+                expand_global_grants(&stage.available_tools, true, &global_names);
+        }
+    }
+
     // 3. Resolve stages against the world's providers.
     let stages = {
         let registry = &world
@@ -729,6 +754,14 @@ fn build_agent_inner(
         .stages
         .iter()
         .map(|s| s.required_tools.clone())
+        .collect();
+    // And which stages hold a global grant, so a refresh can extend the list
+    // with a tool installed *during* the run - the snapshot above only knows
+    // the global inventory as it stood at spawn.
+    let stage_global: Vec<bool> = blueprint
+        .stages
+        .iter()
+        .map(|s| s.available_global_tools)
         .collect();
     // The same list as a lookup set, canonicalised, for the tool state: an
     // interaction for a kept tool has to reach a real person rather than the
@@ -1082,6 +1115,8 @@ fn build_agent_inner(
             mcp_owners: deps.mcp_tool_owners.clone(),
             stage_available,
             stage_required,
+            stage_global,
+            tools_dir: global_tools_dir,
             unattended: unattended_tools,
             dirty: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
@@ -1315,6 +1350,68 @@ system = { kind = "pinned", max_tokens = 1000 }
             def_names.sort_unstable();
             assert_eq!(def_names, vec!["echo", "net_tool"]);
         });
+    }
+
+    /// A global grant expands to the tools whose *file* is in the global
+    /// directory and that survived discovery: a workdir script shadowing a
+    /// global name is not one, a reserved name that discovery dropped is not
+    /// one, and the result is sorted. With no global directory there is nothing
+    /// to grant.
+    #[test]
+    fn global_tool_names_are_the_surviving_tools_from_the_global_dir_only() {
+        let workdir = tempfile::tempdir().unwrap();
+        let global = tempfile::tempdir().unwrap();
+        let workdir_tools = workdir.path().join("tools");
+        std::fs::create_dir(&workdir_tools).unwrap();
+        // `echo` exists in both places; the workdir copy wins the scan.
+        std::fs::write(workdir_tools.join("echo.rhai"), "// @tool echo\n\"repo\"").unwrap();
+        std::fs::write(global.path().join("echo.rhai"), "// @tool echo\n\"global\"").unwrap();
+        std::fs::write(global.path().join("zed.rhai"), "// @tool zed\n1").unwrap();
+        std::fs::write(global.path().join("alpha.rhai"), "// @tool alpha\n1").unwrap();
+        // Compiled, but a reserved name discovery would have dropped.
+        std::fs::write(
+            global.path().join("read_file.rhai"),
+            "// @tool read_file\n1",
+        )
+        .unwrap();
+        let (set, _skipped) = leviath_scripting::ScriptToolSet::discover(&[
+            workdir_tools,
+            global.path().to_path_buf(),
+        ]);
+        let surviving: HashSet<String> = ["echo", "zed", "alpha"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+
+        assert_eq!(
+            global_tool_names(&set, &surviving, Some(global.path())),
+            vec!["alpha".to_string(), "zed".to_string()]
+        );
+        // A name discovery did not keep is not granted even from the global dir.
+        let fewer: HashSet<String> = ["zed".to_string()].into_iter().collect();
+        assert_eq!(
+            global_tool_names(&set, &fewer, Some(global.path())),
+            vec!["zed".to_string()]
+        );
+        assert!(global_tool_names(&set, &surviving, None).is_empty());
+    }
+
+    /// The grant list keeps the blueprint's order, appends what is global and
+    /// new, names nothing twice, and is untouched for a stage without the flag.
+    #[test]
+    fn expand_global_grants_appends_without_duplicates_only_when_allowed() {
+        let available = vec!["read_file".to_string(), "echo".to_string()];
+        let global = vec!["alpha".to_string(), "echo".to_string()];
+        assert_eq!(
+            expand_global_grants(&available, true, &global),
+            vec![
+                "read_file".to_string(),
+                "echo".to_string(),
+                "alpha".to_string()
+            ]
+        );
+        assert_eq!(expand_global_grants(&available, false, &global), available);
+        assert_eq!(expand_global_grants(&[], true, &[]), Vec::<String>::new());
     }
 
     #[test]
@@ -2076,6 +2173,155 @@ system = { kind = "pinned", max_tokens = 1000 }
             chrono::DateTime::parse_from_rfc3339(v["utc"].as_str().expect("utc")).is_ok(),
             "{json}"
         );
+    }
+
+    /// A stage with `available_global_tools` is offered a tool installed in the
+    /// global directory that its `available_tools` never named - at spawn, in
+    /// the resolved stage the runtime reads, not only on a later refresh - and a
+    /// stage without the flag is not. The `dynamic_tools` snapshot the refresh
+    /// path filters against inherits the same expansion.
+    #[tokio::test]
+    async fn build_agent_grants_global_tools_to_a_stage_that_opted_in() {
+        let home = tempfile::tempdir().unwrap();
+        let global = home.path().join(".leviath").join("tools");
+        std::fs::create_dir_all(&global).unwrap();
+        std::fs::write(
+            global.join("echo.rhai"),
+            "// @tool echo\n// @description say it back\nparams.x",
+        )
+        .unwrap();
+        temp_env::async_with_vars(
+            [("LEVIATH_HOME", Some(home.path().to_str().unwrap()))],
+            async {
+                let dir = tempfile::tempdir().unwrap();
+                let manifest = dir.path().join("agent.leviath");
+                std::fs::write(
+                    &manifest,
+                    "[agent]\nname = \"global\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\
+                     dynamic_tools = true\n\n\
+                     [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\
+                     available_tools = [\"read_file\"]\navailable_global_tools = true\n\n\
+                     [stages.plain]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\
+                     available_tools = [\"read_file\"]\n",
+                )
+                .unwrap();
+                let (mut world, cli) = test_world();
+                let hub = InteractionHub::new();
+                let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+                let mut args = spawn_args(&manifest.to_string_lossy());
+                args.workdir = dir.path().to_string_lossy().to_string();
+                let entity = build_agent(
+                    world.world_mut(),
+                    SpawnDeps {
+                        tool_service: cli.as_ref(),
+                        config: &Config::default(),
+                        shared_mcp: mcp,
+                        mcp_tool_defs: &[],
+                        mcp_tool_owners: &Default::default(),
+                        hub: &hub,
+                        now_secs: 100,
+                        subagent_tx: sub_tx(),
+                    },
+                    &args,
+                )
+                .expect("spawn succeeds");
+
+                // The entry stage's resolved tools, as the runtime will offer them.
+                let mut offered: Vec<String> = world
+                    .world()
+                    .get::<leviath_runtime::pipeline::StageInference>(entity)
+                    .expect("the entry stage is resolved")
+                    .tools
+                    .iter()
+                    .map(|t| t.name.clone())
+                    .collect();
+                offered.sort_unstable();
+                assert_eq!(offered, vec!["echo".to_string(), "read_file".to_string()]);
+
+                // The refresh snapshot carries the expansion for the opted-in
+                // stage only.
+                let state = cli.state_for(entity).expect("registered");
+                let dynamic = state.dynamic.as_ref().expect("dynamic_tools agent");
+                assert_eq!(
+                    dynamic.stage_available,
+                    vec![
+                        vec!["read_file".to_string(), "echo".to_string()],
+                        vec!["read_file".to_string()],
+                    ]
+                );
+                assert_eq!(dynamic.stage_global, vec![true, false]);
+                assert_eq!(dynamic.tools_dir.as_deref(), Some(global.as_path()));
+            },
+        )
+        .await;
+    }
+
+    /// The global grant is decided by where a script lives, not by its name: a
+    /// `dynamic_tools` run whose workdir ships `tools/echo.rhai` under the same
+    /// name as a global `echo` has the workdir copy win discovery, and that copy
+    /// is repository content the grant must not advertise. The genuinely global
+    /// `lint` still is.
+    #[tokio::test]
+    async fn build_agent_does_not_grant_a_workdir_script_shadowing_a_global_tool() {
+        let home = tempfile::tempdir().unwrap();
+        let global = home.path().join(".leviath").join("tools");
+        std::fs::create_dir_all(&global).unwrap();
+        std::fs::write(global.join("echo.rhai"), "// @tool echo\n\"global\"").unwrap();
+        std::fs::write(global.join("lint.rhai"), "// @tool lint\n\"ok\"").unwrap();
+        temp_env::async_with_vars(
+            [("LEVIATH_HOME", Some(home.path().to_str().unwrap()))],
+            async {
+                let dir = tempfile::tempdir().unwrap();
+                let workdir_tools = dir.path().join("tools");
+                std::fs::create_dir(&workdir_tools).unwrap();
+                std::fs::write(workdir_tools.join("echo.rhai"), "// @tool echo\n\"repo\"").unwrap();
+                let manifest = dir.path().join("agent.leviath");
+                std::fs::write(
+                    &manifest,
+                    "[agent]\nname = \"shadowed\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\
+                     dynamic_tools = true\n\n\
+                     [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\
+                     available_tools = [\"read_file\"]\navailable_global_tools = true\n",
+                )
+                .unwrap();
+                let (mut world, cli) = test_world();
+                let hub = InteractionHub::new();
+                let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+                let mut args = spawn_args(&manifest.to_string_lossy());
+                args.workdir = dir.path().to_string_lossy().to_string();
+                let entity = build_agent(
+                    world.world_mut(),
+                    SpawnDeps {
+                        tool_service: cli.as_ref(),
+                        config: &Config::default(),
+                        shared_mcp: mcp,
+                        mcp_tool_defs: &[],
+                        mcp_tool_owners: &Default::default(),
+                        hub: &hub,
+                        now_secs: 100,
+                        subagent_tx: sub_tx(),
+                    },
+                    &args,
+                )
+                .expect("spawn succeeds");
+
+                let mut offered: Vec<String> = world
+                    .world()
+                    .get::<leviath_runtime::pipeline::StageInference>(entity)
+                    .expect("the entry stage is resolved")
+                    .tools
+                    .iter()
+                    .map(|t| t.name.clone())
+                    .collect();
+                offered.sort_unstable();
+                assert_eq!(offered, vec!["lint".to_string(), "read_file".to_string()]);
+                // The shadowing copy was discovered (it would answer an explicit
+                // `available_tools` entry); it simply earned no global grant.
+                let state = cli.state_for(entity).expect("registered");
+                assert!(state.script_tool_names.lock().unwrap().contains("echo"));
+            },
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/spawn/scripts.rs
+++ b/crates/leviath-cli/src/daemon/spawn/scripts.rs
@@ -330,3 +330,57 @@ pub(super) fn discover_script_tools(
     let reserved = reserved_tool_names(builtin_names, mcp_tool_defs);
     discover_script_tools_in(&dirs, &reserved)
 }
+
+/// The names a stage's `available_global_tools` grant expands to: every tool in
+/// `set` whose source file lives under `tools_dir` (the global
+/// `~/.leviath/tools/`) and that `surviving` still routes (not dropped for a
+/// reserved-name collision or an unsatisfiable `@requires`).
+///
+/// The file location is the test, not the name. Scan order lets an agent's own
+/// `tools/` or, for a `dynamic_tools` run, the workdir's `tools/` shadow a
+/// global script under the same name, and that shadow is repository content.
+/// Granting it because a trusted global tool happens to share the name would
+/// let a checked-out repo put its own code behind a name the blueprint never
+/// wrote, so a shadowed name is left out here and stays reachable only by an
+/// explicit `available_tools` entry. No global directory (no home) means no
+/// global grants. Sorted, so the model sees the same order every run.
+pub(crate) fn global_tool_names(
+    set: &leviath_scripting::ScriptToolSet,
+    surviving: &HashSet<String>,
+    tools_dir: Option<&std::path::Path>,
+) -> Vec<String> {
+    let Some(global) = tools_dir else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = set
+        .sources()
+        .into_iter()
+        .filter(|(meta, path)| path.starts_with(global) && surviving.contains(&meta.name))
+        .map(|(meta, _)| meta.name)
+        .collect();
+    names.sort_unstable();
+    names
+}
+
+/// A stage's Layer-1 grant list with its global grant applied: `available` as
+/// written, followed by every name in `global_names` it did not already hold,
+/// when `allow_global` is set; `available` unchanged otherwise.
+///
+/// Appending rather than merging keeps the blueprint's own order at the front,
+/// and the de-duplication means a tool a stage names explicitly *and* has
+/// installed globally is advertised once.
+pub(crate) fn expand_global_grants(
+    available: &[String],
+    allow_global: bool,
+    global_names: &[String],
+) -> Vec<String> {
+    let mut granted = available.to_vec();
+    if allow_global {
+        for name in global_names {
+            if !granted.contains(name) {
+                granted.push(name.clone());
+            }
+        }
+    }
+    granted
+}

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -476,6 +476,13 @@ pub(crate) struct DynamicToolCtx {
     /// run), by stage index. Paired with `unattended` so a re-scan can't hand a
     /// `--yolo` agent back the prompting tools spawn resolution took away.
     pub stage_required: Vec<Vec<String>>,
+    /// Which stages set `available_global_tools`, by stage index. A refresh
+    /// re-expands those stages' grants against the global tools rediscovered
+    /// from disk, so a tool installed mid-run reaches a stage that opted in.
+    pub stage_global: Vec<bool>,
+    /// The global tools directory (`~/.leviath/tools/`), the only origin a
+    /// global grant accepts; `None` when no home resolves, which grants nothing.
+    pub tools_dir: Option<PathBuf>,
     /// Whether this run is unattended (`--yolo`).
     pub unattended: bool,
     /// Set when the agent writes a tool file; drained by `wants_refresh`.
@@ -1110,6 +1117,12 @@ impl ToolService for CliToolService {
         // live set so a new tool is both advertised *and* dispatchable.
         let (set, names, script_defs) =
             crate::daemon::spawn::discover_script_tools_in(&ctx.scan_dirs, &ctx.reserved_names);
+        // A stage holding a global grant also takes every global tool the
+        // re-scan found, computed exactly as spawn did (by source directory,
+        // never by name alone), so a tool installed since spawn is advertised
+        // to it and to no stage that did not opt in.
+        let global =
+            crate::daemon::spawn::global_tool_names(&set, &names, ctx.tools_dir.as_deref());
         *state
             .script_tools
             .lock()
@@ -1119,7 +1132,12 @@ impl ToolService for CliToolService {
             .lock()
             .unwrap_or_else(PoisonError::into_inner) = names;
         // Re-filter this stage's advertised tools = static defs + fresh script defs.
-        let available = ctx.stage_available.get(stage_index)?;
+        let allow_global = ctx.stage_global.get(stage_index).copied().unwrap_or(false);
+        let available = crate::daemon::spawn::expand_global_grants(
+            ctx.stage_available.get(stage_index)?,
+            allow_global,
+            &global,
+        );
         // A stage that named no `required_tools` keeps none through an
         // unattended run - the absence is an empty list, not a missing stage,
         // so it must not turn the whole refresh into a no-op.
@@ -1768,11 +1786,58 @@ mod tests {
         stage_required: Vec<Vec<String>>,
         unattended: bool,
     ) -> Arc<AgentToolState> {
+        dynamic_state_with(
+            workdir,
+            DynamicToolCtx {
+                scan_dirs: vec![scan_dir],
+                reserved_names: HashSet::new(),
+                static_defs,
+                mcp_owners: Default::default(),
+                stage_available,
+                stage_required,
+                stage_global: Vec::new(),
+                tools_dir: None,
+                unattended,
+                dirty: Arc::new(AtomicBool::new(false)),
+            },
+        )
+    }
+
+    /// A `DynamicToolCtx` for a global-grant test: `scan_dirs` is the full
+    /// precedence-ordered scan list, `tools_dir` the one directory a
+    /// `stage_global` grant draws from, and every stage names `read_file`.
+    fn global_ctx(
+        scan_dirs: Vec<PathBuf>,
+        stage_global: Vec<bool>,
+        tools_dir: Option<PathBuf>,
+    ) -> DynamicToolCtx {
+        DynamicToolCtx {
+            scan_dirs,
+            reserved_names: HashSet::new(),
+            static_defs: vec![tool_def("read_file")],
+            mcp_owners: Default::default(),
+            stage_available: vec![vec!["read_file".to_string()]; stage_global.len()],
+            stage_required: Vec::new(),
+            stage_global,
+            tools_dir,
+            unattended: false,
+            dirty: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// The state every dynamic-tools test hangs off: attended, write tools
+    /// allowed, and `dynamic` exactly as handed in.
+    fn dynamic_state_with(workdir: PathBuf, dynamic: DynamicToolCtx) -> Arc<AgentToolState> {
         let hub = InteractionHub::new();
-        // `install_tool` writes into the scan dir rather than the real
+        // `install_tool` writes into the ctx's global tools dir when a test
+        // names one, else into its first scan dir, never the real
         // `~/.leviath/tools`, so a test install is what the next refresh finds.
+        let install_dir = dynamic
+            .tools_dir
+            .clone()
+            .or_else(|| dynamic.scan_dirs.first().cloned());
         let builtins = Arc::new(leviath_tools::BuiltinTools::new(
-            leviath_tools::ToolContext::new(workdir).with_tools_dir(Some(scan_dir.clone())),
+            leviath_tools::ToolContext::new(workdir).with_tools_dir(install_dir),
         ));
         let builtin_names: HashSet<String> = builtins.names().into_iter().collect();
         let mut allow = HashMap::new();
@@ -1811,16 +1876,7 @@ mod tests {
             script_tool_names: Arc::new(StdMutex::new(HashSet::new())),
             script_host: no_script_fields().2,
             offered_parts: Arc::new(StdMutex::new(Vec::new())),
-            dynamic: Some(Arc::new(DynamicToolCtx {
-                scan_dirs: vec![scan_dir],
-                reserved_names: HashSet::new(),
-                static_defs,
-                mcp_owners: Default::default(),
-                stage_available,
-                stage_required,
-                unattended,
-                dirty: Arc::new(AtomicBool::new(false)),
-            })),
+            dynamic: Some(Arc::new(dynamic)),
             config_source: test_config_source(),
         })
     }
@@ -1847,6 +1903,98 @@ mod tests {
         // The live script set + names now include the freshly discovered tool.
         assert!(state.script_tool_names.lock().unwrap().contains("echo"));
         assert!(state.script_tools.lock().unwrap().contains("echo"));
+    }
+
+    /// A tool that lands in the global directory mid-run is advertised on the
+    /// next refresh to a stage that set `available_global_tools`, and to no
+    /// stage that did not: the second stage's list is exactly what spawn gave
+    /// it.
+    #[test]
+    fn refresh_tools_extends_an_opted_in_stage_with_new_global_tools() {
+        let workdir = tempfile::tempdir().unwrap();
+        let global = tempfile::tempdir().unwrap();
+        let state = dynamic_state_with(
+            workdir.path().to_path_buf(),
+            global_ctx(
+                vec![global.path().to_path_buf()],
+                vec![true, false],
+                Some(global.path().to_path_buf()),
+            ),
+        );
+        let svc = CliToolService::new();
+        let e =
+            Entity::from_raw_u32(11).expect("a small literal index is always a valid entity id");
+        svc.register(e, state.clone());
+
+        // Nothing installed yet: the opted-in stage sees only what it named.
+        let defs = svc.refresh_tools(e, 0).unwrap();
+        let names: Vec<&str> = defs.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["read_file"]);
+
+        // The run installs a tool into the global directory.
+        std::fs::write(
+            global.path().join("echo.rhai"),
+            "// @tool echo\n// @description say it back\nparams.x",
+        )
+        .unwrap();
+        let defs = svc.refresh_tools(e, 0).unwrap();
+        let mut names: Vec<&str> = defs.iter().map(|t| t.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["echo", "read_file"]);
+        // Dispatchable too, not only advertised.
+        assert!(state.script_tool_names.lock().unwrap().contains("echo"));
+
+        // The stage without the grant is unchanged.
+        let defs = svc.refresh_tools(e, 1).unwrap();
+        let names: Vec<&str> = defs.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["read_file"]);
+    }
+
+    /// A global grant is about where a script lives, not what it is called: a
+    /// `<workdir>/tools/echo.rhai` that shadows a global `echo` (the workdir
+    /// scans first) is repository content, and the refresh does not advertise
+    /// it under the grant. An agent with no home at all has no global directory
+    /// and so no global grants.
+    #[test]
+    fn refresh_tools_does_not_grant_a_shadowed_global_name() {
+        let workdir = tempfile::tempdir().unwrap();
+        let global = tempfile::tempdir().unwrap();
+        let workdir_tools = workdir.path().join("tools");
+        std::fs::create_dir(&workdir_tools).unwrap();
+        std::fs::write(workdir_tools.join("echo.rhai"), "// @tool echo\n\"repo\"").unwrap();
+        std::fs::write(global.path().join("echo.rhai"), "// @tool echo\n\"global\"").unwrap();
+        std::fs::write(global.path().join("lint.rhai"), "// @tool lint\n\"ok\"").unwrap();
+        let state = dynamic_state_with(
+            workdir.path().to_path_buf(),
+            global_ctx(
+                vec![workdir_tools.clone(), global.path().to_path_buf()],
+                vec![true],
+                Some(global.path().to_path_buf()),
+            ),
+        );
+        let svc = CliToolService::new();
+        let e =
+            Entity::from_raw_u32(12).expect("a small literal index is always a valid entity id");
+        svc.register(e, state.clone());
+        let defs = svc.refresh_tools(e, 0).unwrap();
+        let mut names: Vec<&str> = defs.iter().map(|t| t.name.as_str()).collect();
+        names.sort_unstable();
+        // `lint` is global and granted; `echo` resolved to the workdir copy and
+        // is not, though it stays dispatchable for a stage naming it outright.
+        assert_eq!(names, vec!["lint", "read_file"]);
+        assert!(state.script_tool_names.lock().unwrap().contains("echo"));
+
+        // No global directory: the same scan grants nothing beyond the list.
+        let homeless = dynamic_state_with(
+            workdir.path().to_path_buf(),
+            global_ctx(vec![global.path().to_path_buf()], vec![true], None),
+        );
+        let h =
+            Entity::from_raw_u32(13).expect("a small literal index is always a valid entity id");
+        svc.register(h, homeless);
+        let defs = svc.refresh_tools(h, 0).unwrap();
+        let names: Vec<&str> = defs.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["read_file"]);
     }
 
     /// A `dynamic_tools` agent re-filters its advertised set mid-run. That

--- a/crates/leviath-core/src/blueprint/stage.rs
+++ b/crates/leviath-core/src/blueprint/stage.rs
@@ -613,6 +613,23 @@ pub struct Stage {
     #[serde(default)]
     pub allow_blocking_tools: bool,
 
+    /// Whether this stage also advertises every Rhai tool installed in the
+    /// global tools directory (`~/.leviath/tools/`), on top of the names in
+    /// `available_tools`.
+    ///
+    /// `available_tools` is an exact-match allowlist, so a tool that a previous
+    /// run installed with `install_tool` is invisible to every stage that does
+    /// not already name it. This flag is how a stage says "and whatever has
+    /// been installed since": the daemon resolves the global inventory at spawn
+    /// (and again on each `dynamic_tools` refresh) and appends the names to the
+    /// grant list. Only scripts whose file lives in the global directory count;
+    /// a same-named script in the agent's own `tools/` or the run workdir is
+    /// never granted this way, so repository content cannot ride in under a
+    /// global grant. Off by default: a stage has to opt in to running code it
+    /// did not list.
+    #[serde(default)]
+    pub available_global_tools: bool,
+
     /// Per-stage taint/security override. `None` inherits the agent-level
     /// `Blueprint.security` (which in turn inherits the global config toggle).
     /// Set `taint_tracking = false` here to opt a single stage out, or `true`
@@ -758,6 +775,7 @@ impl Stage {
             allow_complete: false,
             allow_as_worker: false,
             allow_blocking_tools: false,
+            available_global_tools: false,
             security: None,
             batch_tool_hint: None,
             shell_hint: None,

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -17,6 +17,7 @@ pub(super) const STAGE_KEYS: &[&str] = &[
     "allow_blocking_tools",
     "allow_complete",
     "available_connectors",
+    "available_global_tools",
     "available_tools",
     "batch_tool_hint",
     "context",
@@ -480,6 +481,13 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     // stops warning about it.
     if let Some(ab) = bool_of(stage_value, "allow_blocking_tools") {
         stage.allow_blocking_tools = ab;
+    }
+
+    // Parse available_global_tools flag: says this stage also advertises every
+    // Rhai tool installed in the global `~/.leviath/tools/` directory, so a
+    // tool an earlier run installed is offered without the blueprint naming it.
+    if let Some(ag) = bool_of(stage_value, "available_global_tools") {
+        stage.available_global_tools = ag;
     }
 
     // Parse per-stage security override: [stages.<name>.security]

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -2303,6 +2303,54 @@ mode = "autonomous"
     assert!(!bp.find_stage("review").unwrap().allow_blocking_tools);
 }
 
+/// `available_global_tools` is read off the stage table: `true` opts the
+/// stage in, an explicit `false` and an absent key both leave it off.
+#[test]
+fn parse_manifest_available_global_tools() {
+    let toml = r#"
+[agent]
+name = "global-tools-test"
+
+[stages.implement]
+mode = "autonomous"
+available_tools = ["read_file"]
+available_global_tools = true
+
+[stages.review]
+mode = "autonomous"
+available_global_tools = false
+
+[stages.summary]
+mode = "autonomous"
+"#;
+    let bp = parse_manifest(toml).unwrap();
+    assert!(bp.find_stage("implement").unwrap().available_global_tools);
+    assert!(!bp.find_stage("review").unwrap().available_global_tools);
+    assert!(!bp.find_stage("summary").unwrap().available_global_tools);
+    // The parser only records the flag; the grant list itself is untouched
+    // until the daemon resolves the global inventory at spawn.
+    assert_eq!(
+        bp.find_stage("implement").unwrap().available_tools,
+        vec!["read_file".to_string()]
+    );
+}
+
+/// A non-boolean `available_global_tools` is not a grant: exactly like
+/// `allow_blocking_tools`, a value of the wrong type reads as unset.
+#[test]
+fn parse_manifest_available_global_tools_ignores_a_non_bool() {
+    let toml = r#"
+[agent]
+name = "global-tools-test"
+
+[stages.main]
+mode = "autonomous"
+available_global_tools = "yes"
+"#;
+    let bp = parse_manifest(toml).unwrap();
+    assert!(!bp.find_stage("main").unwrap().available_global_tools);
+}
+
 #[test]
 fn parse_manifest_fan_out_stage() {
     let toml = r#"

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -154,6 +154,23 @@ without saying so. `lev validate` reports both. See
 is every built-in and every Rhai tool with nothing to keep in step. See
 [tool groups](/docs/tools#tool-groups) for what each reaches and what none of them grant.
 
+`available_global_tools = true` widens that list to every Rhai tool installed in the global
+`~/.leviath/tools/` directory at the moment the run spawns. It exists for tools nobody wrote into
+the blueprint: a run that persisted a mechanical step with `install_tool` last week, say. The stage
+still gets everything in `available_tools`; the global tools are appended after them. Only a script
+whose file lives in the global directory counts. A same-named script in the agent's own `tools/`
+or in the run's working directory wins discovery, as it always has, but it is never granted this
+way, because that file is repository content and a global grant should not be a way for a checkout
+to put its own code behind a trusted name. Each call is still policy-gated like any other tool, and
+`lev validate` marks the stage `(global tools)` so a reader of the report knows the advertised set
+is wider than the manifest says.
+
+```toml
+[stages.implement]
+available_tools        = ["read_file", "edit_file", "shell"]
+available_global_tools = true
+```
+
 `required_tools` is the exception to the unattended cut. A [`--yolo`](/docs/glossary) run drops
 every tool that waits on a person, and this is where a stage names the ones it wants kept anyway.
 Every entry must also appear in `available_tools`, by name or through a group that reaches it;
@@ -408,6 +425,13 @@ dynamic_tools = true
 With it on, a script tool written into the run's own `tools/` directory becomes callable on the
 next inference. Off (the default) is the safer choice, since it means an agent cannot grow its own
 capabilities mid-run.
+
+The re-scan advertises a new tool only to a stage whose `available_tools` names it, with one
+exception: a stage that set `available_global_tools` also picks up whatever has landed in
+`~/.leviath/tools/` since spawn, by the same rule as at spawn (the file has to be in the global
+directory, not merely share a name with one that is). A tool the run itself installs with
+`install_tool` therefore reaches an opted-in stage in the same run, and every stage that opted in
+from the next run onwards whether or not `dynamic_tools` is set.
 
 ## Handing context to a sub-agent
 

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -119,6 +119,7 @@ somewhere else.
 | `allow_as_worker` | `false` | Lets this stage be the target of a [fan-out](/docs/sub-agents) |
 | `accepts_messages` | `true` | Whether `lev msg` reaches this stage. See [Human-in-the-loop](/docs/interaction) |
 | `allow_blocking_tools` | `false` | Marks an autonomous stage as deliberately offering the tools that wait on a person |
+| `available_global_tools` | `false` | Also advertises every Rhai tool installed in `~/.leviath/tools/` at spawn. See [which tools a stage gets](/docs/agents#which-tools-a-stage-gets) |
 | `input.accepts` | the visible regions' `accepts` | The mime types the stage takes as [parts](/docs/mime), used to prefer a model that can see them and by `lev validate` |
 | `input.as_text` | `[]` | Mime types whose parts reach this stage's model as text whatever the model takes |
 | `output.artifacts` | `[]` | The files the stage hands back beside its answer, by name and type. See [Final outputs](/docs/outputs#large-results) |

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -341,6 +341,14 @@ stage control access:
   value is a load error, because a misspelled `deny` that quietly resolved to `ask` would hand
   the author of the typo a prompt where they had written a refusal.
 
+A third, optional setting widens the first. `available_global_tools = true` appends every
+[Rhai tool](/docs/rhai-tools) installed in the global `~/.leviath/tools/` directory to the stage's
+allowlist when the run spawns, so a tool an earlier run installed is offered without the blueprint
+naming it. Only files in that directory qualify; a same-named script in the agent's own `tools/` or
+the run's working directory is never granted this way. The permission gate is unchanged, so an
+installed tool still resolves to `ask` unless something says otherwise. See
+[which tools a stage gets](/docs/agents#which-tools-a-stage-gets).
+
 ```toml
 [stages.implement]
 available_tools = ["read_file", "read_files", "edit_file", "shell"]

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -449,6 +449,10 @@
           "type": "boolean",
           "default": false
         },
+        "available_global_tools": {
+          "type": "boolean",
+          "default": false
+        },
         "batch_tool_hint": {
           "type": "boolean"
         },


### PR DESCRIPTION
Second of the split series (PR 1, #780 `install_tool`, is merged).

A stage's `available_tools` is an exact-match allowlist, so a Rhai tool an earlier run installed into `~/.leviath/tools/` was never offered unless a blueprint happened to name it. `available_global_tools = true` on a stage now appends every tool discovered from the global directory to that stage's grant list.

The expansion is written into the blueprint's own `stage.available_tools` at spawn, after script discovery and before `resolve_stages`, because that is where the runtime reads each stage's grants from; the `stage_available` snapshot the `dynamic_tools` refresh filters against inherits it. Only tools whose source file lives under `leviath_core::tools_dir()` and that survived discovery qualify, so a same-named script in the agent's own `tools/` or in the run workdir (repository content) is never granted under a global name.

- leviath-core: `STAGE_KEYS` entry, `bool_of` parse beside `allow_blocking_tools`, `Stage.available_global_tools` with docs, schema property, parse tests (true, false, absent, non-bool).
- leviath-cli spawn: pure `global_tool_names` and `expand_global_grants` helpers with unit tests; spawn-level tests for the grant and for a shadowing workdir script that must not be granted.
- tool_service: `DynamicToolCtx` gains `stage_global` and `tools_dir`; `refresh_tools` re-expands opted-in stages against the tools rediscovered from the global directory, so a tool installed mid-run reaches them.
- `lev validate`: stage lines carry ` (global tools)` when the flag is set.

Rebased onto current `main`. Built and tested by the PR author; this branch is the same single commit restacked onto `c5391d02` (no content change).