### PR TITLE
feat(dashboard): clearer stage-graph boxes with typed in/out (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ same list.
 
 ### Changed
 
+- The dashboard stage graph reads more clearly. A stage that can end the run
+  shows a `⏹` in its box's top-right corner instead of a `can end` badge on the
+  crowded detail row; the row now names what the stage takes and hands back as
+  `in text · <types> · out text · <types>`, with text always shown; and a box
+  grows to fit its own in/out on a left-to-right graph, so a stage with several
+  types is wider without widening every other box (top-to-bottom and wrapped
+  graphs keep a uniform width) (#400).
 - `--yolo` takes an optional profile, `--yolo=<name>`, on `lev run` and
   `lev agent-client`. The equals sign is required, so `lev run --yolo coder`
   keeps meaning "run coder, plain yolo". The bare flag is unchanged.

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -440,7 +440,7 @@ fn the_context_tab_owns_a_layout_adds_regions_and_routes_tools() {
     );
     let screen = text(&mut dash);
     assert!(screen.contains("its own layout"), "{screen}");
-    assert!(screen.contains("own context"), "{screen}");
+    assert!(screen.contains("▣ own"), "{screen}");
     // Add a region: the popup, Esc cancels, an empty name is ignored, a
     // name adds it and opens its panel.
     goto(&mut dash, FieldId::AddRegion);
@@ -1017,7 +1017,7 @@ fn the_inputs_and_outputs_tab_picks_types_and_opens_files_in_a_window() {
     dash.handle_key(key(KeyCode::Char(' ')));
     dash.handle_key(key(KeyCode::Enter));
     let screen = text(&mut dash);
-    assert!(screen.contains("◧ audio/*"), "{screen}");
+    assert!(screen.contains("in text · audio/*"), "{screen}");
     // With nothing of its own, the input row shows what the regions take
     // between them: the union of their lists (text aside), or any type
     // when one of them takes anything.

--- a/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
@@ -499,7 +499,7 @@ brief = { kind = "pinned", accepts = ["application/pdf"] }
         );
         dash.stage_explorer = Some(explorer());
 
-        let (terminal, text) = rendered_at(&mut dash, 200, 50);
+        let (terminal, text) = rendered_at(&mut dash, 320, 60);
         assert!(text.contains("Stage explorer"), "{text}");
         // By default the canvas is the path and the options: the stages the
         // run has been through and where it can go from implement. Island
@@ -521,7 +521,7 @@ brief = { kind = "pinned", accepts = ["application/pdf"] }
         assert_eq!(style_at_text(&terminal, "implement ×2").fg, Some(C_ACTIVE));
         // `t` brings the whole graph back, pending stages dim.
         dash.stage_explorer.as_mut().unwrap().view.toggle_all();
-        let (terminal, text) = rendered_at(&mut dash, 200, 50);
+        let (terminal, text) = rendered_at(&mut dash, 320, 60);
         for stage in ["plan", "implement", "review", "recover", "island"] {
             assert!(text.contains(stage), "{stage}: {text}");
         }

--- a/crates/leviath-cli/src/tui/flowgraph/content.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/content.rs
@@ -115,10 +115,17 @@ impl NodeStatus {
 /// A box's height on the canvas: a border, the title, two detail rows.
 pub(crate) const NODE_HEIGHT: f64 = 4.0;
 
-/// A box's width for the longest id on the graph: `╭ ▶ ⠋ name ×12 ╮`, and
-/// room for `⑂ 3 run · 1 done · 0 fail`.
-pub(crate) fn node_width(longest_id: usize) -> f64 {
-    (longest_id + 10).max(28) as f64
+/// The smallest a box is drawn, so a one-word stage still reads as a box and
+/// the worker-count detail row (`⑂ 3 run · 1 done · 0 fail`) has room.
+pub(crate) const MIN_NODE_WIDTH: usize = 28;
+
+/// A box's width on the canvas, from the cells its content needs
+/// ([`StageNodeContent::box_width`]), floored at [`MIN_NODE_WIDTH`]. A
+/// left-to-right blueprint gives each box its own width this way; the snake and
+/// the top-to-bottom layout share one width (the widest node) so their columns
+/// stay aligned.
+pub(crate) fn node_width(content_cells: usize) -> f64 {
+    content_cells.max(MIN_NODE_WIDTH) as f64
 }
 
 /// Live counts of a fan-out stage's workers.
@@ -222,49 +229,106 @@ impl StageNodeContent {
         Line::from(Span::styled(format!(" {prefix}{name}{suffix} "), style))
     }
 
-    /// The first detail row: what the stage is, and how far the current
-    /// visit has got.
+    /// The first detail row: what the stage is and where the run is with it.
+    /// A stage is only ever current (the phase and iteration matter) or
+    /// visited (when it last ran matters) or pending (only its kind), never
+    /// two at once, so the row never has to carry an iteration and a clock
+    /// together and stays short enough for a plain box.
     fn detail_row(&self) -> String {
         if let Some(w) = self.workers {
             return format!("⑂ {} run · {} done · {} fail", w.running, w.done, w.failed);
         }
-        // The run's phase takes the kind label's place on the stage the run
-        // is in: "waiting" or "complete" is what matters there, and the row
-        // is not wide enough for both.
-        let phase = match self.status {
-            NodeStatus::Current { run, .. } => run.word(),
-            NodeStatus::Pending | NodeStatus::Visited { .. } => None,
-        };
-        let mut parts: Vec<String> = vec![phase.unwrap_or(self.kind_label).to_string()];
-        if let Some(iteration) = self.iteration {
-            parts.push(format!("iter {iteration}"));
+        match self.status {
+            NodeStatus::Current { run, .. } => {
+                // The phase takes the kind label's place: "waiting" or the
+                // spinner's silence is what matters on the stage the run is in.
+                let mut parts = vec![run.word().unwrap_or(self.kind_label).to_string()];
+                if let Some(iteration) = self.iteration {
+                    parts.push(format!("iter {iteration}"));
+                }
+                parts.join(" · ")
+            }
+            NodeStatus::Visited { .. } => self
+                .last_seen
+                .clone()
+                .unwrap_or_else(|| self.kind_label.to_string()),
+            NodeStatus::Pending => self.kind_label.to_string(),
         }
-        parts.join(" · ")
     }
 
-    /// The second detail row: badges. Mime the stage takes and hands back
-    /// sit here too, so a glance at the graph shows where the files go.
-    fn badge_row(&self) -> String {
+    /// The second detail row: what the stage takes and hands back, read as
+    /// `in <types> · out <types>`. Every stage takes and returns text, so
+    /// `text` leads both lists and the stage's own mime types (an image it
+    /// draws, a document it hands back) follow. `↺ loops` and `▣ own` ride
+    /// the front of the row. It is static - no live decoration - so a box can
+    /// be sized to it once and never have to truncate it. `⏹ can end` is not
+    /// here either: it is a corner marker on the border (see
+    /// [`Self::end_marker`]).
+    fn io_row(&self) -> String {
+        let listed = |extra: &[String]| {
+            std::iter::once("text".to_string())
+                .chain(extra.iter().cloned())
+                .collect::<Vec<_>>()
+                .join(" · ")
+        };
         let mut parts: Vec<String> = Vec::new();
         if self.self_loop {
             parts.push("↺ loops".to_string());
         }
-        if self.is_terminal {
-            parts.push("⏹ can end".to_string());
-        }
         if self.own_layout {
-            parts.push("▣ own context".to_string());
+            parts.push("▣ own".to_string());
         }
-        if !self.inputs.is_empty() {
-            parts.push(format!("◧ {}", self.inputs.join(" ")));
-        }
-        if !self.outputs.is_empty() {
-            parts.push(format!("▤ {}", self.outputs.join(" ")));
-        }
-        if let Some(seen) = &self.last_seen {
-            parts.push(seen.clone());
-        }
+        parts.push(format!("in {}", listed(&self.inputs)));
+        parts.push(format!("out {}", listed(&self.outputs)));
         parts.join(" · ")
+    }
+
+    /// The corner marker for a stage the run can end at, or `None`. Drawn
+    /// right-aligned on the top border rather than in a row, so "this can be
+    /// the last stage" reads as a property of the box, not another badge
+    /// competing with the mime types below.
+    fn end_marker(&self) -> Option<&'static str> {
+        self.is_terminal.then_some("⏹")
+    }
+
+    /// The box width this node needs, in cells: the widest of its three rows
+    /// (title, mode, in/out) plus the borders. The name is measured whole
+    /// here - the box is sized to show it - even though [`Self::title`]
+    /// ellipsizes it when a box is later squeezed narrower than this.
+    pub(crate) fn box_width(&self) -> usize {
+        let title = self.title_cells();
+        // The in/out row is static and the mode row is short in every state
+        // (phase and iteration, or a clock, never both), so a box sized before
+        // the run starts still fits every row once it is under way. A live
+        // "iter N" grows the mode row a little; the breathing cell absorbs it.
+        let detail = 1 + self.detail_row().chars().count();
+        let io = 1 + self.io_row().chars().count();
+        // Two borders, and a cell of breathing room on the right.
+        title.max(detail).max(io) + 3
+    }
+
+    /// The cells [`Self::title`] wants with the name shown whole and the end
+    /// marker's corner left free.
+    fn title_cells(&self) -> usize {
+        let mut prefix = 0;
+        if self.is_entry {
+            prefix += 2;
+        }
+        if self.problem {
+            prefix += 2;
+        }
+        // Status glyph and its trailing space.
+        prefix += 2;
+        let times = self.status.times();
+        let suffix = if times > 1 {
+            format!(" ×{times}").chars().count()
+        } else {
+            0
+        };
+        // Two cells of padding around the text, and the corner marker plus a
+        // gap when the stage can end there.
+        let marker = if self.end_marker().is_some() { 2 } else { 0 };
+        2 + prefix + self.name.chars().count() + suffix + marker
     }
 }
 
@@ -309,11 +373,20 @@ impl NodeContent for StageNodeContent {
             (false, true) => BorderType::Double,
             (false, false) => BorderType::Rounded,
         };
-        let block = Block::default()
+        // The end marker sits in the top-right corner, so the left title is
+        // given two fewer cells when one is present to keep them apart.
+        let marker = self.end_marker();
+        let title_budget = width.saturating_sub(if marker.is_some() { 4 } else { 2 });
+        let mut block = Block::default()
             .borders(Borders::ALL)
             .border_type(border_type)
             .border_style(border_style)
-            .title(self.title(ctx.selected, width.saturating_sub(2)));
+            .title(self.title(ctx.selected, title_budget));
+        if let Some(marker) = marker {
+            block = block.title_top(
+                Line::from(Span::styled(marker, Style::default().fg(C_MUTED))).right_aligned(),
+            );
+        }
         let inner = block.inner(area);
         block.render(area, buf);
         let rows = [
@@ -322,7 +395,7 @@ impl NodeContent for StageNodeContent {
                 Style::default().fg(C_MUTED),
             )),
             Line::from(Span::styled(
-                format!(" {}", self.badge_row()),
+                format!(" {}", self.io_row()),
                 Style::default().fg(C_DIM),
             )),
         ];
@@ -515,18 +588,37 @@ mod tests {
             done: 2,
             failed: 1,
         });
-        let (_, text) = draw(&c, Rect::new(0, 0, 40, 4), false);
+        let (_, text) = draw(&c, Rect::new(0, 0, 60, 4), false);
         assert!(text.contains("▶"), "entry marker: {text}");
+        // A running fan-out shows its worker counts on the mode row.
         assert!(text.contains("⑂ 3 run · 2 done · 1 fail"), "{text}");
-        assert!(text.contains("↺ loops · ⏹ can end · 14:22:01"), "{text}");
-        // What the stage takes and hands back, between the layout badge and
-        // the clock.
+        // "can end" is a corner marker on the border now, not a badge.
+        assert!(text.contains("⏹"), "can-end corner marker: {text}");
+        assert!(
+            !text.contains("can end"),
+            "no can-end badge in a row: {text}"
+        );
+        // Every stage takes and hands back text; loops leads the in/out row.
+        assert!(text.contains("↺ loops · in text · out text"), "{text}");
+        // The stage's own mime types join text in the in/out lists.
         c.inputs = vec!["image/*".to_string(), "audio/wav".to_string()];
         c.outputs = vec!["video/mp4".to_string()];
         let (_, text) = draw(&c, Rect::new(0, 0, 80, 4), false);
         assert!(
-            text.contains("⏹ can end · ◧ image/* audio/wav · ▤ video/mp4 · 14:22:01"),
+            text.contains("in text · image/* · audio/wav · out text · video/mp4"),
             "{text}"
+        );
+        // The last-seen clock rides the mode row of a visited stage (not a
+        // running one, whose row shows its workers).
+        c.workers = None;
+        c.status = NodeStatus::Visited {
+            times: 1,
+            errored: false,
+        };
+        let (_, text) = draw(&c, Rect::new(0, 0, 80, 4), false);
+        assert!(
+            text.contains("14:22:01"),
+            "last-seen on a visited stage: {text}"
         );
         c.clear_live();
         assert_eq!(c.status, NodeStatus::Pending);
@@ -541,6 +633,49 @@ mod tests {
             text.contains('╔'),
             "double border for an external node: {text}"
         );
+    }
+
+    #[test]
+    fn the_end_marker_sits_in_the_corner_and_the_io_row_names_text_both_ways() {
+        let mut n = node("describe", NodeKind::Stage(StageKind::Autonomous));
+        n.is_terminal = true;
+        n.inputs = vec!["image/*".to_string()];
+        n.outputs = vec!["image/*".to_string()];
+        let c = StageNodeContent::from_node(&n);
+        let width = c.box_width();
+        let (_, text) = draw(&c, Rect::new(0, 0, width as u16, 4), false);
+        // The can-end marker is on the top border, in the right corner.
+        let marker = text.chars().position(|ch| ch == '⏹').expect("a marker");
+        assert_eq!(marker / width, 0, "on the top border: {text}");
+        assert!(marker % width >= width - 3, "in the right corner: {text}");
+        // The in/out row leads each side with text and lists the stage's own
+        // types after it.
+        assert!(
+            text.contains("in text · image/* · out text · image/*"),
+            "{text}"
+        );
+        // A stage that takes and hands back types needs a wider box than a
+        // plain one, and the box is sized to fit its content whole.
+        let plain = content();
+        assert!(c.box_width() > plain.box_width(), "wider for its types");
+        assert!(!text.contains('…'), "nothing truncated: {text}");
+    }
+
+    #[test]
+    fn box_width_counts_the_problem_flag_and_the_visit_count() {
+        // A long name so the title row drives the width; the problem marker
+        // and the visit count then each add to it.
+        let mut c = StageNodeContent::from_node(&node(
+            "a-stage-with-a-long-name",
+            NodeKind::Stage(StageKind::Autonomous),
+        ));
+        let base = c.box_width();
+        c.problem = true;
+        c.status = NodeStatus::Visited {
+            times: 12,
+            errored: false,
+        };
+        assert!(c.box_width() > base, "the flag and count widen the box");
     }
 
     #[test]
@@ -596,8 +731,9 @@ mod tests {
         assert!(title.add_modifier.contains(Modifier::BOLD));
         assert!(!title.add_modifier.contains(Modifier::REVERSED));
         assert_eq!(NODE_HEIGHT, 4.0);
-        assert_eq!(node_width(10), 28.0);
-        assert_eq!(node_width(20), 30.0);
+        // Below the floor clamps to it; above it, the content width is used.
+        assert_eq!(node_width(10), MIN_NODE_WIDTH as f64);
+        assert_eq!(node_width(40), 40.0);
     }
 
     #[test]

--- a/crates/leviath-cli/src/tui/flowgraph/layout.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/layout.rs
@@ -85,6 +85,7 @@ impl GraphLayout {
         node_h: f64,
         gap_x: f64,
         gap_y: f64,
+        widths: &HashMap<String, f64>,
     ) -> Vec<(String, (f64, f64))> {
         // A snake is a wrapped grid, not a stack of layers: the sequence
         // index gives the cell directly, and short rows are NOT centred the
@@ -105,18 +106,39 @@ impl GraphLayout {
                 })
                 .collect();
         }
+        // Only the left-to-right layered path gives each column its own width,
+        // so a box wide enough for its in/out row does not force the whole
+        // graph wider. Each column sits at the running sum of the ones before
+        // it, and a column is as wide as its widest box. Top-to-bottom keeps a
+        // single width (`widths` is uniform there), so the packing across its
+        // shared axis is untouched.
+        let width_of = |name: &str| widths.get(name).copied().unwrap_or(node_w);
+        let column_x: Vec<f64> = {
+            let mut xs = Vec::with_capacity(self.max_layer + 1);
+            let mut acc = 0.0;
+            for l in 0..=self.max_layer {
+                xs.push(acc);
+                let col_w = self
+                    .layer_nodes(l)
+                    .iter()
+                    .map(|n| width_of(&n.name))
+                    .fold(0.0_f64, f64::max);
+                acc += col_w + gap_x;
+            }
+            xs
+        };
         let widest = (0..=self.max_layer)
             .map(|l| self.layer_nodes(l).len())
             .fold(0, usize::max);
         let mut out = Vec::with_capacity(self.nodes.len());
-        for l in 0..=self.max_layer {
+        for (l, &x_col) in column_x.iter().enumerate() {
             let column = self.layer_nodes(l);
             let offset = (widest.saturating_sub(column.len())) as f64 / 2.0;
             for node in column {
                 let along = l as f64;
                 let across = node.slot as f64 + offset;
                 let (x, y) = match direction {
-                    Direction::LeftToRight => (along * (node_w + gap_x), across * (node_h + gap_y)),
+                    Direction::LeftToRight => (x_col, across * (node_h + gap_y)),
                     Direction::TopToBottom => (across * (node_w + gap_x), along * (node_h + gap_y)),
                 };
                 out.push((node.name.clone(), (x, y)));
@@ -125,7 +147,10 @@ impl GraphLayout {
         out
     }
 
-    /// The far corner of the laid-out graph in world units.
+    /// The far corner of the laid-out graph in world units. Each node's own
+    /// width sets how far right it reaches, so a wide left-to-right box counts
+    /// for its whole width; on the uniform paths every `widths` entry equals
+    /// `node_w`, so this is the same answer as before.
     pub(crate) fn extent(
         &self,
         direction: Direction,
@@ -133,11 +158,13 @@ impl GraphLayout {
         node_h: f64,
         gap_x: f64,
         gap_y: f64,
+        widths: &HashMap<String, f64>,
     ) -> (f64, f64) {
-        self.positions(direction, node_w, node_h, gap_x, gap_y)
+        self.positions(direction, node_w, node_h, gap_x, gap_y, widths)
             .iter()
-            .fold((0.0_f64, 0.0_f64), |(w, h), (_, (x, y))| {
-                (w.max(x + node_w), h.max(y + node_h))
+            .fold((0.0_f64, 0.0_f64), |(w, h), (name, (x, y))| {
+                let nw = widths.get(name).copied().unwrap_or(node_w);
+                (w.max(x + nw), h.max(y + node_h))
             })
     }
 }
@@ -385,7 +412,14 @@ mod tests {
     fn the_last_box_of_a_row_sits_directly_above_the_first_of_the_next() {
         // The whole point of snaking: the hand-off between rows is a short
         // vertical hop, not a jump back across the canvas.
-        let pos = snake(&chain(10), 4).positions(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0);
+        let pos = snake(&chain(10), 4).positions(
+            Direction::LeftToRight,
+            10.0,
+            3.0,
+            4.0,
+            1.0,
+            &HashMap::new(),
+        );
         let at = |n: &str| pos.iter().find(|(id, _)| id == n).unwrap().1;
         assert_eq!(at("s4").0, at("s3").0, "same column across the row change");
         assert!(at("s4").1 > at("s3").1, "and one row down");
@@ -400,7 +434,14 @@ mod tests {
         assert_eq!(at("s4"), (42.0, 4.0));
         assert_eq!(at("s8"), (0.0, 8.0));
         assert_eq!(
-            snake(&chain(10), 4).extent(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0),
+            snake(&chain(10), 4).extent(
+                Direction::LeftToRight,
+                10.0,
+                3.0,
+                4.0,
+                1.0,
+                &HashMap::new()
+            ),
             (52.0, 11.0)
         );
     }
@@ -417,7 +458,7 @@ mod tests {
         assert_eq!(empty.max_layer, 0);
         assert!(
             empty
-                .positions(Direction::LeftToRight, 1.0, 1.0, 1.0, 1.0)
+                .positions(Direction::LeftToRight, 1.0, 1.0, 1.0, 1.0, &HashMap::new())
                 .is_empty()
         );
     }
@@ -569,7 +610,7 @@ mod tests {
             ],
         );
         let l = layout(&g);
-        let pos = l.positions(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0);
+        let pos = l.positions(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0, &HashMap::new());
         assert_eq!(pos.len(), 4);
         let at = |n: &str| pos.iter().find(|(id, _)| id == n).unwrap().1;
         // Layers step along x by node_w + gap_x.
@@ -590,26 +631,54 @@ mod tests {
         seen.dedup();
         assert_eq!(seen.len(), 4, "no two nodes share a cell");
         assert_eq!(
-            l.extent(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0),
+            l.extent(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0, &HashMap::new()),
             (38.0, 7.0)
         );
         // Top to bottom swaps the axes: layers are rows.
-        let pos = l.positions(Direction::TopToBottom, 10.0, 3.0, 4.0, 1.0);
+        let pos = l.positions(Direction::TopToBottom, 10.0, 3.0, 4.0, 1.0, &HashMap::new());
         let at = |n: &str| pos.iter().find(|(id, _)| id == n).unwrap().1;
         assert_eq!(at("a"), (7.0, 0.0));
         assert_eq!(at("b"), (0.0, 4.0));
         assert_eq!(at("c"), (14.0, 4.0));
         assert_eq!(at("d"), (7.0, 8.0));
         assert_eq!(
-            l.extent(Direction::TopToBottom, 10.0, 3.0, 4.0, 1.0),
+            l.extent(Direction::TopToBottom, 10.0, 3.0, 4.0, 1.0, &HashMap::new()),
             (24.0, 11.0)
         );
         assert_eq!(Direction::LeftToRight.rotated(), Direction::TopToBottom);
         assert_eq!(Direction::TopToBottom.rotated(), Direction::LeftToRight);
         assert!(
             GraphLayout::default()
-                .positions(Direction::LeftToRight, 1.0, 1.0, 1.0, 1.0)
+                .positions(Direction::LeftToRight, 1.0, 1.0, 1.0, 1.0, &HashMap::new())
                 .is_empty()
+        );
+    }
+
+    #[test]
+    fn left_to_right_gives_each_column_the_width_of_its_widest_box() {
+        let g = graph(
+            "a",
+            &["a", "b", "c"],
+            &[("a", "b", P, false), ("b", "c", P, false)],
+        );
+        let l = layout(&g);
+        // `a` is wide (its in/out row); the rest are the plain minimum.
+        let widths = HashMap::from([
+            ("a".to_string(), 30.0),
+            ("b".to_string(), 10.0),
+            ("c".to_string(), 10.0),
+        ]);
+        let pos = l.positions(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0, &widths);
+        let x_of = |n: &str| pos.iter().find(|(id, _)| id == n).unwrap().1.0;
+        // The wide first column pushes the next ones right past a uniform step:
+        // b sits at a's width (30) + the gap (4), not at 10 + 4.
+        assert_eq!(x_of("a"), 0.0);
+        assert_eq!(x_of("b"), 34.0);
+        assert_eq!(x_of("c"), 48.0);
+        // Each node reaches right by its own width: c's edge is 48 + 10.
+        assert_eq!(
+            l.extent(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0, &widths),
+            (58.0, 3.0)
         );
     }
 }

--- a/crates/leviath-cli/src/tui/flowgraph/model.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/model.rs
@@ -195,30 +195,6 @@ impl StageEdge {
 }
 
 impl StageNode {
-    /// What a box is sized for: the id, or more when the badge row needs
-    /// it. A box is `hint + 10` cells wide and its badge row gets `hint + 7`
-    /// of them, so the loop, end and mime badges that never change are
-    /// counted here and a stage that takes or hands back files gets a box
-    /// that shows it.
-    pub(crate) fn width_hint(&self) -> usize {
-        let id = self.id.trim_start_matches("ext:").chars().count();
-        let mut badges: Vec<String> = Vec::new();
-        if self.self_loop {
-            badges.push("↺ loops".to_string());
-        }
-        if self.is_terminal || self.allow_complete {
-            badges.push("⏹ can end".to_string());
-        }
-        if !self.inputs.is_empty() {
-            badges.push(format!("◧ {}", self.inputs.join(" ")));
-        }
-        if !self.outputs.is_empty() {
-            badges.push(format!("▤ {}", self.outputs.join(" ")));
-        }
-        let row = badges.join(" · ").chars().count();
-        id.max(row.saturating_sub(7))
-    }
-
     /// The word the node shows for what it is.
     pub(crate) fn kind_label(&self) -> &'static str {
         match &self.kind {
@@ -574,21 +550,6 @@ worker_agent = "uploader"
         assert!(edge(&g, "check", "publish").unseen.is_empty());
         assert!(edge(&g, "publish", "ext:uploader").unseen.is_empty());
         assert!(g.node("ext:uploader").unwrap().inputs.is_empty());
-        // A box is sized for its badges when they outgrow the name: render's
-        // row is `◧ image/* audio/wav · ▤ video/mp4 text/markdown`, 47
-        // cells, less the 7 the box already allows past the id.
-        assert_eq!(render.width_hint(), 40);
-        assert_eq!(g.node("ext:uploader").unwrap().width_hint(), 8);
-        // A loop and an end count too.
-        let looped = graph(
-            "[agent]\nname = \"l\"\n[stages.plan]\n[stages.plan.transitions.plan]\n[stages.plan.transitions.done]\n[stages.done]\n[stages.done.transitions]\n",
-        );
-        // recover can end and inherits the shared layout: `⏹ can end · ◧
-        // image/* audio/wav` is 31 cells; check's `◧ video/*` fits its name.
-        assert_eq!(g.node("recover").unwrap().width_hint(), 24);
-        assert_eq!(g.node("check").unwrap().width_hint(), 5);
-        assert_eq!(looped.node("plan").unwrap().width_hint(), 4);
-        assert_eq!(looped.node("done").unwrap().width_hint(), 4);
     }
 
     #[test]

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -6,7 +6,7 @@
 //! It never uses rataflow's default key bindings (whose Delete and Backspace
 //! delete nodes): every key maps to an explicit action here.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -23,7 +23,9 @@ use ratatui::widgets::Block;
 use crate::blueprint_edit::Positions;
 use crate::tui::theme::C_ACCENT;
 
-use super::content::{NodeStatus, RunPhase, StageNodeContent, WorkerCounts, edge_style, palette};
+use super::content::{
+    NodeStatus, RunPhase, StageNodeContent, WorkerCounts, edge_style, node_width, palette,
+};
 use super::layout::{self, Direction, GraphLayout};
 use super::model::{EdgeClass, StageEdge, StageGraph};
 use super::snake::{LayoutMode, handles_snake, metrics, route_snake, snake_per_row};
@@ -178,14 +180,39 @@ pub(crate) struct FlowView {
 /// Put saved positions on the boxes, and any box without one to the right
 /// of the rightmost saved box (the way The Lair appends a new stage), so an
 /// arrangement survives a stage being added.
+/// Each node's box width for `direction`. Only a left-to-right layered graph
+/// sizes each box to its own content (so one wide in/out row does not widen the
+/// whole graph); every other case keeps the uniform `node_w`, leaving the snake
+/// and top-to-bottom packing untouched.
+fn node_widths(
+    graph: &StageGraph,
+    direction: Direction,
+    layered: bool,
+    node_w: f64,
+) -> HashMap<String, f64> {
+    let variable = layered && direction == Direction::LeftToRight;
+    graph
+        .nodes
+        .iter()
+        .map(|n| {
+            let w = if variable {
+                node_width(StageNodeContent::from_node(n).box_width())
+            } else {
+                node_w
+            };
+            (n.id.clone(), w)
+        })
+        .collect()
+}
+
 fn apply_positions(
     flow: &mut Flow<StageNodeContent, StepEdge>,
     positions: &Positions,
-    node_w: f64,
     node_h: f64,
     gap_x: f64,
     gap_y: f64,
     snake: bool,
+    widths: &HashMap<String, f64>,
 ) {
     if positions.is_empty() {
         return;
@@ -202,8 +229,9 @@ fn apply_positions(
     }
     let mut right = f64::MIN;
     let mut top = f64::MAX;
-    for (x, y) in positions.values() {
-        right = right.max(x + node_w);
+    for (id, (x, y)) in positions {
+        let nw = widths.get(id).copied().unwrap_or(0.0);
+        right = right.max(x + nw);
         top = top.min(*y);
     }
     let ids: Vec<String> = flow.nodes().map(|n| n.id.clone()).collect();
@@ -347,11 +375,13 @@ fn build(
     let longest = graph
         .nodes
         .iter()
-        .map(super::model::StageNode::width_hint)
+        .map(|n| StageNodeContent::from_node(n).box_width())
         .max()
         .unwrap_or(0);
     let snake = layout.wrap.is_some();
     let (node_w, node_h, gap_x, gap_y) = metrics(longest, snake);
+
+    let widths = node_widths(graph, direction, !snake, node_w);
 
     let nodes: Vec<Node<StageNodeContent>> = graph
         .nodes
@@ -360,7 +390,7 @@ fn build(
             Node::new(
                 n.id.clone(),
                 (0.0, 0.0),
-                (node_w, node_h),
+                (widths[&n.id], node_h),
                 StageNodeContent::from_node(n),
             )
             .with_handles(if snake {
@@ -427,8 +457,8 @@ fn build(
         // the selection away, or Enter after a pan opens nothing.
         .with_deselect_on_pane_click(false)
         .with_locked(locked);
-    flow.set_node_positions(layout.positions(direction, node_w, node_h, gap_x, gap_y));
-    apply_positions(&mut flow, positions, node_w, node_h, gap_x, gap_y, snake);
+    flow.set_node_positions(layout.positions(direction, node_w, node_h, gap_x, gap_y, &widths));
+    apply_positions(&mut flow, positions, node_h, gap_x, gap_y, snake, &widths);
     if edit {
         // A path that exists is not drawn twice, whichever handles a drag
         // would route it through; and a box cannot be wired to itself on
@@ -664,15 +694,16 @@ impl FlowView {
         }
     }
 
-    /// The widest box's sizing hint: the longest id, or the badge row that
-    /// needs more (see [`StageNode::width_hint`]).
+    /// The widest box's content width in cells, so the shared box width fits
+    /// every node's title, mode and in/out row (see
+    /// [`StageNodeContent::box_width`]).
     ///
-    /// [`StageNode::width_hint`]: super::model::StageNode::width_hint
+    /// [`StageNodeContent::box_width`]: super::content::StageNodeContent::box_width
     fn longest_id(&self) -> usize {
         self.graph
             .nodes
             .iter()
-            .map(super::model::StageNode::width_hint)
+            .map(|n| StageNodeContent::from_node(n).box_width())
             .max()
             .unwrap_or(0)
     }
@@ -795,7 +826,9 @@ impl FlowView {
         let longest = self.longest_id();
         let extent = |dir: Direction| {
             let (node_w, node_h, gap_x, gap_y) = metrics(longest, self.mode != LayoutMode::Layered);
-            self.layout.extent(dir, node_w, node_h, gap_x, gap_y)
+            let widths = node_widths(&self.graph, dir, self.mode == LayoutMode::Layered, node_w);
+            self.layout
+                .extent(dir, node_w, node_h, gap_x, gap_y, &widths)
         };
         // A path has no other way round to be turned; what it does with a
         // wider or narrower canvas is fit more or fewer boxes to a row.
@@ -1698,14 +1731,17 @@ merge_stage = "merge"
         draw(&mut v, 200, 50);
         let moved = v.node_rect("plan").unwrap();
         assert!(moved.0 > x as i32 - 2 + 3, "{moved:?}");
-        // A minimap appears when the graph is bigger than the canvas.
+        // A minimap appears when the graph is bigger than the canvas. It is
+        // drawn with half-block cells; which halves are filled depends on the
+        // box sizes, so any of them counts as "a minimap is here".
+        let minimap = |text: &str| text.contains('▄') || text.contains('▀');
         let mut v = FlowView::new(graph(), false);
         let (_, text) = draw(&mut v, 90, 24);
-        assert!(text.contains('▄'), "{text}");
+        assert!(minimap(&text), "{text}");
         // And not when everything is on screen already.
         let mut v = FlowView::new(graph(), false);
         let (_, text) = draw(&mut v, 220, 50);
-        assert!(!text.contains('▄'), "{text}");
+        assert!(!minimap(&text), "{text}");
         // Turning a canvas with nothing selected selects nothing after.
         v.rotate();
         assert_eq!(v.selection(), Selection::Nothing);
@@ -1749,7 +1785,7 @@ notes = { kind = "pinned", accepts = ["text/*"] }
         ));
         let mut v = FlowView::new(g.clone(), false);
         let (_, text) = draw(&mut v, 220, 50);
-        assert!(text.contains("▤ video/mp4"), "{text}");
+        assert!(text.contains("out text · video/mp4"), "{text}");
         let dropped = &g.edges[0];
         assert_eq!(edge_label(dropped, false), "!");
         assert_eq!(edge_label(dropped, true), "! always");
@@ -1826,7 +1862,7 @@ notes = { kind = "pinned", accepts = ["text/*"] }
         v.select_stage("plan");
         let (_, text) = draw(&mut v, 220, 50);
         assert!(text.contains("! ○ plan"), "{text}");
-        assert!(text.contains("▣ own context"), "{text}");
+        assert!(text.contains("▣ own"), "{text}");
         v.clear_selection();
         assert_eq!(v.selection(), Selection::Nothing);
         let plan_implement = v
@@ -1869,5 +1905,49 @@ notes = { kind = "pinned", accepts = ["text/*"] }
         v.select_stage("plan");
         v.replace_graph(graph(), Positions::new());
         assert_eq!(v.selection(), Selection::Node("plan".into()));
+    }
+
+    #[test]
+    fn a_typed_box_is_wider_than_a_plain_one_left_to_right() {
+        let g = Arc::new(StageGraph::from_blueprint(
+            &parse_manifest(
+                r#"
+[agent]
+name = "img"
+entry_stage = "describe"
+[stages.describe]
+[stages.describe.input]
+accepts = ["image/*"]
+[[stages.describe.output.artifacts]]
+name = "image"
+type = "image/*"
+[stages.describe.transitions.done]
+[stages.done]
+[stages.done.transitions]
+"#,
+            )
+            .unwrap(),
+        ));
+        let mut v = FlowView::new(g, false);
+        let (_, text) = draw(&mut v, 200, 20);
+        assert_eq!(v.direction(), Direction::LeftToRight);
+        // node_rect is (left, top, right, bottom), so width is right - left.
+        let describe = v.node_rect("describe").expect("drawn");
+        let done = v.node_rect("done").expect("drawn");
+        let width = |r: (i32, i32, i32, i32)| r.2 - r.0;
+        // The busy box is wider than the plain one, which stays at the floor.
+        assert!(
+            width(describe) > width(done),
+            "typed wider: describe {describe:?}, done {done:?}"
+        );
+        // Its in/out row names the image type on both sides; the plain box
+        // still reads its text in and out.
+        assert!(
+            text.contains("in text · image/* · out text · image/*"),
+            "{text}"
+        );
+        assert!(text.contains("in text · out text"), "{text}");
+        // The edge still joins the two boxes.
+        assert!(text.contains('▶'), "an arrowhead joins them: {text}");
     }
 }


### PR DESCRIPTION
Cleans up the dashboard stage-graph boxes you flagged as unclear.

## The three complaints, fixed

- **"can end" placement** — now a `⏹` marker in the box's **top-right corner** (drawn only for a terminal stage), off the crowded detail row.
- **in/out clarity + text** — the detail row reads `in text · <types> · out text · <types>`, so it's obvious which types are inputs vs outputs, and **text is always shown** (every stage takes and hands back text).
- **box sizing** — on a left-to-right graph each box **sizes to its own content**, so a stage with several types gets a wider box while the others keep theirs.

## How the width works

rataflow already routes edges to each node's own rect, so the work was leviath's own layout: `positions()`/`extent()` now take per-node widths, and the **left-to-right** path places each column at the running sum of the previous columns' widths (a column = its widest box), so a wide box pushes its neighbours instead of overlapping. **Top-to-bottom and snake** graphs keep a uniform width — their shared cross-axis needs it — so only the orientation that can afford variable width uses it.

## Rendered sample (left-to-right; typed box wider, edge connects)
```
╭ ▶ ○ describe ──────────────────────────╮        ╭ ○ done ─────────────────⏹╮
│ autonomous                             │        │ autonomous               │
│ in text · image/* · out text · image/* │───────▶│ in text · out text       │
╰────────────────────────────────────────╯        ╰──────────────────────────╯
```
`describe` (42 cells) is wider than the plain terminal `done` (28 cells, `⏹` corner); the plain box did not grow, and the edge still connects.

100% coverage on leviath-cli; clippy clean (`-D warnings`, no `#[allow]`); docs and structure pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kh7J65m1oRXm1WP7vCb7YN
