### PR TITLE
feat: blueprint dependencies with lev deps and a Meshy sprite-to-3d example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,12 @@ same list.
   whether this machine has it and exits non-zero when it does not, and
   `lev deps install` sets it up after asking: it writes an MCP server's
   non-secret settings into your config and tells you to set the secret in your
-  own environment, or runs a declared shell command or Rhai install script. A
-  bundled `sprite-to-3d` agent turns a sprite sheet into a rigged, game-ready
-  model with Meshy and declares the Meshy dependency (#827).
+  own environment, or runs a declared shell command or Rhai install script.
+  `lev validate` lists each declared dependency and whether this machine has it,
+  and `GET /api/blueprints/{name}` carries them as `dependencies` (announced by
+  the `blueprints.dependencies` capability). A bundled `sprite-to-3d` agent
+  turns a sprite sheet into a rigged, game-ready model with Meshy and declares
+  the Meshy dependency (#827).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ same list.
   `lev deps install` sets it up after asking: it writes an MCP server's
   non-secret settings into your config and tells you to set the secret in your
   own environment, or runs a declared shell command or Rhai install script. A
-  `sprite-to-3d` example agent under `docs/examples/` turns a sprite sheet into a
-  rigged, game-ready model with Meshy and declares the Meshy dependency (#827).
+  bundled `sprite-to-3d` agent turns a sprite sheet into a rigged, game-ready
+  model with Meshy and declares the Meshy dependency (#827).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ same list.
   billed. `lev deps list` shows what an agent needs, `lev deps check` says
   whether this machine has it and exits non-zero when it does not, and
   `lev deps install` sets it up after asking: it writes an MCP server's
-  non-secret settings into your config and tells you to set the secret in your
-  own environment, or runs a declared shell command or Rhai install script.
+  non-secret settings into your config and allowlists the secret it needs, so a
+  `${VAR}` in the server's headers or a stdio server's env is filled from your
+  environment at connect time rather than written to a file; or it runs a
+  declared shell command or Rhai install script.
   `lev validate` lists each declared dependency and whether this machine has it,
   and `GET /api/blueprints/{name}` carries them as `dependencies` (announced by
   the `blueprints.dependencies` capability). A bundled `sprite-to-3d` agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ same list.
 
 ## Unreleased
 
+### Added
+
+- Blueprints can declare what has to be in place before they run, as a top-level
+  `[[dependencies]]` array: an MCP server with the env secrets it needs, an
+  environment variable, a program on `PATH`, or a condition a Rhai script
+  decides. An unmet required dependency fails the spawn before any model is
+  billed. `lev deps list` shows what an agent needs, `lev deps check` says
+  whether this machine has it and exits non-zero when it does not, and
+  `lev deps install` sets it up after asking: it writes an MCP server's
+  non-secret settings into your config and tells you to set the secret in your
+  own environment, or runs a declared shell command or Rhai install script. A
+  `sprite-to-3d` example agent under `docs/examples/` turns a sprite sheet into a
+  rigged, game-ready model with Meshy and declares the Meshy dependency (#827).
+
 ### Changed
 
 - The dashboard stage graph reads more clearly. A stage that can end the run

--- a/crates/leviath-cli/agents/sprite-to-3d/agent.leviath
+++ b/crates/leviath-cli/agents/sprite-to-3d/agent.leviath
@@ -120,7 +120,9 @@ format = "image/*"
 
 [stages.prep-reference.transitions.review-reference]
 hint = "Once the reference region holds a single clean full-body T-pose of the character."
-transform = "clear"
+# Carry the reference forward. `clear` would wipe it (a sliding-window region is
+# stage-specific); the conversation is freshened by each stage's context.reset.
+transform = "direct"
 
 # ── 2. Rank and critique the reference before spending on 3D ─────────────────
 
@@ -164,12 +166,14 @@ require_output = true
 available_connectors = ["meshy"]
 available_tools = ["context_read", "context_list", "context_write", "context_append", "context_attach", "context_export", "read_file", "write_file", "list_dir", "submit_output"]
 system_prompt = """
-The reference region holds one finished T-pose render of the character. It is
-final: do not change it, and do not generate or edit any images. Meshy is here to
-build a 3D model, nothing else.
+The reference region holds exactly one finished T-pose render of the character.
+That render is your 3D input - not the source sprite sheet. It is final: do not
+change it, and do not generate or edit any images. Meshy is here to build a 3D
+model, nothing else.
 
-Export the reference image to the working directory, then use only Meshy's 3D
-tools on it:
+Export that one reference image to the working directory, and feed THAT file to
+Meshy. Never pass the source sprite sheet to image_to_3d - it would build a relief
+of the whole sheet instead of the character. Then use only Meshy's 3D tools:
 - meshy_image_to_3d on the reference to generate the model.
 - meshy_get_task_status to poll until it is done.
 - meshy_rig to rig the model when the character is humanoid.
@@ -210,7 +214,8 @@ reset = ["conversation"]
 
 [stages.build-model.transitions.verify-model]
 hint = "Once a rigged, game-ready model is in the model region."
-transform = "clear"
+# Carry the model and reference forward so verify-model can compare them.
+transform = "direct"
 
 # ── 4. Check the model against the source for gaps before finalizing ─────────
 

--- a/crates/leviath-cli/agents/sprite-to-3d/agent.leviath
+++ b/crates/leviath-cli/agents/sprite-to-3d/agent.leviath
@@ -175,7 +175,7 @@ transform = "clear"
 # ── 4. Check the model against the source for gaps before finalizing ─────────
 
 [stages.verify-model]
-mode = "autonomous"
+mode = "output"
 description = "Compare the model against the source for gaps before finalizing"
 max_iterations = 10
 require_output = true

--- a/crates/leviath-cli/agents/sprite-to-3d/agent.leviath
+++ b/crates/leviath-cli/agents/sprite-to-3d/agent.leviath
@@ -179,12 +179,24 @@ of the whole sheet instead of the character. Then use only Meshy's 3D tools:
 - meshy_rig to rig the model when the character is humanoid.
 - meshy_download_model to fetch the finished file.
 
-Model settings that give the best results:
+Model settings that matter, passed to image_to_3d:
+- symmetry_mode = "off". This is important: the character is symmetric except for
+  one-sided details like an arm cannon or a shoulder pad, and Meshy's default
+  auto-symmetry mirrors both sides to match, which deletes those details (the
+  arm cannon becomes an ordinary hand). Turn symmetry off so asymmetric
+  accessories survive.
 - Prefer the balanced model tier over the highest-detail one: the very high
   detail setting tends to lose geometry behind the character, while the balanced
   tier keeps clean, complete topology for a stylized game asset.
-- Aim for roughly 8k to 12k polygons.
-- Keep the colors and materials matching the reference.
+- Aim for roughly 8k to 12k polygons (target_polycount), and quad topology for
+  clean rigging.
+- Enable PBR, and give a texture_prompt describing the character's palette and
+  materials (read the review notes and the reference) so the colors match.
+
+After the model comes back, look at Meshy's preview and confirm the asymmetric
+details from the reference are present - in particular any arm cannon. If a
+one-sided accessory was flattened to match the other side, regenerate with
+symmetry off before finishing.
 
 Store the downloaded model in the model region and submit it as the run's model
 artifact. Use the scratchpad for working notes.

--- a/crates/leviath-cli/agents/sprite-to-3d/agent.leviath
+++ b/crates/leviath-cli/agents/sprite-to-3d/agent.leviath
@@ -53,8 +53,13 @@ kind = "pinned"
 budget = "20%"
 accepts = ["image/*"]
 
+# One reference only: a sliding window of size one keeps just the latest image
+# the reference stage settled on, so build-model has a single, unambiguous
+# picture to hand Meshy - no picking among same-named candidates.
 [context.regions.reference]
-kind = "pinned"
+kind = "sliding_window"
+max_items = 1
+max_tokens = 4000
 budget = "20%"
 accepts = ["image/*"]
 
@@ -77,21 +82,27 @@ budget = "20%"
 
 [stages.prep-reference]
 mode = "autonomous"
-description = "Make one clean, high-detail T-pose reference image of the character"
-max_iterations = 15
+description = "Make one polished 3D-style T-pose reference render of the character"
+max_iterations = 10
 require_output = true
 available_tools = ["context_read", "context_list", "context_write", "context_append", "context_attach", "context_export", "submit_output"]
 system_prompt = """
 The source region holds a sprite sheet or a single image of a character.
 
-Produce ONE clean, high-detail image of that character standing in a full-body,
-front-facing T-pose on a plain neutral background, and store it in the reference
-region. A single clear T-pose image gives the best image-to-3D result, so do not
-make a multi-frame sheet here.
+Produce ONE polished, high-quality render of that character standing in a
+full-body, front-facing T-pose on a plain neutral background, and store it in the
+reference region. This render is what a 3D model will be built from, so it must
+look like a clean 3D character render, NOT pixel art: smooth surfaces, rounded
+volumes, soft studio lighting and clear depth, the way a modern stylized game
+character looks. Translate the sprite's design into that 3D-render style.
 
-Keep the character exactly on-model: the same silhouette, proportions, colors and
-accessories as the source. Do not restyle it, and do not invent details the
-source does not show. Use the scratchpad for working notes.
+Keep the character on-model: the same silhouette, proportions, colors, and
+accessories as the source, just rendered as a solid 3D-looking figure rather than
+pixels. Do not invent details the source does not show, and do not make a
+multi-frame sheet - a single clean T-pose gives the best image-to-3D result.
+
+Regenerate until you have one you are happy with, then submit; only the latest
+image is kept as the reference. Use the scratchpad for working notes.
 """
 
 [stages.prep-reference.model]
@@ -153,21 +164,36 @@ require_output = true
 available_connectors = ["meshy"]
 available_tools = ["context_read", "context_list", "context_write", "context_append", "context_attach", "context_export", "read_file", "write_file", "list_dir", "submit_output"]
 system_prompt = """
-Use the Meshy tools to turn the single T-pose reference into a 3D model that is
-ready to drop into a game engine.
+The reference region holds one finished T-pose render of the character. It is
+final: do not change it, and do not generate or edit any images. Meshy is here to
+build a 3D model, nothing else.
 
-Guidance that gives the best results:
-- Use Meshy's image-to-3D on the reference image.
+Export the reference image to the working directory, then use only Meshy's 3D
+tools on it:
+- meshy_image_to_3d on the reference to generate the model.
+- meshy_get_task_status to poll until it is done.
+- meshy_rig to rig the model when the character is humanoid.
+- meshy_download_model to fetch the finished file.
+
+Model settings that give the best results:
 - Prefer the balanced model tier over the highest-detail one: the very high
   detail setting tends to lose geometry behind the character, while the balanced
   tier keeps clean, complete topology for a stylized game asset.
 - Aim for roughly 8k to 12k polygons.
-- Ask Meshy to rig the model when the character is humanoid.
 - Keep the colors and materials matching the reference.
 
-Download the finished model, store it in the model region, and submit it as the
-run's model artifact. Use the scratchpad for working notes.
+Store the downloaded model in the model region and submit it as the run's model
+artifact. Use the scratchpad for working notes.
 """
+
+# Meshy is for 3D only. Its image-generation and text tools are denied here, so
+# the model cannot spend credits regenerating the reference - the image work is
+# the reference stage's job, done with an image model.
+[stages.build-model.tool_permissions]
+"meshy__meshy_image_to_image" = "deny"
+"meshy__meshy_text_to_image" = "deny"
+"meshy__meshy_text_to_3d" = "deny"
+"meshy__meshy_creative_lab" = "deny"
 
 [stages.build-model.model]
 allow_user_default = false

--- a/crates/leviath-cli/agents/sprite-to-3d/agent.leviath
+++ b/crates/leviath-cli/agents/sprite-to-3d/agent.leviath
@@ -4,9 +4,11 @@ version = "0.1.0"
 description = "Turn a sprite sheet or character image into a rigged, game-ready 3D model with Meshy"
 entry_stage = "prep-reference"
 
-# Meshy does the actual image-to-3D work over its MCP server, which needs an API
-# key. The run refuses to start until the server is configured and the key is
-# set, and lev deps install writes the non-secret server settings for you.
+# Meshy does the actual image-to-3D work over its MCP server (run with npx),
+# which needs an API key. The run refuses to start until the server is
+# configured and the key is set. lev deps install writes the non-secret server
+# settings and allowlists the key so its ${MESHY_API_KEY} stays in your
+# environment rather than the config file.
 [[dependencies]]
 name = "meshy"
 kind = "mcp_server"
@@ -16,11 +18,23 @@ description = "Meshy image-to-3D, reached over its MCP server"
 remedy = "Run: lev deps install sprite-to-3d, then set MESHY_API_KEY in your environment"
 
 [dependencies.install.server]
-transport = "http"
-url = "https://www.meshy.ai/mcp"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@meshy-ai/meshy-mcp-server"]
 
-[dependencies.install.server.headers]
-Authorization = "Bearer ${MESHY_API_KEY}"
+[dependencies.install.server.env]
+MESHY_API_KEY = "${MESHY_API_KEY}"
+
+# The Meshy MCP server runs with npx, which Node.js provides.
+[[dependencies]]
+name = "npx"
+kind = "binary"
+command = "npx"
+remedy = "Install Node.js (it provides npx), for example from https://nodejs.org"
+
+[dependencies.install.commands]
+macos = "brew install node"
+linux = "sudo apt-get install -y nodejs npm"
 
 # ── Regions ────────────────────────────────────────────────────────────────
 

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -1405,6 +1405,16 @@ mod tests {
                 leviath_core::manifest::parse_manifest(manifest).expect("manifest parses");
 
             for stage in &blueprint.stages {
+                // Portability is about stages that fall back to the user's
+                // configured default. A stage that pins its models on purpose
+                // (`allow_user_default = false`) is opting out of it - an image
+                // or 3D stage cannot be provider-portable, because a vendor like
+                // Anthropic has no image model at all - so it is not held to the
+                // every-provider rule. Stages that allow the default (every
+                // other bundled stage) still are.
+                if !stage.model.allow_user_default {
+                    continue;
+                }
                 let stage_name = &stage.name;
                 let listed: Vec<&str> = stage
                     .model

--- a/crates/leviath-cli/src/commands/deps.rs
+++ b/crates/leviath-cli/src/commands/deps.rs
@@ -352,7 +352,7 @@ fn mcp_from_template(
         command: tpl.command.clone(),
         url: tpl.url.clone(),
         args: tpl.args.clone(),
-        env: std::collections::HashMap::new(),
+        env: tpl.env.clone().into_iter().collect(),
         headers: tpl.headers.clone().into_iter().collect(),
     }
 }
@@ -365,7 +365,7 @@ fn run_plan(
     config: &mut crate::config::Config,
 ) -> anyhow::Result<()> {
     if let Some((server, secrets)) = &plan.server {
-        add_server(config, server, &env.config_path)?;
+        add_server(config, server, secrets, &env.config_path)?;
         for var in secrets {
             if env
                 .probe
@@ -401,19 +401,35 @@ fn run_plan(
 fn add_server(
     config: &mut crate::config::Config,
     server: &MCPServerConfig,
+    env_secrets: &[String],
     path: &Path,
 ) -> anyhow::Result<()> {
     server
         .clone()
         .resolve()
         .map_err(|e| anyhow::anyhow!("the server template is not valid: {e}"))?;
+    let mut changed = false;
     if config.mcp_servers.iter().any(|s| s.name == server.name) {
         println!("  MCP server '{}' is already configured.", server.name);
-        return Ok(());
+    } else {
+        config.mcp_servers.push(server.clone());
+        println!("  added MCP server '{}' to your config.", server.name);
+        changed = true;
     }
-    config.mcp_servers.push(server.clone());
-    config.save_to_path_public(path)?;
-    println!("  added MCP server '{}' to your config.", server.name);
+    // Allowlist the secrets the server's `${VAR}` headers interpolate. Without
+    // this the header is refused even when the variable is set, so the server
+    // connects unauthenticated - the exact gap that makes an install look done
+    // but fail at the first call.
+    for var in env_secrets {
+        if !config.security.allow_env_vars.iter().any(|v| v == var) {
+            config.security.allow_env_vars.push(var.clone());
+            println!("  allowed {var} for the server's headers ([security] allow_env_vars).");
+            changed = true;
+        }
+    }
+    if changed {
+        config.save_to_path_public(path)?;
+    }
     Ok(())
 }
 
@@ -710,9 +726,17 @@ mod tests {
             &env,
         )
         .unwrap_err(); // still blocking because the secret is not set
-        // The server was written to config.
+        // The server was written to config, and its secret was allowlisted so
+        // the `${MESHY_API_KEY}` header will interpolate.
         let config = crate::config::Config::load_from_path_public(&env.config_path).unwrap();
         assert!(config.mcp_servers.iter().any(|s| s.name == "meshy"));
+        assert!(
+            config
+                .security
+                .allow_env_vars
+                .iter()
+                .any(|v| v == "MESHY_API_KEY")
+        );
         // With the secret set and --all, re-installing is idempotent: the
         // server is already configured and the secret is already set.
         let env2 = env_with(

--- a/crates/leviath-cli/src/commands/deps.rs
+++ b/crates/leviath-cli/src/commands/deps.rs
@@ -1,0 +1,1171 @@
+//! `lev deps` - inspect and install a blueprint's declared dependencies.
+//!
+//! `lev deps list <agent>` shows what an agent declares it needs; `lev deps
+//! check <agent>` says whether this machine has it (and exits non-zero when a
+//! required one is missing); `lev deps install <agent>` puts them in place,
+//! always after asking, because installing runs commands and writes config on
+//! the machine.
+//!
+//! The command logic lives in [`execute_with`], driven by a [`DepsEnv`] whose
+//! seams - the config path, the machine [`Probe`], a [`CommandRunner`] and a
+//! [`Prompt`] - are injected so the whole thing is testable without touching
+//! the real machine. `main.rs` builds the real env.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, bail};
+use leviath_core::blueprint::{Blueprint, Dependency, DependencyInstall, DependencyKind};
+use leviath_mcp::{MCPServerConfig, MCPTransport};
+
+use crate::dependencies::{self, DependencyState, Probe};
+
+/// `lev deps` and its subcommands.
+#[derive(clap::Args, Debug)]
+pub struct DepsArgs {
+    /// Which dependency action to take.
+    #[command(subcommand)]
+    pub command: DepsCommand,
+}
+
+/// The `lev deps` subcommands.
+#[derive(clap::Subcommand, Debug)]
+pub enum DepsCommand {
+    /// List the dependencies an agent declares.
+    List(AgentRef),
+    /// Check whether this machine satisfies an agent's dependencies.
+    Check(AgentRef),
+    /// Install an agent's dependencies (runs commands and writes config).
+    Install(InstallArgs),
+}
+
+/// An installed agent name, or a path to a blueprint directory or manifest.
+#[derive(clap::Args, Debug)]
+pub struct AgentRef {
+    /// An installed agent name, or a path to its directory or `agent.leviath`.
+    pub agent: String,
+}
+
+/// Arguments for `lev deps install`.
+#[derive(clap::Args, Debug)]
+pub struct InstallArgs {
+    /// An installed agent name, or a path to its directory or `agent.leviath`.
+    pub agent: String,
+    /// Install without the per-dependency confirmation prompt.
+    #[arg(long)]
+    pub yes: bool,
+    /// Act on every dependency, not only the ones that are missing.
+    #[arg(long)]
+    pub all: bool,
+}
+
+/// Runs a shell command during install. Injected so tests never shell out.
+pub trait CommandRunner: Send + Sync {
+    /// Run a command, returning `Ok` on success or an error message.
+    fn run(&self, command: &str) -> Result<(), String>;
+}
+
+/// Asks the user things during install. Injected so tests never read stdin.
+pub trait Prompt {
+    /// Ask a yes/no question; the default when unsure is "no".
+    fn confirm(&self, message: &str) -> bool;
+}
+
+/// The seams `lev deps` needs, so [`execute_with`] is testable end to end.
+pub struct DepsEnv {
+    /// Where the user's `config.toml` lives (read for servers, written on install).
+    pub config_path: PathBuf,
+    /// The installed-agents directory, for resolving an agent by name.
+    pub agents_dir: Option<PathBuf>,
+    /// Reads env and `PATH`.
+    pub probe: Box<dyn Probe>,
+    /// Runs install commands.
+    pub runner: Arc<dyn CommandRunner>,
+    /// Asks the user to confirm.
+    pub prompt: Box<dyn Prompt>,
+    /// This host's OS key for per-OS install commands: `macos`/`linux`/`windows`.
+    pub os: &'static str,
+}
+
+/// The OS key used for per-OS install commands on the host this build runs on.
+///
+/// `#[cfg]` rather than `cfg!()` so only the arm for the target platform is
+/// compiled - the other two are not instrumented, so each platform's build
+/// covers the one branch it can take.
+pub fn host_os() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "macos"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "windows"
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        "linux"
+    }
+}
+
+/// Run a `lev deps` subcommand against the injected environment.
+pub fn execute_with(args: DepsArgs, env: &DepsEnv) -> anyhow::Result<()> {
+    match args.command {
+        DepsCommand::List(a) => list(&a.agent, env),
+        DepsCommand::Check(a) => check(&a.agent, env),
+        DepsCommand::Install(a) => install(a, env),
+    }
+}
+
+/// Resolve an agent name-or-path to its parsed blueprint and its directory.
+///
+/// The read is the existence check (an agent that resolves to no readable
+/// manifest is "not found"), so there is one error path per real failure -
+/// missing, unparseable, invalid - and no unreachable guard.
+fn resolve_agent(agent: &str, env: &DepsEnv) -> anyhow::Result<(Blueprint, PathBuf)> {
+    let as_path = Path::new(agent);
+    let (manifest, dir) = if as_path.is_file() {
+        let dir = as_path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        (as_path.to_path_buf(), dir)
+    } else if as_path.is_dir() {
+        (
+            as_path.join(leviath_core::files::MANIFEST_FILENAME),
+            as_path.to_path_buf(),
+        )
+    } else if let Some(dir) = &env.agents_dir {
+        let base = dir.join(agent);
+        (base.join(leviath_core::files::MANIFEST_FILENAME), base)
+    } else {
+        bail!("no such path '{agent}', and no installed-agents directory to look it up in");
+    };
+    let content = std::fs::read_to_string(&manifest).map_err(|_| {
+        anyhow::anyhow!(
+            "could not find agent '{agent}': no manifest at {}",
+            manifest.display()
+        )
+    })?;
+    let blueprint = leviath_core::manifest::parse_manifest(&content)
+        .map_err(|e| anyhow::anyhow!("parse {}: {e}", manifest.display()))?;
+    blueprint
+        .validate()
+        .map_err(|e| anyhow::anyhow!("invalid blueprint {}: {e}", manifest.display()))?;
+    Ok((blueprint, dir))
+}
+
+/// The configured MCP servers, or an empty list when there is no config yet.
+fn configured_servers(env: &DepsEnv) -> anyhow::Result<Vec<MCPServerConfig>> {
+    Ok(load_config_or_default(&env.config_path)?.mcp_servers)
+}
+
+/// Load the config at `path`, or the defaults when the file does not exist.
+fn load_config_or_default(path: &Path) -> anyhow::Result<crate::config::Config> {
+    if path.is_file() {
+        crate::config::Config::load_from_path_public(path)
+    } else {
+        Ok(crate::config::Config::default())
+    }
+}
+
+fn list(agent: &str, env: &DepsEnv) -> anyhow::Result<()> {
+    let (blueprint, _dir) = resolve_agent(agent, env)?;
+    if blueprint.dependencies.is_empty() {
+        println!("'{}' declares no dependencies.", blueprint.name);
+        return Ok(());
+    }
+    println!("'{}' dependencies:", blueprint.name);
+    for dep in &blueprint.dependencies {
+        let req = if dep.required { "required" } else { "optional" };
+        println!("  - {} ({}, {req})", dep.name, dep.kind.tag());
+        println!("      {}", describe_kind(&dep.kind));
+        if let Some(desc) = &dep.description {
+            println!("      {desc}");
+        }
+        if dep.install.is_some() {
+            println!("      installable with `lev deps install {agent}`");
+        }
+    }
+    Ok(())
+}
+
+/// A one-line "what it wants" for a dependency kind.
+fn describe_kind(kind: &DependencyKind) -> String {
+    match kind {
+        DependencyKind::McpServer { server, env } if env.is_empty() => {
+            format!("MCP server '{server}'")
+        }
+        DependencyKind::McpServer { server, env } => {
+            format!("MCP server '{server}' with {}", env.join(", "))
+        }
+        DependencyKind::Env { var } => format!("environment variable {var}"),
+        DependencyKind::Binary { command } => format!("program '{command}' on PATH"),
+        DependencyKind::Script { check } => format!("script check {check}"),
+    }
+}
+
+fn check(agent: &str, env: &DepsEnv) -> anyhow::Result<()> {
+    let (blueprint, dir) = resolve_agent(agent, env)?;
+    let servers = configured_servers(env)?;
+    let report =
+        dependencies::evaluate(&blueprint.dependencies, &servers, &dir, env.probe.as_ref());
+    if report.statuses.is_empty() {
+        println!("'{}' declares no dependencies.", blueprint.name);
+        return Ok(());
+    }
+    println!("'{}' dependencies:", blueprint.name);
+    for s in &report.statuses {
+        let (mark, detail) = match &s.state {
+            DependencyState::Satisfied => ("ok  ", String::new()),
+            DependencyState::Unmet(remedy) => ("MISS", format!(" - {remedy}")),
+            DependencyState::Unusable(reason) => ("ERR ", format!(" - {reason}")),
+        };
+        let req = if s.required { "" } else { " (optional)" };
+        println!("  [{mark}] {} ({}){req}{detail}", s.name, s.kind);
+    }
+    if let Some(msg) = report.blocking_message() {
+        bail!("{msg}");
+    }
+    println!("\nAll required dependencies are satisfied.");
+    Ok(())
+}
+
+fn install(args: InstallArgs, env: &DepsEnv) -> anyhow::Result<()> {
+    let (blueprint, dir) = resolve_agent(&args.agent, env)?;
+    // Load the whole config once, so an MCP-server install mutates and saves
+    // this copy rather than re-reading the file.
+    let mut config = load_config_or_default(&env.config_path)?;
+    let report = dependencies::evaluate(
+        &blueprint.dependencies,
+        &config.mcp_servers,
+        &dir,
+        env.probe.as_ref(),
+    );
+
+    let mut acted = false;
+    for (dep, status) in blueprint.dependencies.iter().zip(&report.statuses) {
+        let satisfied = status.state.is_satisfied();
+        if satisfied && !args.all {
+            continue;
+        }
+        let Some(plan) = install_plan(dep, env.os) else {
+            if !satisfied {
+                println!(
+                    "  {} ({}): nothing to install - {}",
+                    dep.name,
+                    dep.kind.tag(),
+                    dep.remedy
+                        .clone()
+                        .unwrap_or_else(|| "no install steps declared".to_string())
+                );
+            }
+            continue;
+        };
+        println!("\n{}", plan.summary(&dep.name));
+        println!("  WARNING: this changes your machine (runs commands and/or writes config).");
+        if !args.yes
+            && !env
+                .prompt
+                .confirm(&format!("Install dependency '{}'?", dep.name))
+        {
+            println!("  skipped.");
+            continue;
+        }
+        acted = true;
+        run_plan(&plan, &dir, env, &mut config)?;
+    }
+
+    if !acted {
+        println!("\nNo install steps were run.");
+    } else {
+        println!("\nRe-checking...");
+    }
+    // Always re-check, so the exit code reflects whether required dependencies
+    // are now satisfied - a declined or partial install still reports as unmet.
+    check(&args.agent, env)
+}
+
+/// What installing one dependency will do, resolved for this host's OS.
+struct Plan {
+    /// An MCP server to write into the config, and the secrets it still needs.
+    server: Option<(MCPServerConfig, Vec<String>)>,
+    /// A shell command to run.
+    command: Option<String>,
+    /// A Rhai install script (path relative to the blueprint).
+    script: Option<String>,
+}
+
+impl Plan {
+    fn summary(&self, name: &str) -> String {
+        let mut lines = vec![format!("Install '{name}':")];
+        if let Some((server, _)) = &self.server {
+            lines.push(format!(
+                "  - add MCP server '{}' to your config",
+                server.name
+            ));
+        }
+        if let Some(cmd) = &self.command {
+            lines.push(format!("  - run: {cmd}"));
+        }
+        if let Some(script) = &self.script {
+            lines.push(format!("  - run install script {script}"));
+        }
+        lines.join("\n")
+    }
+}
+
+/// Build the install plan for a dependency, or `None` when it declares no way to
+/// install itself.
+fn install_plan(dep: &Dependency, os: &str) -> Option<Plan> {
+    let install = dep.install.as_ref();
+    let server = match &dep.kind {
+        DependencyKind::McpServer { server, env } => install
+            .and_then(|i| i.server.as_ref())
+            .map(|tpl| (mcp_from_template(server, tpl), env.clone())),
+        _ => None,
+    };
+    let command = install.and_then(|i| chosen_command(i, os));
+    let script = install.and_then(|i| i.script.clone());
+    if server.is_none() && command.is_none() && script.is_none() {
+        return None;
+    }
+    Some(Plan {
+        server,
+        command,
+        script,
+    })
+}
+
+/// The install command for this OS: the per-OS entry, else the generic one.
+fn chosen_command(install: &DependencyInstall, os: &str) -> Option<String> {
+    install
+        .commands
+        .get(os)
+        .cloned()
+        .or_else(|| install.command.clone())
+}
+
+/// Turn a blueprint's MCP server template into a config entry.
+fn mcp_from_template(
+    name: &str,
+    tpl: &leviath_core::blueprint::McpServerTemplate,
+) -> MCPServerConfig {
+    MCPServerConfig {
+        name: name.to_string(),
+        transport: tpl.transport.as_deref().map(|t| match t {
+            "http" => MCPTransport::Http,
+            // Validation restricts this to "stdio"/"http"; anything else would
+            // have been refused at load, so stdio is the only other case.
+            _ => MCPTransport::Stdio,
+        }),
+        command: tpl.command.clone(),
+        url: tpl.url.clone(),
+        args: tpl.args.clone(),
+        env: std::collections::HashMap::new(),
+        headers: tpl.headers.clone().into_iter().collect(),
+    }
+}
+
+/// Carry out an install plan: write the server, run the command, run the script.
+fn run_plan(
+    plan: &Plan,
+    dir: &Path,
+    env: &DepsEnv,
+    config: &mut crate::config::Config,
+) -> anyhow::Result<()> {
+    if let Some((server, secrets)) = &plan.server {
+        add_server(config, server, &env.config_path)?;
+        for var in secrets {
+            if env
+                .probe
+                .env(var)
+                .filter(|v| !v.trim().is_empty())
+                .is_some()
+            {
+                println!("  {var} is already set.");
+            } else {
+                println!(
+                    "  {var} is not set. It is a secret, so set it in your environment yourself,\n\
+                     e.g. add `export {var}=...` to your shell profile, then open a new shell.\n\
+                     It is read at connect time and never written to a file by this command."
+                );
+            }
+        }
+    }
+    if let Some(cmd) = &plan.command {
+        println!("  running: {cmd}");
+        env.runner
+            .run(cmd)
+            .map_err(|e| anyhow::anyhow!("install command failed: {e}"))?;
+        println!("  done.");
+    }
+    if let Some(script) = &plan.script {
+        run_install_script(&dir.join(script), script, env)?;
+        println!("  install script done.");
+    }
+    Ok(())
+}
+
+/// Add an MCP server to the config, unless one of that name is present, and save.
+fn add_server(
+    config: &mut crate::config::Config,
+    server: &MCPServerConfig,
+    path: &Path,
+) -> anyhow::Result<()> {
+    server
+        .clone()
+        .resolve()
+        .map_err(|e| anyhow::anyhow!("the server template is not valid: {e}"))?;
+    if config.mcp_servers.iter().any(|s| s.name == server.name) {
+        println!("  MCP server '{}' is already configured.", server.name);
+        return Ok(());
+    }
+    config.mcp_servers.push(server.clone());
+    config.save_to_path_public(path)?;
+    println!("  added MCP server '{}' to your config.", server.name);
+    Ok(())
+}
+
+/// Run a Rhai install script, giving it one host function - `sh(command)` -
+/// backed by the injected runner, plus the read-only probes a check gets.
+fn run_install_script(path: &Path, shown: &str, env: &DepsEnv) -> anyhow::Result<()> {
+    let source =
+        std::fs::read_to_string(path).with_context(|| format!("read install script {shown}"))?;
+    let mut engine = rhai::Engine::new();
+    leviath_scripting::harden(&mut engine, 1_000_000);
+    let runner = env.runner.clone();
+    engine.register_fn(
+        "sh",
+        move |cmd: &str| -> Result<(), Box<rhai::EvalAltResult>> {
+            runner.run(cmd).map_err(|e| e.into())
+        },
+    );
+    let ast = engine
+        .compile(&source)
+        .map_err(|e| anyhow::anyhow!("{shown}: {e}"))?;
+    engine
+        .call_fn::<()>(&mut rhai::Scope::new(), &ast, "install", ())
+        .map_err(|e| anyhow::anyhow!("{shown}: install: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    struct FakeProbe {
+        env: HashMap<String, String>,
+    }
+    impl Probe for FakeProbe {
+        fn env(&self, name: &str) -> Option<String> {
+            self.env.get(name).cloned()
+        }
+        fn which(&self, _name: &str) -> bool {
+            false
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeRunner {
+        ran: Mutex<Vec<String>>,
+        fail: bool,
+    }
+    impl CommandRunner for FakeRunner {
+        fn run(&self, command: &str) -> Result<(), String> {
+            self.ran.lock().unwrap().push(command.to_string());
+            if self.fail {
+                Err("boom".to_string())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    struct FakePrompt {
+        answer: bool,
+    }
+    impl Prompt for FakePrompt {
+        fn confirm(&self, _message: &str) -> bool {
+            self.answer
+        }
+    }
+
+    fn env_with(
+        dir: &Path,
+        probe_env: HashMap<String, String>,
+        runner: Arc<dyn CommandRunner>,
+        confirm: bool,
+    ) -> DepsEnv {
+        DepsEnv {
+            config_path: dir.join("config.toml"),
+            agents_dir: Some(dir.join("agents")),
+            probe: Box::new(FakeProbe { env: probe_env }),
+            runner,
+            prompt: Box::new(FakePrompt { answer: confirm }),
+            os: "linux",
+        }
+    }
+
+    fn write_agent(dir: &Path, name: &str, deps_toml: &str) -> PathBuf {
+        let adir = dir.join("agents").join(name);
+        std::fs::create_dir_all(&adir).unwrap();
+        let manifest = adir.join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            format!(
+                "[agent]\nname = \"{name}\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+                 [stages.main]\nmodel = {{ provider = \"anthropic\", model = \"m\" }}\n\n{deps_toml}"
+            ),
+        )
+        .unwrap();
+        adir
+    }
+
+    #[test]
+    fn execute_with_routes_each_subcommand() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"e\"\nkind = \"env\"\nvar = \"TOKEN\"\n",
+        );
+        let env = env_with(
+            dir.path(),
+            HashMap::from([("TOKEN".into(), "x".into())]),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        execute_with(
+            DepsArgs {
+                command: DepsCommand::List(AgentRef { agent: "a".into() }),
+            },
+            &env,
+        )
+        .unwrap();
+        execute_with(
+            DepsArgs {
+                command: DepsCommand::Check(AgentRef { agent: "a".into() }),
+            },
+            &env,
+        )
+        .unwrap();
+        execute_with(
+            DepsArgs {
+                command: DepsCommand::Install(InstallArgs {
+                    agent: "a".into(),
+                    yes: true,
+                    all: false,
+                }),
+            },
+            &env,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn host_os_is_one_of_the_known_keys() {
+        assert!(["macos", "linux", "windows"].contains(&host_os()));
+    }
+
+    #[test]
+    fn resolve_by_name_dir_file_and_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(dir.path(), "a", "");
+        let env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        // By installed name.
+        assert!(resolve_agent("a", &env).is_ok());
+        // By directory path.
+        let adir = dir.path().join("agents").join("a");
+        assert!(resolve_agent(adir.to_str().unwrap(), &env).is_ok());
+        // By manifest path.
+        let manifest = adir.join("agent.leviath");
+        assert!(resolve_agent(manifest.to_str().unwrap(), &env).is_ok());
+        // Missing.
+        let err = resolve_agent("nope", &env).unwrap_err().to_string();
+        assert!(err.contains("could not find agent 'nope'"), "{err}");
+    }
+
+    #[test]
+    fn resolve_reports_parse_and_validate_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        // Unparseable TOML.
+        let bad = dir.path().join("agents").join("bad");
+        std::fs::create_dir_all(&bad).unwrap();
+        std::fs::write(bad.join("agent.leviath"), "not = = valid").unwrap();
+        assert!(
+            resolve_agent("bad", &env)
+                .unwrap_err()
+                .to_string()
+                .contains("parse")
+        );
+        // Parses but fails blueprint validation (two deps share a name).
+        let inv = dir.path().join("agents").join("inv");
+        std::fs::create_dir_all(&inv).unwrap();
+        std::fs::write(
+            inv.join("agent.leviath"),
+            "[agent]\nname = \"inv\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"a\", model = \"m\" }\n\n\
+             [[dependencies]]\nname = \"d\"\nkind = \"env\"\nvar = \"X\"\n\n\
+             [[dependencies]]\nname = \"d\"\nkind = \"env\"\nvar = \"Y\"\n",
+        )
+        .unwrap();
+        assert!(
+            resolve_agent("inv", &env)
+                .unwrap_err()
+                .to_string()
+                .contains("invalid blueprint")
+        );
+    }
+
+    #[test]
+    fn resolve_without_agents_dir_needs_a_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        env.agents_dir = None;
+        let err = resolve_agent("bare-name", &env).unwrap_err().to_string();
+        assert!(err.contains("no such path"), "{err}");
+    }
+
+    #[test]
+    fn list_shows_declared_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"meshy\"\nkind = \"mcp_server\"\nserver = \"meshy\"\n\
+             env = [\"MESHY_API_KEY\"]\ndescription = \"3d\"\n[dependencies.install.server]\nurl = \"https://x\"\n",
+        );
+        let env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        list("a", &env).unwrap();
+        // And an agent with none.
+        write_agent(dir.path(), "b", "");
+        list("b", &env).unwrap();
+    }
+
+    #[test]
+    fn check_reports_satisfied_and_blocks_on_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"key\"\nkind = \"env\"\nvar = \"TOKEN\"\n",
+        );
+        // Missing -> error (non-zero exit).
+        let miss = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        let err = check("a", &miss).unwrap_err().to_string();
+        assert!(err.contains("not satisfied"), "{err}");
+        // Present -> ok.
+        let have = env_with(
+            dir.path(),
+            HashMap::from([("TOKEN".into(), "x".into())]),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        check("a", &have).unwrap();
+        // No deps -> ok.
+        write_agent(dir.path(), "b", "");
+        check("b", &have).unwrap();
+    }
+
+    #[test]
+    fn install_writes_mcp_server_and_guides_for_the_secret() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"meshy\"\nkind = \"mcp_server\"\nserver = \"meshy\"\n\
+             env = [\"MESHY_API_KEY\"]\n[dependencies.install.server]\ntransport = \"http\"\nurl = \"https://api.meshy.ai/mcp\"\n",
+        );
+        let env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: false,
+            },
+            &env,
+        )
+        .unwrap_err(); // still blocking because the secret is not set
+        // The server was written to config.
+        let config = crate::config::Config::load_from_path_public(&env.config_path).unwrap();
+        assert!(config.mcp_servers.iter().any(|s| s.name == "meshy"));
+        // With the secret set and --all, re-installing is idempotent: the
+        // server is already configured and the secret is already set.
+        let env2 = env_with(
+            dir.path(),
+            HashMap::from([("MESHY_API_KEY".into(), "sk".into())]),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: true,
+            },
+            &env2,
+        )
+        .unwrap(); // now satisfied
+    }
+
+    #[test]
+    fn install_runs_a_command_and_reports_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"blender\"\nkind = \"binary\"\ncommand = \"blender\"\n\
+             [dependencies.install]\ncommand = \"echo installing\"\n",
+        );
+        let runner = Arc::new(FakeRunner::default());
+        let env = env_with(dir.path(), HashMap::new(), runner.clone(), true);
+        // Binary is never found by FakeProbe, so it is unmet and the command runs.
+        install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: false,
+            },
+            &env,
+        )
+        .unwrap_err(); // still unmet after echo (fake which is always false)
+        assert_eq!(runner.ran.lock().unwrap().as_slice(), ["echo installing"]);
+        // A failing command surfaces the error.
+        let failing = Arc::new(FakeRunner {
+            fail: true,
+            ..Default::default()
+        });
+        let env2 = env_with(dir.path(), HashMap::new(), failing, true);
+        let err = install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: true,
+            },
+            &env2,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("install command failed"), "{err}");
+    }
+
+    #[test]
+    fn install_declines_and_skips_when_not_confirmed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"b\"\nkind = \"binary\"\ncommand = \"x\"\n\
+             [dependencies.install]\ncommand = \"echo hi\"\n",
+        );
+        let runner = Arc::new(FakeRunner::default());
+        let env = env_with(dir.path(), HashMap::new(), runner.clone(), false);
+        install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: false,
+                all: false,
+            },
+            &env,
+        )
+        .unwrap_err();
+        assert!(
+            runner.ran.lock().unwrap().is_empty(),
+            "declined install must not run"
+        );
+    }
+
+    #[test]
+    fn install_reports_when_nothing_to_do_or_no_steps() {
+        let dir = tempfile::tempdir().unwrap();
+        // Two dependencies with no install info: one bare (default message),
+        // one carrying its own remedy.
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"key\"\nkind = \"env\"\nvar = \"TOKEN\"\n\n\
+             [[dependencies]]\nname = \"key2\"\nkind = \"env\"\nvar = \"TOKEN2\"\n\
+             remedy = \"ask an admin for TOKEN2\"\n",
+        );
+        let env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        // Unmet, but nothing to install -> re-check still reports it as unmet.
+        install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: false,
+            },
+            &env,
+        )
+        .unwrap_err();
+        // Everything satisfied -> re-check passes.
+        let have = env_with(
+            dir.path(),
+            HashMap::from([("TOKEN".into(), "x".into()), ("TOKEN2".into(), "y".into())]),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: false,
+            },
+            &have,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn install_runs_a_rhai_script_with_sh() {
+        let dir = tempfile::tempdir().unwrap();
+        let adir = write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"thing\"\nkind = \"binary\"\ncommand = \"x\"\n\
+             [dependencies.install]\nscript = \"install.rhai\"\n",
+        );
+        std::fs::write(
+            adir.join("install.rhai"),
+            r#"fn install() { sh("do it"); }"#,
+        )
+        .unwrap();
+        let runner = Arc::new(FakeRunner::default());
+        let env = env_with(dir.path(), HashMap::new(), runner.clone(), true);
+        install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: false,
+            },
+            &env,
+        )
+        .unwrap_err(); // binary still not found
+        assert_eq!(runner.ran.lock().unwrap().as_slice(), ["do it"]);
+
+        // A script whose sh() fails surfaces the error.
+        std::fs::write(adir.join("install.rhai"), r#"fn install() { sh("nope"); }"#).unwrap();
+        let failing = Arc::new(FakeRunner {
+            fail: true,
+            ..Default::default()
+        });
+        let env2 = env_with(dir.path(), HashMap::new(), failing, true);
+        let err = install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: false,
+            },
+            &env2,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("boom"), "{err}");
+
+        // A script that will not compile surfaces a compile error naming it.
+        std::fs::write(adir.join("install.rhai"), "fn install() {").unwrap();
+        let env3 = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        let err = install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: false,
+            },
+            &env3,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("install.rhai"), "{err}");
+    }
+
+    #[test]
+    fn list_covers_every_dependency_kind() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "all",
+            "[[dependencies]]\nname = \"m1\"\nkind = \"mcp_server\"\nserver = \"meshy\"\n\
+             env = [\"KEY\"]\ndescription = \"d1\"\n[dependencies.install.server]\nurl = \"https://x\"\n\n\
+             [[dependencies]]\nname = \"m2\"\nkind = \"mcp_server\"\nserver = \"other\"\n\n\
+             [[dependencies]]\nname = \"e\"\nkind = \"env\"\nvar = \"TOKEN\"\n\n\
+             [[dependencies]]\nname = \"b\"\nkind = \"binary\"\ncommand = \"blender\"\n\n\
+             [[dependencies]]\nname = \"s\"\nkind = \"script\"\ncheck = \"chk.rhai\"\nrequired = false\n",
+        );
+        let env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        list("all", &env).unwrap();
+    }
+
+    #[test]
+    fn check_covers_every_output_arm() {
+        let dir = tempfile::tempdir().unwrap();
+        let adir = write_agent(
+            dir.path(),
+            "c",
+            "[[dependencies]]\nname = \"ok\"\nkind = \"env\"\nvar = \"TOKEN\"\n\n\
+             [[dependencies]]\nname = \"miss\"\nkind = \"binary\"\ncommand = \"nope\"\n\n\
+             [[dependencies]]\nname = \"broke\"\nkind = \"script\"\ncheck = \"chk.rhai\"\n\n\
+             [[dependencies]]\nname = \"opt\"\nkind = \"env\"\nvar = \"NOPE\"\nrequired = false\n",
+        );
+        std::fs::write(adir.join("chk.rhai"), r#"fn check() { throw "boom" }"#).unwrap();
+        let env = env_with(
+            dir.path(),
+            HashMap::from([("TOKEN".into(), "x".into())]),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        // ok=Satisfied, miss=Unmet, broke=Unusable, opt=optional-unmet -> blocks.
+        check("c", &env).unwrap_err();
+    }
+
+    #[test]
+    fn install_reports_an_invalid_server_template() {
+        let dir = tempfile::tempdir().unwrap();
+        // A server template with neither command nor url cannot resolve.
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"m\"\nkind = \"mcp_server\"\nserver = \"m\"\n\
+             [dependencies.install.server]\n",
+        );
+        let env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        let err = install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: false,
+            },
+            &env,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("not valid"), "{err}");
+    }
+
+    #[test]
+    fn a_bad_agent_errors_through_every_subcommand() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        assert!(list("nope", &env).is_err());
+        assert!(check("nope", &env).is_err());
+        assert!(
+            install(
+                InstallArgs {
+                    agent: "nope".into(),
+                    yes: true,
+                    all: false,
+                },
+                &env,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn a_corrupt_config_surfaces_through_check_and_install() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"m\"\nkind = \"mcp_server\"\nserver = \"m\"\n",
+        );
+        std::fs::write(dir.path().join("config.toml"), "this = = broken").unwrap();
+        let env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        assert!(check("a", &env).is_err());
+        assert!(
+            install(
+                InstallArgs {
+                    agent: "a".into(),
+                    yes: true,
+                    all: false,
+                },
+                &env,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn add_server_save_failure_surfaces() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"m\"\nkind = \"mcp_server\"\nserver = \"m\"\n\
+             [dependencies.install.server]\nurl = \"https://x\"\n",
+        );
+        // A file where the config's parent dir would go makes the save fail.
+        std::fs::write(dir.path().join("blocker"), b"x").unwrap();
+        let mut env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        env.config_path = dir.path().join("blocker").join("config.toml");
+        assert!(
+            install(
+                InstallArgs {
+                    agent: "a".into(),
+                    yes: true,
+                    all: false,
+                },
+                &env,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn a_missing_install_script_surfaces() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"b\"\nkind = \"binary\"\ncommand = \"x\"\n\
+             [dependencies.install]\nscript = \"missing.rhai\"\n",
+        );
+        let env = env_with(
+            dir.path(),
+            HashMap::new(),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        let err = install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: false,
+            },
+            &env,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("read install script"), "{err}");
+    }
+
+    #[test]
+    fn install_all_skips_a_satisfied_dependency_with_no_steps() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "a",
+            "[[dependencies]]\nname = \"e\"\nkind = \"env\"\nvar = \"TOKEN\"\n",
+        );
+        let env = env_with(
+            dir.path(),
+            HashMap::from([("TOKEN".into(), "x".into())]),
+            Arc::new(FakeRunner::default()),
+            true,
+        );
+        // --all reaches the satisfied dep, which has no install steps: skipped.
+        install(
+            InstallArgs {
+                agent: "a".into(),
+                yes: true,
+                all: true,
+            },
+            &env,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn chosen_command_prefers_the_per_os_entry() {
+        let mut install = DependencyInstall {
+            command: Some("generic".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            chosen_command(&install, "linux").as_deref(),
+            Some("generic")
+        );
+        install.commands.insert("linux".into(), "apt".into());
+        assert_eq!(chosen_command(&install, "linux").as_deref(), Some("apt"));
+        assert_eq!(
+            chosen_command(&install, "macos").as_deref(),
+            Some("generic")
+        );
+    }
+
+    #[test]
+    fn mcp_template_maps_transport_and_headers() {
+        let tpl = leviath_core::blueprint::McpServerTemplate {
+            transport: Some("http".into()),
+            url: Some("https://x".into()),
+            headers: std::collections::BTreeMap::from([("A".into(), "b".into())]),
+            ..Default::default()
+        };
+        let server = mcp_from_template("s", &tpl);
+        assert_eq!(server.transport, Some(MCPTransport::Http));
+        assert_eq!(server.headers.get("A").map(String::as_str), Some("b"));
+        let stdio = leviath_core::blueprint::McpServerTemplate {
+            transport: Some("stdio".into()),
+            command: Some("srv".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            mcp_from_template("s", &stdio).transport,
+            Some(MCPTransport::Stdio)
+        );
+    }
+}

--- a/crates/leviath-cli/src/commands/deps.rs
+++ b/crates/leviath-cli/src/commands/deps.rs
@@ -18,7 +18,7 @@ use anyhow::{Context, bail};
 use leviath_core::blueprint::{Blueprint, Dependency, DependencyInstall, DependencyKind};
 use leviath_mcp::{MCPServerConfig, MCPTransport};
 
-use crate::dependencies::{self, DependencyState, Probe};
+use crate::dependencies::{self, Probe};
 
 /// `lev deps` and its subcommands.
 #[derive(clap::Args, Debug)]
@@ -212,13 +212,7 @@ fn check(agent: &str, env: &DepsEnv) -> anyhow::Result<()> {
     }
     println!("'{}' dependencies:", blueprint.name);
     for s in &report.statuses {
-        let (mark, detail) = match &s.state {
-            DependencyState::Satisfied => ("ok  ", String::new()),
-            DependencyState::Unmet(remedy) => ("MISS", format!(" - {remedy}")),
-            DependencyState::Unusable(reason) => ("ERR ", format!(" - {reason}")),
-        };
-        let req = if s.required { "" } else { " (optional)" };
-        println!("  [{mark}] {} ({}){req}{detail}", s.name, s.kind);
+        println!("  {}", s.line());
     }
     if let Some(msg) = report.blocking_message() {
         bail!("{msg}");

--- a/crates/leviath-cli/src/commands/mod.rs
+++ b/crates/leviath-cli/src/commands/mod.rs
@@ -43,6 +43,7 @@ pub mod ctl;
 pub mod daemon;
 pub mod daemon_service;
 pub mod dashboard;
+pub mod deps;
 pub mod doctor;
 pub(crate) mod list;
 pub mod mcp;

--- a/crates/leviath-cli/src/commands/serve/blueprint_types.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprint_types.rs
@@ -31,3 +31,153 @@ pub(super) struct StageRoutingInfo {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(super) context_reset: Vec<String>,
 }
+
+/// One blueprint, with the manifest text behind it.
+///
+/// The detail route only. A listing that carried one of these per blueprint
+/// would send every manifest on the machine to answer "what agents are there",
+/// which is why this is a separate shape rather than an extra field on
+/// [`BlueprintInfo`](super::types::BlueprintInfo).
+///
+/// Flattened, so the detail route's JSON is the info's own fields plus
+/// `manifest`, and a client that reads only those is unaffected.
+#[derive(Debug, Serialize)]
+pub(super) struct BlueprintDetail {
+    #[serde(flatten)]
+    pub(super) info: super::types::BlueprintInfo,
+    /// The blueprint's context regions.
+    ///
+    /// On the detail route rather than the listing, for the same reason the
+    /// manifest is: answering "what agents are there" should not cost every
+    /// region of every agent on the machine.
+    pub(super) regions: Vec<super::types::RegionInfo>,
+    /// The blueprint's fan-out stages, with their limits as the daemon will
+    /// apply them. Empty for a blueprint that never fans out.
+    pub(super) fan_outs: Vec<super::types::FanOutInfo>,
+    /// The stages that route produced parts (`output_routing`) or reset a
+    /// region on entry (`context.reset`); empty when the blueprint does neither.
+    pub(super) stage_routing: Vec<StageRoutingInfo>,
+    /// What the agent declares it needs before it runs (`[[dependencies]]`),
+    /// so a console can show them and warn before a spawn that would fail the
+    /// dependency gate. Empty for a blueprint that declares none.
+    pub(super) dependencies: Vec<DependencyInfo>,
+    /// The manifest exactly as it is on disk.
+    ///
+    /// Without this a console has no way to read what it is editing: naming
+    /// the file in `path` is not the same as being able to open it, since the
+    /// browser cannot, and the fallbacks it is left with (a draft in local
+    /// storage, or a copy bundled at build time) are both disconnected from
+    /// the file the daemon actually runs.
+    pub(super) manifest: String,
+}
+
+/// One declared dependency, so the detail route carries what an agent needs
+/// without a console parsing the manifest. The kind-specific fields appear only
+/// for the kind that has them.
+#[derive(Debug, Serialize)]
+pub(super) struct DependencyInfo {
+    /// The dependency's name.
+    pub(super) name: String,
+    /// Its kind: `mcp_server`, `env`, `binary` or `script`.
+    pub(super) kind: &'static str,
+    /// Whether an unmet result blocks the run.
+    pub(super) required: bool,
+    /// How to satisfy it when missing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) remedy: Option<String>,
+    /// Why the agent needs it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) description: Option<String>,
+    /// kind=mcp_server: the server name that must be configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) server: Option<String>,
+    /// kind=mcp_server: the env secrets the server needs.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) env: Vec<String>,
+    /// kind=env: the variable that must be set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) var: Option<String>,
+    /// kind=binary: the program that must be on PATH.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) command: Option<String>,
+    /// kind=script: the Rhai check script's path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) check: Option<String>,
+    /// Whether the blueprint declares how to install it.
+    pub(super) installable: bool,
+}
+
+/// The declared dependencies of a blueprint, in declaration order, so the
+/// detail route carries them structured. Empty for a blueprint that declares
+/// none.
+pub(super) fn dependency_infos(blueprint: &leviath_core::Blueprint) -> Vec<DependencyInfo> {
+    use leviath_core::blueprint::DependencyKind;
+    blueprint
+        .dependencies
+        .iter()
+        .map(|dep| {
+            let mut info = DependencyInfo {
+                name: dep.name.clone(),
+                kind: dep.kind.tag(),
+                required: dep.required,
+                remedy: dep.remedy.clone(),
+                description: dep.description.clone(),
+                server: None,
+                env: Vec::new(),
+                var: None,
+                command: None,
+                check: None,
+                installable: dep.install.is_some(),
+            };
+            match &dep.kind {
+                DependencyKind::McpServer { server, env } => {
+                    info.server = Some(server.clone());
+                    info.env = env.clone();
+                }
+                DependencyKind::Env { var } => info.var = Some(var.clone()),
+                DependencyKind::Binary { command } => info.command = Some(command.clone()),
+                DependencyKind::Script { check } => info.check = Some(check.clone()),
+            }
+            info
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dependency_infos_carries_every_kind() {
+        let bp = leviath_core::manifest::parse_manifest(
+            "[agent]\nname = \"a\"\n\n\
+             [[dependencies]]\nname = \"m\"\nkind = \"mcp_server\"\nserver = \"meshy\"\n\
+             env = [\"K\"]\nremedy = \"r\"\ndescription = \"d\"\n\
+             [dependencies.install.server]\nurl = \"https://x\"\n\n\
+             [[dependencies]]\nname = \"e\"\nkind = \"env\"\nvar = \"V\"\n\n\
+             [[dependencies]]\nname = \"b\"\nkind = \"binary\"\ncommand = \"c\"\n\n\
+             [[dependencies]]\nname = \"s\"\nkind = \"script\"\ncheck = \"chk.rhai\"\n",
+        )
+        .unwrap();
+        let infos = dependency_infos(&bp);
+        assert_eq!(infos.len(), 4);
+        assert_eq!(infos[0].kind, "mcp_server");
+        assert_eq!(infos[0].server.as_deref(), Some("meshy"));
+        assert_eq!(infos[0].env, vec!["K".to_string()]);
+        assert_eq!(infos[0].remedy.as_deref(), Some("r"));
+        assert_eq!(infos[0].description.as_deref(), Some("d"));
+        assert!(infos[0].required);
+        assert!(infos[0].installable);
+        assert_eq!(infos[1].var.as_deref(), Some("V"));
+        assert_eq!(infos[2].command.as_deref(), Some("c"));
+        assert_eq!(infos[3].check.as_deref(), Some("chk.rhai"));
+        assert!(!infos[3].installable);
+        // Exercise the wire serialization the detail route relies on.
+        let json = serde_json::to_string(&infos).expect("serializes");
+        assert!(json.contains("\"kind\":\"mcp_server\""), "{json}");
+        assert!(json.contains("\"installable\":true"), "{json}");
+        // An agent with no dependencies yields an empty list.
+        let none = leviath_core::manifest::parse_manifest("[agent]\nname = \"n\"\n").unwrap();
+        assert!(dependency_infos(&none).is_empty());
+    }
+}

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -8,7 +8,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::Json;
 
-use super::blueprint_types::{RoutePair, StageRoutingInfo};
+use super::blueprint_types::{BlueprintDetail, RoutePair, StageRoutingInfo};
 use super::types::*;
 use leviath_core::manifest::parse_manifest;
 
@@ -327,11 +327,16 @@ pub(super) async fn get_blueprint(
         .unwrap_or_default();
     let fan_outs = parsed.as_ref().map(fan_out_infos).unwrap_or_default();
     let stage_routing = parsed.as_ref().map(stage_routing_infos).unwrap_or_default();
+    let dependencies = parsed
+        .as_ref()
+        .map(super::blueprint_types::dependency_infos)
+        .unwrap_or_default();
     Ok(Json(BlueprintDetail {
         info,
         regions,
         fan_outs,
         stage_routing,
+        dependencies,
         manifest,
     }))
 }

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -307,6 +307,13 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // entry (`context.reset`), so a console shows or checks them without
     // parsing the manifest.
     "blueprints.stage_routing",
+    // `dependencies` on the detail route: what an agent declares it needs
+    // before it runs (an MCP server, an env var, a program on PATH, a Rhai
+    // check), each with its kind, whether it is required, and whether the
+    // blueprint says how to install it. A console can show them and warn before
+    // a spawn that would fail the dependency gate, rather than parsing the
+    // manifest or discovering the failure by running.
+    "blueprints.dependencies",
     "tools.list",
     // `GET /api/update`: how this copy was installed, and the command that
     // upgrades it. Announced because the fallback is guessing, and the console

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -455,7 +455,8 @@ pub(super) struct BlueprintInfo {
     /// answer to that would be an error arm no test can reach.
     ///
     /// Skipped when serializing, so `GET /api/blueprints` stays a catalog.
-    /// [`BlueprintDetail`] is what puts it on the wire.
+    /// [`BlueprintDetail`](super::blueprint_types::BlueprintDetail) is what puts
+    /// it on the wire.
     #[serde(skip)]
     pub(super) manifest: String,
 }
@@ -520,41 +521,6 @@ pub(super) struct FanOutInfo {
     /// stage names one; `null` means the conversation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) results_region: Option<String>,
-}
-
-/// One blueprint, with the manifest text behind it.
-///
-/// The detail route only. A listing that carried one of these per blueprint
-/// would send every manifest on the machine to answer "what agents are there",
-/// which is why this is a separate shape rather than an extra field on
-/// [`BlueprintInfo`].
-///
-/// Flattened, so the detail route's JSON is [`BlueprintInfo`]'s own fields
-/// plus `manifest`, and a client that reads only those is unaffected.
-#[derive(Debug, Serialize)]
-pub(super) struct BlueprintDetail {
-    #[serde(flatten)]
-    pub(super) info: BlueprintInfo,
-    /// The blueprint's context regions.
-    ///
-    /// On the detail route rather than the listing, for the same reason the
-    /// manifest is: answering "what agents are there" should not cost every
-    /// region of every agent on the machine.
-    pub(super) regions: Vec<RegionInfo>,
-    /// The blueprint's fan-out stages, with their limits as the daemon will
-    /// apply them. Empty for a blueprint that never fans out.
-    pub(super) fan_outs: Vec<FanOutInfo>,
-    /// The stages that route produced parts (`output_routing`) or reset a
-    /// region on entry (`context.reset`); empty when the blueprint does neither.
-    pub(super) stage_routing: Vec<super::blueprint_types::StageRoutingInfo>,
-    /// The manifest exactly as it is on disk.
-    ///
-    /// Without this a console has no way to read what it is editing: naming
-    /// the file in `path` is not the same as being able to open it, since the
-    /// browser cannot, and the fallbacks it is left with (a draft in local
-    /// storage, or a copy bundled at build time) are both disconnected from
-    /// the file the daemon actually runs.
-    pub(super) manifest: String,
 }
 
 /// Query for `GET /api/blueprints`.

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -511,6 +511,7 @@ fn execute_reporting_outcome(
         let workdir = crate::commands::resolve_cwd().unwrap_or_default();
         if !args.json {
             print_model_resolution(&checked.blueprint, config, registry);
+            print_dependencies(&checked.blueprint, config, &checked.agent_dir);
         }
         env = env
             .with_providers(&checked.blueprint, config)
@@ -537,6 +538,31 @@ fn execute_reporting_outcome(
         return Ok(ValidateOutcome::LintFailed { errors, warnings });
     }
     Ok(ValidateOutcome::Success)
+}
+
+/// Print each declared dependency and whether this machine satisfies it, the
+/// same check the spawn gate makes. Non-fatal: an unmet dependency is a
+/// machine-setup fact, not a blueprint error, so it is shown rather than
+/// counted as a finding. A blueprint that declares none prints nothing.
+fn print_dependencies(
+    blueprint: &leviath_core::Blueprint,
+    config: &crate::config::Config,
+    agent_dir: &std::path::Path,
+) {
+    if blueprint.dependencies.is_empty() {
+        return;
+    }
+    let report = crate::dependencies::evaluate(
+        &blueprint.dependencies,
+        &config.mcp_servers,
+        agent_dir,
+        &crate::dependencies::SystemProbe,
+    );
+    println!();
+    println!("Dependencies:");
+    for status in &report.statuses {
+        println!("  {}", status.line());
+    }
 }
 
 /// What each stage would actually dispatch to on this machine, and why.
@@ -1378,6 +1404,21 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
 
     fn parse(toml: &str) -> leviath_core::Blueprint {
         leviath_core::manifest::parse_manifest(toml).unwrap()
+    }
+
+    #[test]
+    fn print_dependencies_skips_when_none_and_lists_when_present() {
+        let cfg = crate::config::Config::default();
+        let dir = std::path::Path::new(".");
+        // A blueprint with no dependencies prints nothing and must not panic.
+        let none = parse("[agent]\nname = \"n\"\n");
+        print_dependencies(&none, &cfg, dir);
+        // One with a dependency reaches the listing loop.
+        let some = parse(
+            "[agent]\nname = \"a\"\n\n\
+             [[dependencies]]\nname = \"e\"\nkind = \"env\"\nvar = \"LEVIATH_VALIDATE_UNSET_XYZ\"\n",
+        );
+        print_dependencies(&some, &cfg, dir);
     }
 
     /// Helper to create a minimal valid blueprint TOML with given stages.

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -542,6 +542,22 @@ fn build_agent_inner(
     // 1. Load the blueprint (the client resolves the manifest path).
     let (content, blueprint) = load_blueprint(args, deps.config)?;
 
+    // 1b. Fail fast if a required dependency is not satisfied, before any
+    // billed inference. Every spawn - `lev run`, the serve API, sub-agents and
+    // fan-out - passes through here, so this is the one place that gate lives.
+    if let Some(msg) = crate::dependencies::evaluate(
+        &blueprint.dependencies,
+        &deps.config.mcp_servers,
+        Path::new(&args.blueprint_path)
+            .parent()
+            .unwrap_or_else(|| Path::new(".")),
+        &crate::dependencies::SystemProbe,
+    )
+    .blocking_message()
+    {
+        return Err(msg);
+    }
+
     // 2a. Entry stage + per-stage sandbox resolution. Each stage's effective
     // sandbox cascades stage → agent → global (`resolve_sandbox`); building the
     // manager creates any containers up front and fails here (returning the
@@ -1819,6 +1835,44 @@ system = { kind = "pinned", max_tokens = 1000 }
         .unwrap_err();
         assert!(err.contains("cannot read mime check"), "got: {err}");
         assert!(err.contains("gone.rhai"), "got: {err}");
+    }
+
+    /// A required dependency that is not satisfied fails the spawn before any
+    /// tokens are spent, with a message pointing at `lev deps`.
+    #[tokio::test]
+    async fn build_agent_fails_fast_on_an_unmet_dependency() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"v\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\n\
+             [[dependencies]]\nname = \"key\"\nkind = \"env\"\n\
+             var = \"LEVIATH_DEPS_SPAWN_UNSET_XYZ\"\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let args = spawn_args(&manifest.to_string_lossy());
+        let err = build_agent(
+            world.world_mut(),
+            SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                mcp_tool_owners: &Default::default(),
+                hub: &hub,
+                now_secs: 100,
+                subagent_tx: sub_tx(),
+            },
+            &args,
+        )
+        .unwrap_err();
+        assert!(err.contains("dependencies are not satisfied"), "got: {err}");
+        assert!(err.contains("LEVIATH_DEPS_SPAWN_UNSET_XYZ"), "got: {err}");
+        assert!(err.contains("lev deps"), "got: {err}");
     }
 
     /// The run id becomes a directory name and everything a run writes lands

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -550,7 +550,7 @@ fn build_agent_inner(
         &deps.config.mcp_servers,
         Path::new(&args.blueprint_path)
             .parent()
-            .unwrap_or_else(|| Path::new(".")),
+            .unwrap_or(Path::new(".")),
         &crate::dependencies::SystemProbe,
     )
     .blocking_message()

--- a/crates/leviath-cli/src/dependencies.rs
+++ b/crates/leviath-cli/src/dependencies.rs
@@ -67,6 +67,15 @@ impl DependencyState {
     pub fn is_satisfied(&self) -> bool {
         matches!(self, DependencyState::Satisfied)
     }
+
+    /// The remedy or reason to show, empty when satisfied.
+    pub fn detail(&self) -> &str {
+        match self {
+            DependencyState::Satisfied => "",
+            DependencyState::Unmet(remedy) => remedy,
+            DependencyState::Unusable(reason) => reason,
+        }
+    }
 }
 
 /// One dependency's evaluated status.
@@ -107,12 +116,12 @@ impl DependencyReport {
         }
         let mut msg = String::from("this agent's dependencies are not satisfied:");
         for s in blocking {
-            let detail = match &s.state {
-                DependencyState::Unmet(remedy) => remedy.clone(),
-                DependencyState::Unusable(reason) => reason.clone(),
-                DependencyState::Satisfied => unreachable!("blocking is never satisfied"),
-            };
-            msg.push_str(&format!("\n  - {} ({}): {detail}", s.name, s.kind));
+            msg.push_str(&format!(
+                "\n  - {} ({}): {}",
+                s.name,
+                s.kind,
+                s.state.detail()
+            ));
         }
         msg.push_str("\n\nRun `lev deps check <agent>` to see them, or `lev deps install <agent>` to set them up.");
         Some(msg)
@@ -307,10 +316,7 @@ mod tests {
             env: HashMap::from([("MESHY_API_KEY".into(), "  ".into())]),
             bins: vec![],
         };
-        assert!(matches!(
-            eval_one(&d, &[server("meshy")], &blank),
-            DependencyState::Unmet(_)
-        ));
+        assert!(!eval_one(&d, &[server("meshy")], &blank).is_satisfied());
     }
 
     #[test]
@@ -439,6 +445,13 @@ mod tests {
             !msg.contains("opt"),
             "optional deps are not blocking: {msg}"
         );
+    }
+
+    #[test]
+    fn dependency_state_detail_covers_every_variant() {
+        assert_eq!(DependencyState::Satisfied.detail(), "");
+        assert_eq!(DependencyState::Unmet("fix it".into()).detail(), "fix it");
+        assert_eq!(DependencyState::Unusable("broke".into()).detail(), "broke");
     }
 
     #[test]

--- a/crates/leviath-cli/src/dependencies.rs
+++ b/crates/leviath-cli/src/dependencies.rs
@@ -91,6 +91,25 @@ pub struct DependencyStatus {
     pub state: DependencyState,
 }
 
+impl DependencyStatus {
+    /// A one-line human status, shared by `lev deps check`, `lev validate` and
+    /// `lev doctor`: `[ok  ] name (kind)`, or `[MISS] name (kind) - remedy`.
+    pub fn line(&self) -> String {
+        let mark = match &self.state {
+            DependencyState::Satisfied => "ok  ",
+            DependencyState::Unmet(_) => "MISS",
+            DependencyState::Unusable(_) => "ERR ",
+        };
+        let req = if self.required { "" } else { " (optional)" };
+        let detail = self.state.detail();
+        if detail.is_empty() {
+            format!("[{mark}] {} ({}){req}", self.name, self.kind)
+        } else {
+            format!("[{mark}] {} ({}){req} - {detail}", self.name, self.kind)
+        }
+    }
+}
+
 /// The evaluation of a blueprint's whole dependency list.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DependencyReport {
@@ -452,6 +471,28 @@ mod tests {
         assert_eq!(DependencyState::Satisfied.detail(), "");
         assert_eq!(DependencyState::Unmet("fix it".into()).detail(), "fix it");
         assert_eq!(DependencyState::Unusable("broke".into()).detail(), "broke");
+    }
+
+    #[test]
+    fn status_line_covers_marks_and_optional() {
+        let mk = |state, required| DependencyStatus {
+            name: "d".into(),
+            kind: "env",
+            required,
+            state,
+        };
+        assert_eq!(
+            mk(DependencyState::Satisfied, true).line(),
+            "[ok  ] d (env)"
+        );
+        assert_eq!(
+            mk(DependencyState::Unmet("set it".into()), true).line(),
+            "[MISS] d (env) - set it"
+        );
+        assert_eq!(
+            mk(DependencyState::Unusable("broke".into()), false).line(),
+            "[ERR ] d (env) (optional) - broke"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/dependencies.rs
+++ b/crates/leviath-cli/src/dependencies.rs
@@ -1,0 +1,487 @@
+//! Checking a blueprint's declared `[[dependencies]]` against this machine.
+//!
+//! A blueprint says what it needs (see [`leviath_core::blueprint::Dependency`]);
+//! this module answers whether the machine has it. The same evaluator is used
+//! two ways: the spawn gate fails a run before the first billed inference if a
+//! required dependency is missing, and `lev deps` reports the same findings
+//! (and, separately and explicitly, installs).
+//!
+//! Nothing here installs or changes anything - a check only reads. The
+//! env-and-PATH reads go through a [`Probe`] so the evaluator is testable
+//! without depending on the host's environment; [`SystemProbe`] is the real one.
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use leviath_core::blueprint::{Dependency, DependencyKind};
+use leviath_mcp::MCPServerConfig;
+
+/// The machine facts a check reads: environment variables and what is on
+/// `PATH`. Injected so the evaluator can be tested against a fake machine.
+pub trait Probe {
+    /// The value of an environment variable, or `None` if it is unset.
+    fn env(&self, name: &str) -> Option<String>;
+    /// Whether a program of this name resolves on `PATH`.
+    fn which(&self, name: &str) -> bool;
+}
+
+/// The real machine.
+pub struct SystemProbe;
+
+impl Probe for SystemProbe {
+    fn env(&self, name: &str) -> Option<String> {
+        std::env::var(name).ok()
+    }
+    fn which(&self, name: &str) -> bool {
+        which_in(std::env::var_os("PATH"), name)
+    }
+}
+
+/// Whether `name` (or `name.exe`) is a file in any directory of `path`.
+///
+/// The `.exe` suffix is checked on every OS: it costs a stat that misses on
+/// Unix and spares a `#[cfg(windows)]` split. This is presence, not an
+/// executable-bit check - enough to tell "installed" from "not".
+fn which_in(path: Option<OsString>, name: &str) -> bool {
+    let Some(path) = path else {
+        return false;
+    };
+    std::env::split_paths(&path)
+        .any(|dir| dir.join(name).is_file() || dir.join(format!("{name}.exe")).is_file())
+}
+
+/// Whether a dependency is in place, and why not when it is not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DependencyState {
+    /// The dependency is present.
+    Satisfied,
+    /// It is missing; the string is the remedy shown to the user.
+    Unmet(String),
+    /// The check itself could not run (a broken script, an unreadable file);
+    /// the string is the reason.
+    Unusable(String),
+}
+
+impl DependencyState {
+    /// Whether this counts as "in place".
+    pub fn is_satisfied(&self) -> bool {
+        matches!(self, DependencyState::Satisfied)
+    }
+}
+
+/// One dependency's evaluated status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyStatus {
+    /// The dependency's name.
+    pub name: String,
+    /// Its kind tag (`mcp_server`, `env`, `binary`, `script`).
+    pub kind: &'static str,
+    /// Whether an unmet result blocks the run.
+    pub required: bool,
+    /// What the check found.
+    pub state: DependencyState,
+}
+
+/// The evaluation of a blueprint's whole dependency list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyReport {
+    /// One entry per declared dependency, in declaration order.
+    pub statuses: Vec<DependencyStatus>,
+}
+
+impl DependencyReport {
+    /// The required dependencies that are not satisfied - what blocks a run.
+    pub fn blocking(&self) -> Vec<&DependencyStatus> {
+        self.statuses
+            .iter()
+            .filter(|s| s.required && !s.state.is_satisfied())
+            .collect()
+    }
+
+    /// A spawn-blocking message when a required dependency is missing, or
+    /// `None` when the run may proceed.
+    pub fn blocking_message(&self) -> Option<String> {
+        let blocking = self.blocking();
+        if blocking.is_empty() {
+            return None;
+        }
+        let mut msg = String::from("this agent's dependencies are not satisfied:");
+        for s in blocking {
+            let detail = match &s.state {
+                DependencyState::Unmet(remedy) => remedy.clone(),
+                DependencyState::Unusable(reason) => reason.clone(),
+                DependencyState::Satisfied => unreachable!("blocking is never satisfied"),
+            };
+            msg.push_str(&format!("\n  - {} ({}): {detail}", s.name, s.kind));
+        }
+        msg.push_str("\n\nRun `lev deps check <agent>` to see them, or `lev deps install <agent>` to set them up.");
+        Some(msg)
+    }
+}
+
+/// Evaluate every dependency of a blueprint against this machine.
+///
+/// `servers` is the operator's configured MCP servers, `blueprint_dir` the
+/// directory holding the manifest (a `script` check is resolved and fenced
+/// against it), and `probe` reads env and `PATH`.
+pub fn evaluate(
+    deps: &[Dependency],
+    servers: &[MCPServerConfig],
+    blueprint_dir: &Path,
+    probe: &dyn Probe,
+) -> DependencyReport {
+    let statuses = deps
+        .iter()
+        .map(|dep| DependencyStatus {
+            name: dep.name.clone(),
+            kind: dep.kind.tag(),
+            required: dep.required,
+            state: evaluate_one(dep, servers, blueprint_dir, probe),
+        })
+        .collect();
+    DependencyReport { statuses }
+}
+
+/// A dependency's own remedy, or a sensible default sentence.
+fn remedy_or(dep: &Dependency, default: String) -> String {
+    dep.remedy.clone().unwrap_or(default)
+}
+
+fn evaluate_one(
+    dep: &Dependency,
+    servers: &[MCPServerConfig],
+    blueprint_dir: &Path,
+    probe: &dyn Probe,
+) -> DependencyState {
+    match &dep.kind {
+        DependencyKind::McpServer { server, env } => {
+            if !servers.iter().any(|s| &s.name == server) {
+                return DependencyState::Unmet(remedy_or(
+                    dep,
+                    format!("configure the MCP server '{server}' in your config"),
+                ));
+            }
+            for var in env {
+                if probe.env(var).filter(|v| !v.trim().is_empty()).is_none() {
+                    return DependencyState::Unmet(remedy_or(
+                        dep,
+                        format!("set {var} (the '{server}' server needs it)"),
+                    ));
+                }
+            }
+            DependencyState::Satisfied
+        }
+        DependencyKind::Env { var } => {
+            if probe.env(var).filter(|v| !v.trim().is_empty()).is_some() {
+                DependencyState::Satisfied
+            } else {
+                DependencyState::Unmet(remedy_or(
+                    dep,
+                    format!("set the environment variable {var}"),
+                ))
+            }
+        }
+        DependencyKind::Binary { command } => {
+            if probe.which(command) {
+                DependencyState::Satisfied
+            } else {
+                DependencyState::Unmet(remedy_or(
+                    dep,
+                    format!("install '{command}' and put it on your PATH"),
+                ))
+            }
+        }
+        DependencyKind::Script { check } => evaluate_script(check, blueprint_dir),
+    }
+}
+
+/// Compile and run a `script` dependency's check, fenced to the blueprint dir.
+fn evaluate_script(check: &str, blueprint_dir: &Path) -> DependencyState {
+    let path = blueprint_dir.join(check);
+    if !leviath_core::resolves_within(&path, blueprint_dir) {
+        return DependencyState::Unusable(format!(
+            "the check script '{check}' resolves outside the blueprint directory"
+        ));
+    }
+    let source = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            return DependencyState::Unusable(format!("read check script '{check}': {e}"));
+        }
+    };
+    let compiled = match leviath_scripting::dependency_check::compile(check, &source) {
+        Ok(c) => c,
+        Err(e) => return DependencyState::Unusable(e.to_string()),
+    };
+    match leviath_scripting::dependency_check::run(&compiled) {
+        leviath_scripting::dependency_check::Verdict::Satisfied => DependencyState::Satisfied,
+        leviath_scripting::dependency_check::Verdict::Unmet(remedy) => {
+            DependencyState::Unmet(remedy)
+        }
+        leviath_scripting::dependency_check::Verdict::Unusable(reason) => {
+            DependencyState::Unusable(reason)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::blueprint::DependencyKind;
+    use std::collections::HashMap;
+
+    struct FakeProbe {
+        env: HashMap<String, String>,
+        bins: Vec<String>,
+    }
+    impl Probe for FakeProbe {
+        fn env(&self, name: &str) -> Option<String> {
+            self.env.get(name).cloned()
+        }
+        fn which(&self, name: &str) -> bool {
+            self.bins.iter().any(|b| b == name)
+        }
+    }
+
+    fn dep(name: &str, kind: DependencyKind) -> Dependency {
+        Dependency {
+            name: name.to_string(),
+            kind,
+            required: true,
+            remedy: None,
+            description: None,
+            install: None,
+        }
+    }
+
+    fn server(name: &str) -> MCPServerConfig {
+        MCPServerConfig {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn eval_one(
+        dep: &Dependency,
+        servers: &[MCPServerConfig],
+        probe: &dyn Probe,
+    ) -> DependencyState {
+        evaluate(std::slice::from_ref(dep), servers, Path::new("."), probe)
+            .statuses
+            .remove(0)
+            .state
+    }
+
+    #[test]
+    fn mcp_server_satisfied_and_missing() {
+        let probe = FakeProbe {
+            env: HashMap::from([("MESHY_API_KEY".into(), "sk-123".into())]),
+            bins: vec![],
+        };
+        let d = dep(
+            "meshy",
+            DependencyKind::McpServer {
+                server: "meshy".into(),
+                env: vec!["MESHY_API_KEY".into()],
+            },
+        );
+        assert_eq!(
+            eval_one(&d, &[server("meshy")], &probe),
+            DependencyState::Satisfied
+        );
+        // Server not configured.
+        assert!(
+            matches!(eval_one(&d, &[], &probe), DependencyState::Unmet(m) if m.contains("meshy"))
+        );
+        // Server present but the key is missing.
+        let no_key = FakeProbe {
+            env: HashMap::new(),
+            bins: vec![],
+        };
+        assert!(matches!(
+            eval_one(&d, &[server("meshy")], &no_key),
+            DependencyState::Unmet(m) if m.contains("MESHY_API_KEY")
+        ));
+        // A blank key counts as unset.
+        let blank = FakeProbe {
+            env: HashMap::from([("MESHY_API_KEY".into(), "  ".into())]),
+            bins: vec![],
+        };
+        assert!(matches!(
+            eval_one(&d, &[server("meshy")], &blank),
+            DependencyState::Unmet(_)
+        ));
+    }
+
+    #[test]
+    fn env_and_binary_kinds() {
+        let probe = FakeProbe {
+            env: HashMap::from([("TOKEN".into(), "x".into())]),
+            bins: vec!["blender".into()],
+        };
+        assert_eq!(
+            eval_one(
+                &dep(
+                    "t",
+                    DependencyKind::Env {
+                        var: "TOKEN".into()
+                    }
+                ),
+                &[],
+                &probe
+            ),
+            DependencyState::Satisfied
+        );
+        assert!(matches!(
+            eval_one(&dep("t", DependencyKind::Env { var: "NOPE".into() }), &[], &probe),
+            DependencyState::Unmet(m) if m.contains("NOPE")
+        ));
+        assert_eq!(
+            eval_one(
+                &dep(
+                    "b",
+                    DependencyKind::Binary {
+                        command: "blender".into()
+                    }
+                ),
+                &[],
+                &probe
+            ),
+            DependencyState::Satisfied
+        );
+        assert!(matches!(
+            eval_one(&dep("b", DependencyKind::Binary { command: "nope".into() }), &[], &probe),
+            DependencyState::Unmet(m) if m.contains("nope")
+        ));
+    }
+
+    #[test]
+    fn a_custom_remedy_overrides_the_default() {
+        let probe = FakeProbe {
+            env: HashMap::new(),
+            bins: vec![],
+        };
+        let mut d = dep("t", DependencyKind::Env { var: "NOPE".into() });
+        d.remedy = Some("do the thing".into());
+        assert_eq!(
+            eval_one(&d, &[], &probe),
+            DependencyState::Unmet("do the thing".into())
+        );
+    }
+
+    #[test]
+    fn script_check_states() {
+        let probe = FakeProbe {
+            env: HashMap::new(),
+            bins: vec![],
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let write = |name: &str, body: &str| {
+            std::fs::write(dir.path().join(name), body).unwrap();
+        };
+        write("ok.rhai", "fn check() { () }");
+        write("bad.rhai", r#"fn check() { "install it" }"#);
+        write("broken.rhai", r#"fn check() { throw "boom" }"#);
+        let run = |name: &str| {
+            evaluate(
+                &[dep("s", DependencyKind::Script { check: name.into() })],
+                &[],
+                dir.path(),
+                &probe,
+            )
+            .statuses
+            .remove(0)
+            .state
+        };
+        assert_eq!(run("ok.rhai"), DependencyState::Satisfied);
+        assert_eq!(run("bad.rhai"), DependencyState::Unmet("install it".into()));
+        assert!(matches!(run("broken.rhai"), DependencyState::Unusable(r) if r.contains("boom")));
+        assert!(
+            matches!(run("missing.rhai"), DependencyState::Unusable(r) if r.contains("read check script"))
+        );
+        // A path escaping the blueprint dir is refused.
+        assert!(matches!(
+            run("../escape.rhai"),
+            DependencyState::Unusable(r) if r.contains("outside the blueprint")
+        ));
+        // A script that will not compile is unusable.
+        write("nofn.rhai", "fn other() { () }");
+        assert!(
+            matches!(run("nofn.rhai"), DependencyState::Unusable(r) if r.contains("fn check()"))
+        );
+    }
+
+    #[test]
+    fn report_blocking_and_message() {
+        let probe = FakeProbe {
+            env: HashMap::new(),
+            bins: vec![],
+        };
+        let mut optional = dep("opt", DependencyKind::Env { var: "NOPE".into() });
+        optional.required = false;
+        let report = evaluate(
+            &[
+                dep("need", DependencyKind::Env { var: "NOPE".into() }),
+                optional,
+                dep("have", DependencyKind::Env { var: "NOPE".into() }),
+            ],
+            &[],
+            Path::new("."),
+            &probe,
+        );
+        // Only the required, unmet one blocks.
+        let blocking = report.blocking();
+        assert_eq!(blocking.len(), 2); // "need" and "have" are both required+unmet
+        let msg = report.blocking_message().unwrap();
+        assert!(msg.contains("need"), "{msg}");
+        assert!(msg.contains("lev deps install"), "{msg}");
+        assert!(
+            !msg.contains("opt"),
+            "optional deps are not blocking: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_satisfied_report_has_no_blocking_message() {
+        let probe = FakeProbe {
+            env: HashMap::from([("TOKEN".into(), "x".into())]),
+            bins: vec![],
+        };
+        let report = evaluate(
+            &[dep(
+                "t",
+                DependencyKind::Env {
+                    var: "TOKEN".into(),
+                },
+            )],
+            &[],
+            Path::new("."),
+            &probe,
+        );
+        assert!(report.blocking().is_empty());
+        assert!(report.blocking_message().is_none());
+        assert!(report.statuses[0].state.is_satisfied());
+    }
+
+    #[test]
+    fn system_probe_reads_the_real_machine() {
+        let probe = SystemProbe;
+        // PATH is always set; a nonsense var is not.
+        assert!(probe.env("PATH").is_some());
+        assert!(probe.env("LEVIATH_DEPS_DEFINITELY_UNSET_XYZ").is_none());
+        // A binary that cannot exist is not found.
+        assert!(!probe.which("leviath-not-a-real-binary-xyz"));
+    }
+
+    #[test]
+    fn which_in_finds_files_and_handles_no_path() {
+        assert!(!which_in(None, "anything"));
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("foo"), b"#!/bin/sh\n").unwrap();
+        std::fs::write(dir.path().join("bar.exe"), b"MZ").unwrap();
+        let path = std::env::join_paths([dir.path()]).unwrap();
+        assert!(which_in(Some(path.clone()), "foo"));
+        assert!(which_in(Some(path.clone()), "bar"));
+        assert!(!which_in(Some(path), "missing"));
+    }
+}

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -86,6 +86,9 @@ pub enum Commands {
     /// Validate an agent blueprint
     Validate(commands::validate::ValidateArgs),
 
+    /// Inspect and install an agent's declared dependencies
+    Deps(commands::deps::DepsArgs),
+
     /// Run blueprint tests
     Test(commands::test::TestArgs),
 
@@ -190,6 +193,7 @@ Blueprints:
   add           Install a blueprint
   remove        Remove an installed blueprint
   validate      Validate an agent blueprint
+  deps          Inspect and install an agent's dependencies
   test          Run blueprint tests
   pack          Bundle a blueprint for distribution
   tools         List and validate the global Rhai script tools
@@ -307,6 +311,12 @@ pub trait RiskyExecutors {
         &self,
         args: commands::mcp::McpArgs,
     ) -> impl std::future::Future<Output = anyhow::Result<()>>;
+    /// `lev deps` - reads env and PATH, and (on install) runs commands and
+    /// rewrites config.
+    fn deps(
+        &self,
+        args: commands::deps::DepsArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
     /// `lev providers` - reads the config file and may rewrite `provider_order`.
     fn providers(
         &self,
@@ -376,6 +386,7 @@ pub async fn dispatch(command: Commands, ex: &impl RiskyExecutors) -> anyhow::Re
         Commands::Timeline(args) => commands::timeline::execute(args).await,
         Commands::Result(args) => commands::result::execute(args).await,
         Commands::Mcp(args) => ex.mcp(args).await,
+        Commands::Deps(args) => ex.deps(args).await,
         Commands::Providers(args) => ex.providers(args).await,
         Commands::Auth(args) => ex.auth(args).await,
         Commands::Update(args) => ex.update(args).await,
@@ -470,6 +481,10 @@ mod tests {
         }
 
         async fn mcp(&self, _args: commands::mcp::McpArgs) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn deps(&self, _args: commands::deps::DepsArgs) -> anyhow::Result<()> {
             Ok(())
         }
 
@@ -798,6 +813,19 @@ mod tests {
             assert!(result.is_err());
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_deps_variant_is_routed() {
+        // `deps` is a risky executor (install writes config / runs commands);
+        // MockRisky answers Ok, so this exercises only the routing.
+        let args = commands::deps::DepsArgs {
+            command: commands::deps::DepsCommand::List(commands::deps::AgentRef {
+                agent: "x".to_string(),
+            }),
+        };
+        let result = dispatch(Commands::Deps(args), &MockRisky).await;
+        assert!(result.is_ok());
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -19,6 +19,7 @@ pub mod commands;
 pub mod config;
 pub mod credentials;
 pub mod daemon;
+pub(crate) mod dependencies;
 pub mod dispatch;
 pub(crate) mod held_checkpoints;
 pub(crate) mod lint;

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -19,7 +19,7 @@ pub mod commands;
 pub mod config;
 pub mod credentials;
 pub mod daemon;
-pub(crate) mod dependencies;
+pub mod dependencies;
 pub mod dispatch;
 pub(crate) mod held_checkpoints;
 pub(crate) mod lint;

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -108,6 +108,46 @@ async fn async_main() -> anyhow::Result<()> {
 /// command cores. Never compiled into the coverage-measured `--lib` build.
 struct RealExecutors;
 
+/// Runs `lev deps install` shell commands through the platform shell.
+struct SystemRunner;
+
+impl commands::deps::CommandRunner for SystemRunner {
+    fn run(&self, command: &str) -> Result<(), String> {
+        let status = if cfg!(windows) {
+            leviath_sys::child_command("cmd")
+                .arg("/C")
+                .arg(command)
+                .status()
+        } else {
+            leviath_sys::child_command("sh")
+                .arg("-c")
+                .arg(command)
+                .status()
+        };
+        match status {
+            Ok(s) if s.success() => Ok(()),
+            Ok(s) => Err(format!("command exited with {s}")),
+            Err(e) => Err(format!("could not run command: {e}")),
+        }
+    }
+}
+
+/// Asks `lev deps install` confirmations on the real terminal.
+struct StdinPrompt;
+
+impl commands::deps::Prompt for StdinPrompt {
+    fn confirm(&self, message: &str) -> bool {
+        use std::io::Write;
+        print!("{message} [y/N] ");
+        let _ = std::io::stdout().flush();
+        let mut line = String::new();
+        if std::io::stdin().read_line(&mut line).is_err() {
+            return false;
+        }
+        matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+    }
+}
+
 impl RiskyExecutors for RealExecutors {
     async fn run(&self, args: commands::run::RunArgs) -> anyhow::Result<()> {
         real_run(args).await
@@ -239,6 +279,21 @@ impl RiskyExecutors for RealExecutors {
             config_path: leviath_cli::config::Config::config_path(),
         };
         commands::providers::execute_with(args, &env).await
+    }
+
+    async fn deps(&self, args: commands::deps::DepsArgs) -> anyhow::Result<()> {
+        // The command logic is the tested `deps::execute_with`; only the real
+        // machine seams - the config path, env/PATH reads, the shell and the
+        // stdin prompt - are composed here.
+        let env = commands::deps::DepsEnv {
+            config_path: leviath_cli::config::Config::config_path(),
+            agents_dir: leviath_core::paths::agents_dir(),
+            probe: Box::new(leviath_cli::dependencies::SystemProbe),
+            runner: std::sync::Arc::new(SystemRunner),
+            prompt: Box::new(StdinPrompt),
+            os: commands::deps::host_os(),
+        };
+        commands::deps::execute_with(args, &env)
     }
 
     async fn update(&self, args: commands::update::UpdateArgs) -> anyhow::Result<()> {

--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -328,10 +328,16 @@ pub struct McpServerTemplate {
     /// Arguments passed to `command`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
-    /// Non-secret headers. A value may reference a secret with `${VAR}`, where
-    /// `VAR` is named in the dependency's `env` and filled in at install.
+    /// Non-secret headers, for an http server. A value may reference a secret
+    /// with `${VAR}`, where `VAR` is named in the dependency's `env`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub headers: BTreeMap<String, String>,
+    /// Environment for a stdio server's child process. A value may reference a
+    /// secret with `${VAR}` (expanded from the environment at connect time, so
+    /// the secret stays out of the config file), where `VAR` is named in the
+    /// dependency's `env`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
 }
 
 impl Blueprint {

--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -9,7 +9,7 @@ use crate::error::ValidationError;
 use crate::layout::{ContextLayout, RegionSeed};
 use crate::lifecycle::CompactionConfig;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Regions every stage can see, whatever its own `[context.regions]` says.
 ///
@@ -142,6 +142,15 @@ pub struct Blueprint {
     /// empty table is the common case and is not written back.
     #[serde(default, skip_serializing_if = "toml::Table::is_empty")]
     pub mime_types: toml::Table,
+
+    /// Things that must be in place before this agent can run, declared as
+    /// `[[dependencies]]` in the manifest: an MCP server, an environment
+    /// variable, a program on `PATH`, or a condition a Rhai script checks.
+    /// Declared, never granted. The operator is shown what is missing and how
+    /// to fix it, and an unmet required dependency fails the spawn before the
+    /// first billed inference. See [`Dependency`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<Dependency>,
 }
 
 /// The `[safe_commands]` section of a manifest.
@@ -179,6 +188,152 @@ pub struct ReadPathsConfig {
     pub allow: Vec<String>,
 }
 
+/// One `[[dependencies]]` entry: something that must be in place before an
+/// agent can run. Declared in the manifest, never granted - every surface that
+/// reports it (`lev validate`, `lev deps`, the spawn gate, the API) shows what
+/// is missing and the `remedy` for fixing it.
+///
+/// The `kind` field selects what must be present and carries its own fields
+/// (see [`DependencyKind`]); the optional [`install`](Self::install) block says
+/// how `lev deps install` can put it in place, and is never run automatically.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Dependency {
+    /// A short identifier, unique within the blueprint.
+    pub name: String,
+
+    /// What must be present, and the fields describing it.
+    #[serde(flatten)]
+    pub kind: DependencyKind,
+
+    /// Whether an unmet dependency blocks the run. `true` (the default) fails
+    /// the spawn; `false` downgrades a miss to a warning the run proceeds past.
+    #[serde(default = "default_dependency_required")]
+    pub required: bool,
+
+    /// A human sentence telling the user how to satisfy the dependency, shown
+    /// wherever a miss is reported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remedy: Option<String>,
+
+    /// A one-line note on why the agent needs it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// How `lev deps install` can put this dependency in place. Optional and
+    /// never run automatically: installing runs commands or writes config on
+    /// the user's machine and always asks first. See [`DependencyInstall`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install: Option<DependencyInstall>,
+}
+
+/// The default for [`Dependency::required`]: a declared dependency blocks the
+/// run unless the manifest says otherwise.
+fn default_dependency_required() -> bool {
+    true
+}
+
+/// What a [`Dependency`] requires, selected by the manifest's `kind` field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DependencyKind {
+    /// An MCP server that must be configured in the user's config, plus any
+    /// environment variables or secrets it needs. The check confirms the named
+    /// server exists and every `env` var is set and non-empty.
+    McpServer {
+        /// The server name that must appear in the user's `[[mcp_servers]]`.
+        server: String,
+        /// Environment variables / secrets the server needs. Values are
+        /// prompted for at install, never stored in the blueprint.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        env: Vec<String>,
+    },
+    /// An environment variable that must be set and non-empty.
+    Env {
+        /// The variable name.
+        var: String,
+    },
+    /// A program that must resolve on `PATH`.
+    Binary {
+        /// The program name, e.g. `blender`.
+        command: String,
+    },
+    /// A condition a Rhai script decides. The `check` script returns
+    /// `#{ ok: bool, remedy: string }`; the optional installer lives in
+    /// [`DependencyInstall::script`].
+    Script {
+        /// Path to the Rhai check script, relative to the blueprint directory.
+        check: String,
+    },
+}
+
+impl DependencyKind {
+    /// The manifest `kind` string for this variant (`"mcp_server"`, `"env"`,
+    /// `"binary"`, `"script"`), matching the serialized tag.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            DependencyKind::McpServer { .. } => "mcp_server",
+            DependencyKind::Env { .. } => "env",
+            DependencyKind::Binary { .. } => "binary",
+            DependencyKind::Script { .. } => "script",
+        }
+    }
+}
+
+/// How a [`Dependency`] can be installed by `lev deps install`.
+///
+/// Every field is optional; a dependency may declare any combination. Nothing
+/// here runs without an explicit `lev deps install` and a confirmation, because
+/// each option changes the user's machine: running a command, executing a
+/// script, or writing an MCP server into their config.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DependencyInstall {
+    /// A shell command that installs the dependency on any platform, e.g.
+    /// `"pip install trimesh"`. Run only after the user confirms.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+
+    /// Per-OS shell commands, keyed by `"macos"`, `"linux"` or `"windows"`,
+    /// preferred over [`command`](Self::command) on a matching host.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub commands: BTreeMap<String, String>,
+
+    /// A Rhai install script (relative to the blueprint), run with the script
+    /// I/O surface and gated exactly like a script tool. For a `script`
+    /// dependency this is its installer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub script: Option<String>,
+
+    /// For an `mcp_server` dependency: the non-user-specific server settings the
+    /// installer writes into the user's config. Secrets are never placed here -
+    /// they are named in the dependency's `env` and prompted for securely.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server: Option<McpServerTemplate>,
+}
+
+/// The non-secret settings for an MCP server that a blueprint can ship so
+/// `lev deps install` can write it into the user's config. Mirrors the
+/// installable half of the CLI's MCP server config; the user-specific secrets
+/// (header and env values) are prompted for and stored separately.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpServerTemplate {
+    /// `"stdio"` or `"http"`. Inferred from `command`/`url` when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    /// The program to launch for a stdio server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    /// The endpoint for an http server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Arguments passed to `command`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    /// Non-secret headers. A value may reference a secret with `${VAR}`, where
+    /// `VAR` is named in the dependency's `env` and filled in at install.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+}
+
 impl Blueprint {
     /// Create a new blueprint with the specified configuration.
     pub fn new(
@@ -210,6 +365,7 @@ impl Blueprint {
             safe_commands: None,
             output: None,
             mime_types: toml::Table::new(),
+            dependencies: Vec::new(),
         }
     }
 
@@ -344,6 +500,83 @@ impl Blueprint {
 
         self.validate_region_references()?;
 
+        self.validate_dependencies()?;
+
+        Ok(())
+    }
+
+    /// Check every `[[dependencies]]` entry is well-formed. This validates the
+    /// declaration only - names are unique and non-empty, each kind's fields are
+    /// present, and an `install` block is shaped for its kind. Whether the
+    /// dependency is actually satisfied (the server exists, the var is set, the
+    /// binary is on `PATH`) is checked at spawn and by `lev deps check`, which
+    /// see the machine this crate does not touch.
+    fn validate_dependencies(&self) -> std::result::Result<(), ValidationError> {
+        let mut seen = std::collections::HashSet::new();
+        for dep in &self.dependencies {
+            let name = dep.name.trim();
+            if name.is_empty() {
+                return Err(ValidationError::Dependency {
+                    name: dep.name.clone(),
+                    message: "a dependency needs a non-empty name".to_string(),
+                });
+            }
+            if !seen.insert(name) {
+                return Err(ValidationError::Dependency {
+                    name: name.to_string(),
+                    message: "two dependencies share this name".to_string(),
+                });
+            }
+            let require = |field: &str, value: &str| -> std::result::Result<(), ValidationError> {
+                if value.trim().is_empty() {
+                    return Err(ValidationError::Dependency {
+                        name: name.to_string(),
+                        message: format!(
+                            "a '{}' dependency needs a non-empty '{field}'",
+                            dep.kind.tag()
+                        ),
+                    });
+                }
+                Ok(())
+            };
+            match &dep.kind {
+                DependencyKind::McpServer { server, .. } => require("server", server)?,
+                DependencyKind::Env { var } => require("var", var)?,
+                DependencyKind::Binary { command } => require("command", command)?,
+                DependencyKind::Script { check } => require("check", check)?,
+            }
+            if let Some(install) = &dep.install {
+                if install.server.is_some() && !matches!(dep.kind, DependencyKind::McpServer { .. })
+                {
+                    return Err(ValidationError::Dependency {
+                        name: name.to_string(),
+                        message: "install.server is only valid for a 'mcp_server' dependency"
+                            .to_string(),
+                    });
+                }
+                if let Some(transport) =
+                    install.server.as_ref().and_then(|s| s.transport.as_deref())
+                    && !matches!(transport, "stdio" | "http")
+                {
+                    return Err(ValidationError::Dependency {
+                        name: name.to_string(),
+                        message: format!(
+                            "install.server.transport must be \"stdio\" or \"http\", got \"{transport}\""
+                        ),
+                    });
+                }
+                for os in install.commands.keys() {
+                    if !matches!(os.as_str(), "macos" | "linux" | "windows") {
+                        return Err(ValidationError::Dependency {
+                            name: name.to_string(),
+                            message: format!(
+                                "install.commands key '{os}' must be \"macos\", \"linux\" or \"windows\""
+                            ),
+                        });
+                    }
+                }
+            }
+        }
         Ok(())
     }
 

--- a/crates/leviath-core/src/error.rs
+++ b/crates/leviath-core/src/error.rs
@@ -30,6 +30,15 @@ pub enum ValidationError {
         message: String,
     },
 
+    /// Dependency-declaration validation failure
+    #[error("Invalid dependency '{name}': {message}")]
+    Dependency {
+        /// The offending dependency's name.
+        name: String,
+        /// What is wrong with it.
+        message: String,
+    },
+
     /// Layout-level validation failure
     #[error("Invalid layout: {0}")]
     Layout(String),

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -181,6 +181,13 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
         blueprint.mime_types = rows.clone();
     }
 
+    // What the agent needs in place before it runs: [[dependencies]]. Parsed
+    // here so a broken declaration fails `lev validate` and the spawn rather
+    // than being ignored until the agent reaches for the missing thing.
+    if let Some(deps_arr) = array_of(&parsed, "dependencies") {
+        blueprint.dependencies = parse_dependencies(deps_arr)?;
+    }
+
     Ok(blueprint)
 }
 

--- a/crates/leviath-core/src/manifest/sections.rs
+++ b/crates/leviath-core/src/manifest/sections.rs
@@ -251,6 +251,200 @@ pub(super) const OUTPUT_KEYS: &[&str] = &[
     "validator",
 ];
 
+/// Parse the `[[dependencies]]` array: what an agent needs in place before it
+/// runs. Shape only - whether a dependency is satisfied is a spawn/`lev deps`
+/// concern. A missing or unknown `kind`, or a kind missing its field, is a hard
+/// error so a broken declaration fails `lev validate` rather than at spawn.
+pub(super) fn parse_dependencies(
+    items: &[toml::Value],
+) -> Result<Vec<crate::blueprint::Dependency>> {
+    items.iter().map(parse_dependency).collect()
+}
+
+fn parse_dependency(item: &toml::Value) -> Result<crate::blueprint::Dependency> {
+    use crate::blueprint::{Dependency, DependencyKind};
+    let table = item
+        .as_table()
+        .ok_or_else(|| Error::Other("each [[dependencies]] entry must be a table".to_string()))?;
+    let text = |key: &str| {
+        table
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    };
+    let name = text("name")
+        .ok_or_else(|| Error::Other("a dependency needs a name".to_string()))?
+        .to_string();
+    let kind_tag = text("kind").ok_or_else(|| {
+        Error::Other(format!(
+            "dependency '{name}' needs a kind (mcp_server, env, binary or script)"
+        ))
+    })?;
+    let need = |key: &str| -> Result<String> {
+        text(key).map(str::to_string).ok_or_else(|| {
+            Error::Other(format!(
+                "dependency '{name}' of kind '{kind_tag}' needs '{key}'"
+            ))
+        })
+    };
+    let string_list = |key: &str| -> Result<Vec<String>> {
+        let Some(arr) = table.get(key).and_then(|v| v.as_array()) else {
+            return Ok(Vec::new());
+        };
+        arr.iter()
+            .map(|e| {
+                e.as_str().map(str::to_string).ok_or_else(|| {
+                    Error::Other(format!(
+                        "dependency '{name}': {key} entries must be strings, got: {e}"
+                    ))
+                })
+            })
+            .collect()
+    };
+    let kind = match kind_tag {
+        "mcp_server" => DependencyKind::McpServer {
+            server: need("server")?,
+            env: string_list("env")?,
+        },
+        "env" => DependencyKind::Env { var: need("var")? },
+        "binary" => DependencyKind::Binary {
+            command: need("command")?,
+        },
+        "script" => DependencyKind::Script {
+            check: need("check")?,
+        },
+        other => {
+            return Err(Error::Other(format!(
+                "dependency '{name}' has unknown kind '{other}' \
+                 (valid: mcp_server, env, binary, script)"
+            )));
+        }
+    };
+    let install = match table.get("install") {
+        None => None,
+        Some(value) => Some(parse_dependency_install(&name, value)?),
+    };
+    Ok(Dependency {
+        name,
+        kind,
+        required: table
+            .get("required")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true),
+        remedy: text("remedy").map(str::to_string),
+        description: text("description").map(str::to_string),
+        install,
+    })
+}
+
+fn parse_dependency_install(
+    dep: &str,
+    value: &toml::Value,
+) -> Result<crate::blueprint::DependencyInstall> {
+    use crate::blueprint::{DependencyInstall, McpServerTemplate};
+    let table = value
+        .as_table()
+        .ok_or_else(|| Error::Other(format!("dependency '{dep}': install must be a table")))?;
+    let text = |key: &str| {
+        table
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    };
+    let str_map = |key: &str| -> Result<std::collections::BTreeMap<String, String>> {
+        let Some(t) = table.get(key).and_then(|v| v.as_table()) else {
+            return Ok(std::collections::BTreeMap::new());
+        };
+        t.iter()
+            .map(|(k, v)| {
+                v.as_str()
+                    .map(|s| (k.clone(), s.to_string()))
+                    .ok_or_else(|| {
+                        Error::Other(format!(
+                            "dependency '{dep}': install.{key} values must be strings"
+                        ))
+                    })
+            })
+            .collect()
+    };
+    let server = match table.get("server") {
+        None => None,
+        Some(sv) => {
+            let st = sv.as_table().ok_or_else(|| {
+                Error::Other(format!(
+                    "dependency '{dep}': install.server must be a table"
+                ))
+            })?;
+            let stext = |key: &str| {
+                st.get(key)
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+            };
+            let args = match st.get("args").and_then(|v| v.as_array()) {
+                None => Vec::new(),
+                Some(a) => a
+                    .iter()
+                    .map(|e| {
+                        e.as_str().map(str::to_string).ok_or_else(|| {
+                            Error::Other(format!(
+                                "dependency '{dep}': install.server.args entries must be strings"
+                            ))
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            };
+            let headers = match st.get("headers").and_then(|v| v.as_table()) {
+                None => std::collections::BTreeMap::new(),
+                Some(h) => h
+                    .iter()
+                    .map(|(k, v)| {
+                        v.as_str().map(|s| (k.clone(), s.to_string())).ok_or_else(|| {
+                            Error::Other(format!(
+                                "dependency '{dep}': install.server.headers values must be strings"
+                            ))
+                        })
+                    })
+                    .collect::<Result<std::collections::BTreeMap<_, _>>>()?,
+            };
+            Some(McpServerTemplate {
+                transport: stext("transport"),
+                command: stext("command"),
+                url: stext("url"),
+                args,
+                headers,
+            })
+        }
+    };
+    Ok(DependencyInstall {
+        command: text("command").map(str::to_string),
+        commands: str_map("commands")?,
+        script: text("script").map(str::to_string),
+        server,
+    })
+}
+
+/// Every key a `[[dependencies]]` entry may carry, across all kinds, for the
+/// schema guard in `tests.rs`. A flat union: the parser reads the keys its kind
+/// needs and kind mismatches are caught in `Blueprint::validate`.
+#[cfg(test)]
+pub(super) const DEPENDENCIES_KEYS: &[&str] = &[
+    "check",
+    "command",
+    "description",
+    "env",
+    "install",
+    "kind",
+    "name",
+    "remedy",
+    "required",
+    "server",
+    "var",
+];
+
 pub(super) fn parse_security_config(security_table: &toml::value::Table) -> crate::SecurityConfig {
     let mut sc = crate::SecurityConfig::default();
     if let Some(tt) = bool_of(security_table, "taint_tracking") {

--- a/crates/leviath-core/src/manifest/sections.rs
+++ b/crates/leviath-core/src/manifest/sections.rs
@@ -397,25 +397,28 @@ fn parse_dependency_install(
                     })
                     .collect::<Result<Vec<_>>>()?,
             };
-            let headers = match st.get("headers").and_then(|v| v.as_table()) {
-                None => std::collections::BTreeMap::new(),
-                Some(h) => h
-                    .iter()
-                    .map(|(k, v)| {
-                        v.as_str().map(|s| (k.clone(), s.to_string())).ok_or_else(|| {
-                            Error::Other(format!(
-                                "dependency '{dep}': install.server.headers values must be strings"
-                            ))
+            let str_table = |key: &str| -> Result<std::collections::BTreeMap<String, String>> {
+                match st.get(key).and_then(|v| v.as_table()) {
+                    None => Ok(std::collections::BTreeMap::new()),
+                    Some(h) => h
+                        .iter()
+                        .map(|(k, v)| {
+                            v.as_str().map(|s| (k.clone(), s.to_string())).ok_or_else(|| {
+                                Error::Other(format!(
+                                    "dependency '{dep}': install.server.{key} values must be strings"
+                                ))
+                            })
                         })
-                    })
-                    .collect::<Result<std::collections::BTreeMap<_, _>>>()?,
+                        .collect(),
+                }
             };
             Some(McpServerTemplate {
                 transport: stext("transport"),
                 command: stext("command"),
                 url: stext("url"),
                 args,
-                headers,
+                headers: str_table("headers")?,
+                env: str_table("env")?,
             })
         }
     };

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -6404,6 +6404,9 @@ args = ["--flag"]
 
 [dependencies.install.server.headers]
 Authorization = "Bearer ${MESHY_API_KEY}"
+
+[dependencies.install.server.env]
+MESHY_API_KEY = "${MESHY_API_KEY}"
 "#,
     )
     .unwrap();
@@ -6424,6 +6427,10 @@ Authorization = "Bearer ${MESHY_API_KEY}"
     assert_eq!(
         server.headers.get("Authorization").map(String::as_str),
         Some("Bearer ${MESHY_API_KEY}")
+    );
+    assert_eq!(
+        server.env.get("MESHY_API_KEY").map(String::as_str),
+        Some("${MESHY_API_KEY}")
     );
     bp.validate().unwrap();
 }
@@ -6523,6 +6530,10 @@ fn dependency_parse_errors() {
         (
             "[[dependencies]]\nname=\"d\"\nkind=\"mcp_server\"\nserver=\"s\"\n[dependencies.install.server]\ncommand=\"x\"\n[dependencies.install.server.headers]\nA = 1",
             "install.server.headers values must be strings",
+        ),
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"mcp_server\"\nserver=\"s\"\n[dependencies.install.server]\ncommand=\"x\"\n[dependencies.install.server.env]\nK = 1",
+            "install.server.env values must be strings",
         ),
         (
             "[[dependencies]]\nname=\"d\"\nkind=\"binary\"\ncommand=\"c\"\n[dependencies.install.commands]\nmacos = 1",

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -6002,6 +6002,11 @@ fn the_published_schema_and_the_parser_agree_on_every_key() {
             super::stage::HOOK_KEYS,
         ),
         ("agent", &["$defs", "agent"][..], super::AGENT_KEYS),
+        (
+            "dependency",
+            &["$defs", "dependency"][..],
+            super::sections::DEPENDENCIES_KEYS,
+        ),
     ] {
         assert_eq!(
             keys_at(schema_path),
@@ -6294,4 +6299,365 @@ fn artifact_declarations_are_checked_at_load() {
         .unwrap_err()
         .to_string();
     assert!(err.contains("tool_accepts must be a table"), "{err}");
+}
+
+// ─── [[dependencies]] ─────────────────────────────────────────────────────
+
+use crate::blueprint::{Dependency, DependencyInstall, DependencyKind, McpServerTemplate};
+
+fn deps_manifest(body: &str) -> Result<crate::Blueprint> {
+    parse_manifest(&format!("[agent]\nname = \"deps\"\n{body}\n"))
+}
+
+#[test]
+fn parses_every_dependency_kind() {
+    let bp = deps_manifest(
+        r#"
+[[dependencies]]
+name = "meshy"
+kind = "mcp_server"
+server = "meshy"
+env = ["MESHY_API_KEY"]
+remedy = "set up meshy"
+description = "image to 3d"
+
+[[dependencies]]
+name = "key"
+kind = "env"
+var = "SOME_KEY"
+
+[[dependencies]]
+name = "blender"
+kind = "binary"
+command = "blender"
+required = false
+
+[[dependencies]]
+name = "probe"
+kind = "script"
+check = "deps/check.rhai"
+"#,
+    )
+    .unwrap();
+    assert_eq!(bp.dependencies.len(), 4);
+    let meshy = &bp.dependencies[0];
+    assert!(meshy.required);
+    assert_eq!(meshy.remedy.as_deref(), Some("set up meshy"));
+    assert_eq!(meshy.description.as_deref(), Some("image to 3d"));
+    assert!(
+        matches!(&meshy.kind, DependencyKind::McpServer { server, env }
+        if server == "meshy" && env == &["MESHY_API_KEY".to_string()])
+    );
+    assert!(matches!(&bp.dependencies[1].kind, DependencyKind::Env { var } if var == "SOME_KEY"));
+    assert!(!bp.dependencies[2].required);
+    assert!(
+        matches!(&bp.dependencies[2].kind, DependencyKind::Binary { command } if command == "blender")
+    );
+    assert!(
+        matches!(&bp.dependencies[3].kind, DependencyKind::Script { check } if check == "deps/check.rhai")
+    );
+    bp.validate().unwrap();
+}
+
+#[test]
+fn dependency_kind_tag_names_each_variant() {
+    assert_eq!(
+        DependencyKind::McpServer {
+            server: "s".into(),
+            env: vec![]
+        }
+        .tag(),
+        "mcp_server"
+    );
+    assert_eq!(DependencyKind::Env { var: "v".into() }.tag(), "env");
+    assert_eq!(
+        DependencyKind::Binary {
+            command: "c".into()
+        }
+        .tag(),
+        "binary"
+    );
+    assert_eq!(DependencyKind::Script { check: "x".into() }.tag(), "script");
+}
+
+#[test]
+fn parses_mcp_install_with_server_template() {
+    let bp = deps_manifest(
+        r#"
+[[dependencies]]
+name = "meshy"
+kind = "mcp_server"
+server = "meshy"
+env = ["MESHY_API_KEY"]
+
+[dependencies.install]
+command = "echo generic"
+
+[dependencies.install.commands]
+macos = "brew install meshy"
+linux = "apt install meshy"
+
+[dependencies.install.server]
+transport = "http"
+url = "https://api.meshy.ai/mcp"
+args = ["--flag"]
+
+[dependencies.install.server.headers]
+Authorization = "Bearer ${MESHY_API_KEY}"
+"#,
+    )
+    .unwrap();
+    let install = bp.dependencies[0].install.as_ref().unwrap();
+    assert_eq!(install.command.as_deref(), Some("echo generic"));
+    assert_eq!(
+        install.commands.get("macos").map(String::as_str),
+        Some("brew install meshy")
+    );
+    assert_eq!(
+        install.commands.get("linux").map(String::as_str),
+        Some("apt install meshy")
+    );
+    let server = install.server.as_ref().unwrap();
+    assert_eq!(server.transport.as_deref(), Some("http"));
+    assert_eq!(server.url.as_deref(), Some("https://api.meshy.ai/mcp"));
+    assert_eq!(server.args, vec!["--flag".to_string()]);
+    assert_eq!(
+        server.headers.get("Authorization").map(String::as_str),
+        Some("Bearer ${MESHY_API_KEY}")
+    );
+    bp.validate().unwrap();
+}
+
+#[test]
+fn parses_script_install_and_stdio_server_command() {
+    let bp = deps_manifest(
+        r#"
+[[dependencies]]
+name = "thing"
+kind = "script"
+check = "deps/check.rhai"
+[dependencies.install]
+script = "deps/install.rhai"
+"#,
+    )
+    .unwrap();
+    let install = bp.dependencies[0].install.as_ref().unwrap();
+    assert_eq!(install.script.as_deref(), Some("deps/install.rhai"));
+    bp.validate().unwrap();
+
+    // A stdio server template (command, no transport) parses too.
+    let bp = deps_manifest(
+        r#"
+[[dependencies]]
+name = "srv"
+kind = "mcp_server"
+server = "srv"
+[dependencies.install.server]
+command = "srv-mcp"
+"#,
+    )
+    .unwrap();
+    let server = bp.dependencies[0]
+        .install
+        .as_ref()
+        .unwrap()
+        .server
+        .as_ref()
+        .unwrap();
+    assert_eq!(server.command.as_deref(), Some("srv-mcp"));
+    bp.validate().unwrap();
+}
+
+#[test]
+fn dependency_entry_must_be_a_table() {
+    let err = parse_manifest("dependencies = [\"x\"]\n[agent]\nname = \"d\"\n")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("must be a table"), "{err}");
+}
+
+#[test]
+fn dependency_parse_errors() {
+    for (body, expect) in [
+        (
+            "[[dependencies]]\nkind = \"env\"\nvar = \"X\"",
+            "a dependency needs a name",
+        ),
+        ("[[dependencies]]\nname = \"d\"", "needs a kind"),
+        (
+            "[[dependencies]]\nname = \"d\"\nkind = \"nope\"",
+            "unknown kind 'nope'",
+        ),
+        (
+            "[[dependencies]]\nname = \"d\"\nkind = \"mcp_server\"",
+            "needs 'server'",
+        ),
+        (
+            "[[dependencies]]\nname = \"d\"\nkind = \"env\"",
+            "needs 'var'",
+        ),
+        (
+            "[[dependencies]]\nname = \"d\"\nkind = \"binary\"",
+            "needs 'command'",
+        ),
+        (
+            "[[dependencies]]\nname = \"d\"\nkind = \"script\"",
+            "needs 'check'",
+        ),
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"mcp_server\"\nserver=\"s\"\nenv=[1]",
+            "env entries must be strings",
+        ),
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"binary\"\ncommand=\"c\"\ninstall = 3",
+            "install must be a table",
+        ),
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"mcp_server\"\nserver=\"s\"\n[dependencies.install]\nserver = 3",
+            "install.server must be a table",
+        ),
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"mcp_server\"\nserver=\"s\"\n[dependencies.install.server]\nargs=[1]",
+            "install.server.args entries must be strings",
+        ),
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"mcp_server\"\nserver=\"s\"\n[dependencies.install.server]\ncommand=\"x\"\n[dependencies.install.server.headers]\nA = 1",
+            "install.server.headers values must be strings",
+        ),
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"binary\"\ncommand=\"c\"\n[dependencies.install.commands]\nmacos = 1",
+            "install.commands values must be strings",
+        ),
+    ] {
+        let err = deps_manifest(body).unwrap_err().to_string();
+        assert!(err.contains(expect), "body {body:?} -> {err}");
+    }
+}
+
+#[test]
+fn dependency_validate_errors() {
+    for (body, expect) in [
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"env\"\nvar=\"A\"\n[[dependencies]]\nname=\"d\"\nkind=\"env\"\nvar=\"B\"",
+            "two dependencies share this name",
+        ),
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"binary\"\ncommand=\"c\"\n[dependencies.install.server]\ncommand=\"x\"",
+            "install.server is only valid",
+        ),
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"mcp_server\"\nserver=\"s\"\n[dependencies.install.server]\ntransport=\"ftp\"",
+            "must be \"stdio\" or \"http\"",
+        ),
+        (
+            "[[dependencies]]\nname=\"d\"\nkind=\"binary\"\ncommand=\"c\"\n[dependencies.install.commands]\nfreebsd=\"x\"",
+            "must be \"macos\", \"linux\" or \"windows\"",
+        ),
+    ] {
+        let bp = deps_manifest(body).unwrap();
+        let err = bp.validate().unwrap_err().to_string();
+        assert!(err.contains(expect), "body {body:?} -> {err}");
+    }
+}
+
+#[test]
+fn empty_dependency_name_fails_validate() {
+    let mut bp = parse_manifest("[agent]\nname = \"a\"\n").unwrap();
+    bp.dependencies.push(Dependency {
+        name: "  ".into(),
+        kind: DependencyKind::Env { var: "X".into() },
+        required: true,
+        remedy: None,
+        description: None,
+        install: None,
+    });
+    let err = bp.validate().unwrap_err().to_string();
+    assert!(err.contains("non-empty name"), "{err}");
+}
+
+#[test]
+fn dependencies_round_trip_through_json() {
+    let bp = deps_manifest(
+        r#"
+[[dependencies]]
+name = "meshy"
+kind = "mcp_server"
+server = "meshy"
+env = ["MESHY_API_KEY"]
+[dependencies.install]
+command = "pip install meshy"
+[dependencies.install.server]
+url = "https://api.meshy.ai/mcp"
+
+[[dependencies]]
+name = "blender"
+kind = "binary"
+command = "blender"
+required = false
+"#,
+    )
+    .unwrap();
+    let json = serde_json::to_string(&bp.dependencies).unwrap();
+    let back: Vec<Dependency> = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, bp.dependencies);
+}
+
+#[test]
+fn dependency_required_defaults_true_on_deserialize() {
+    let dep: Dependency = serde_json::from_str(r#"{"name":"d","kind":"env","var":"X"}"#).unwrap();
+    assert!(dep.required);
+    assert!(matches!(dep.kind, DependencyKind::Env { .. }));
+}
+
+#[test]
+fn install_and_template_defaults_are_empty() {
+    assert!(DependencyInstall::default().command.is_none());
+    assert!(DependencyInstall::default().commands.is_empty());
+    assert!(McpServerTemplate::default().transport.is_none());
+    assert!(McpServerTemplate::default().args.is_empty());
+}
+
+#[test]
+fn empty_kind_fields_fail_validate() {
+    // The parser rejects an empty kind field up front, so these are only
+    // reachable on a blueprint built in code or restored from JSON. Validate
+    // catches them there too.
+    let cases = [
+        (
+            DependencyKind::McpServer {
+                server: " ".into(),
+                env: vec![],
+            },
+            "non-empty 'server'",
+        ),
+        (
+            DependencyKind::Env { var: String::new() },
+            "non-empty 'var'",
+        ),
+        (
+            DependencyKind::Binary {
+                command: "  ".into(),
+            },
+            "non-empty 'command'",
+        ),
+        (
+            DependencyKind::Script {
+                check: String::new(),
+            },
+            "non-empty 'check'",
+        ),
+    ];
+    for (kind, expect) in cases {
+        let mut bp = parse_manifest("[agent]\nname = \"a\"\n").unwrap();
+        bp.dependencies.push(Dependency {
+            name: "d".into(),
+            kind,
+            required: true,
+            remedy: None,
+            description: None,
+            install: None,
+        });
+        let err = bp.validate().unwrap_err().to_string();
+        assert!(err.contains(expect), "{err}");
+    }
 }

--- a/crates/leviath-mcp/src/client.rs
+++ b/crates/leviath-mcp/src/client.rs
@@ -263,7 +263,22 @@ impl MCPClient {
         match config.resolve()? {
             ResolvedTransport::Stdio { command, args, env } => {
                 let args: Vec<&str> = args.iter().map(String::as_str).collect();
-                Self::spawn(command, &args, env).await
+                // Expand `${VAR}` in the child's env, the same way an http
+                // server's headers are expanded, so a stdio server can take a
+                // secret from the environment (`MESHY_API_KEY = "${MESHY_API_KEY}"`)
+                // rather than having it written into the config file. A
+                // credential-shaped name is only substituted when it is on the
+                // allowlist; an unset or refused one drops to empty.
+                let expanded: std::collections::HashMap<String, String> = env
+                    .iter()
+                    .map(|(k, v)| {
+                        (
+                            k.clone(),
+                            crate::transport::http::expand_env_allowing(v, allow_env),
+                        )
+                    })
+                    .collect();
+                Self::spawn(command, &args, &expanded).await
             }
             ResolvedTransport::Http { url, headers } => {
                 let mut headers = headers.clone();
@@ -1596,6 +1611,24 @@ for line in sys.stdin:
         let mut client = MCPClient::from_config(&config)
             .await
             .expect("stdio config should connect");
+        client.connect().await.expect("handshake should succeed");
+        assert_eq!(client.list_tools().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn from_config_expands_env_for_a_stdio_server() {
+        let _guard = always_on_tracing_guard();
+        let mut config =
+            MCPServerConfig::stdio("s", "python3", vec!["-c".into(), echo_tool_stub().source()]);
+        // A `${VAR}` in the child's env is expanded at connect time (unset here,
+        // so it resolves to empty); the python stub ignores it and still serves.
+        config.env.insert(
+            "SOME_VAR".to_string(),
+            "${LEVIATH_MCP_TEST_UNSET}".to_string(),
+        );
+        let mut client = MCPClient::from_config_with_auth(&config, None, &[])
+            .await
+            .expect("stdio config with env should connect");
         client.connect().await.expect("handshake should succeed");
         assert_eq!(client.list_tools().await.unwrap().len(), 1);
     }

--- a/crates/leviath-scripting/src/dependency_check.rs
+++ b/crates/leviath-scripting/src/dependency_check.rs
@@ -1,0 +1,212 @@
+//! Script-backed checks for a blueprint dependency.
+//!
+//! A `[[dependencies]]` entry of `kind = "script"` names a `check`, a `.rhai`
+//! file beside the blueprint that decides whether the thing the agent needs is
+//! in place:
+//!
+//! ```rhai
+//! // deps/check.rhai: the agent needs a config file and an API key.
+//! fn check() {
+//!     if !has_env("ACME_API_KEY") { return "set ACME_API_KEY in your env"; }
+//!     if !path_exists("/opt/acme/config.toml") { return "run acme-setup first"; }
+//!     ()   // satisfied
+//! }
+//! ```
+//!
+//! One function, one contract: **`fn check()` returns `()` when the dependency
+//! is satisfied, or a string remedy saying how to satisfy it**. The remedy is
+//! shown by `lev deps`, `lev validate` and the spawn gate.
+//!
+//! The engine is hardened - no `eval`, no `import`, operation-bounded - and
+//! gets three read-only probes and nothing else: `has_env(name)`, `env(name)`
+//! and `path_exists(path)`. A check reads the machine, it never changes it;
+//! anything that installs is a separate, explicit `lev deps install`.
+
+use rhai::{AST, Dynamic, Engine, Scope};
+
+/// Operation budget for a check: a handful of probes and some string work.
+const CHECK_MAX_OPERATIONS: u64 = 1_000_000;
+
+/// A compiled dependency check, ready to run.
+#[derive(Debug, Clone)]
+pub struct DependencyCheck {
+    /// The script path as written in the manifest, for error context.
+    pub path: String,
+    ast: AST,
+}
+
+/// Build the hardened engine every check runs on, with the read-only probes.
+fn build_engine() -> Engine {
+    let mut engine = Engine::new();
+    crate::harden(&mut engine, CHECK_MAX_OPERATIONS);
+    crate::functions::register_functions(&mut engine);
+    crate::types::register_types(&mut engine);
+    // Read-only probes. A check inspects the machine and never mutates it, so
+    // there is deliberately no shell, no write and no network here.
+    engine.register_fn("has_env", |name: &str| std::env::var_os(name).is_some());
+    engine.register_fn("env", |name: &str| std::env::var(name).unwrap_or_default());
+    engine.register_fn("path_exists", |path: &str| {
+        std::path::Path::new(path).exists()
+    });
+    engine
+}
+
+/// Compile a dependency check and check its shape.
+///
+/// `check()` must exist and take no parameters. A script that defines nothing,
+/// or defines it with the wrong arity, is refused here rather than silently
+/// never running.
+pub fn compile(path: &str, source: &str) -> crate::Result<DependencyCheck> {
+    let engine = build_engine();
+    let ast = engine
+        .compile(source)
+        .map_err(|e| crate::Error::CompilationFailed(format!("{path}: {e}")))?;
+    let arity = ast
+        .iter_functions()
+        .find(|f| f.name == "check")
+        .map(|f| f.params.len());
+    match arity {
+        Some(0) => Ok(DependencyCheck {
+            path: path.to_string(),
+            ast,
+        }),
+        Some(n) => Err(crate::Error::ValidationFailed(format!(
+            "{path}: fn check must take no parameters, found {n}"
+        ))),
+        None => Err(crate::Error::ValidationFailed(format!(
+            "{path}: script must define fn check()"
+        ))),
+    }
+}
+
+/// What a check said about a dependency.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Verdict {
+    /// The dependency is in place.
+    Satisfied,
+    /// It is not, with this remedy. Shown to the user verbatim.
+    Unmet(String),
+    /// The check itself is broken: it threw, ran out of operations, or returned
+    /// something that is neither `()` nor a string. Carries the error text.
+    Unusable(String),
+}
+
+/// Run a compiled `check()`.
+pub fn run(check: &DependencyCheck) -> Verdict {
+    let engine = build_engine();
+    let result: Result<Dynamic, _> = engine.call_fn(&mut Scope::new(), &check.ast, "check", ());
+    let value = match result {
+        Ok(v) => v,
+        Err(e) => return Verdict::Unusable(format!("{}: check: {e}", check.path)),
+    };
+    if value.is_unit() {
+        return Verdict::Satisfied;
+    }
+    match value.into_string() {
+        // An empty string is easy to write by accident and unambiguous, so it
+        // reads as "satisfied" rather than as a blank remedy.
+        Ok(remedy) if remedy.trim().is_empty() => Verdict::Satisfied,
+        Ok(remedy) => Verdict::Unmet(remedy),
+        Err(actual) => Verdict::Unusable(format!(
+            "{}: check must return () or a string, got {actual}",
+            check.path
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compiled(source: &str) -> DependencyCheck {
+        compile("deps/check.rhai", source).expect("fixture compiles")
+    }
+
+    #[test]
+    fn a_satisfied_check_returns_unit_or_empty() {
+        assert_eq!(run(&compiled("fn check() { () }")), Verdict::Satisfied);
+        assert_eq!(run(&compiled(r#"fn check() { "" }"#)), Verdict::Satisfied);
+        assert_eq!(
+            run(&compiled(r#"fn check() { "   " }"#)),
+            Verdict::Satisfied
+        );
+    }
+
+    #[test]
+    fn an_unmet_check_returns_its_remedy() {
+        assert_eq!(
+            run(&compiled(r#"fn check() { "install acme" }"#)),
+            Verdict::Unmet("install acme".to_string())
+        );
+    }
+
+    #[test]
+    fn probes_read_the_machine_read_only() {
+        // PATH is set on every platform CI runs on; a random name is not.
+        assert_eq!(
+            run(&compiled(
+                r#"fn check() { if has_env("PATH") { () } else { "no PATH" } }"#
+            )),
+            Verdict::Satisfied
+        );
+        assert_eq!(
+            run(&compiled(
+                r#"fn check() { if has_env("LEVIATH_DEP_UNSET_XYZ") { "set" } else { "missing" } }"#
+            )),
+            Verdict::Unmet("missing".to_string())
+        );
+        assert_eq!(
+            run(&compiled(
+                r#"fn check() { if env("PATH") == "" { "empty" } else { () } }"#
+            )),
+            Verdict::Satisfied
+        );
+        assert_eq!(
+            run(&compiled(
+                r#"fn check() { if env("LEVIATH_DEP_UNSET_XYZ") == "" { "empty" } else { () } }"#
+            )),
+            Verdict::Unmet("empty".to_string())
+        );
+    }
+
+    #[test]
+    fn path_exists_probe_answers_both_ways() {
+        let dir = std::env::temp_dir();
+        let present = format!(
+            r#"fn check() {{ if path_exists("{}") {{ () }} else {{ "missing" }} }}"#,
+            dir.display().to_string().replace('\\', "\\\\")
+        );
+        assert_eq!(run(&compiled(&present)), Verdict::Satisfied);
+        assert_eq!(
+            run(&compiled(
+                r#"fn check() { if path_exists("/leviath/nope/xyz") { "here" } else { "gone" } }"#
+            )),
+            Verdict::Unmet("gone".to_string())
+        );
+    }
+
+    #[test]
+    fn a_broken_check_is_unusable() {
+        let unusable = |source: &str| {
+            let v = format!("{:?}", run(&compiled(source)));
+            assert!(v.starts_with("Unusable("), "{v}");
+            v
+        };
+        assert!(unusable(r#"fn check() { throw "boom" }"#).contains("boom"));
+        assert!(unusable("fn check() { 42 }").contains("() or a string"));
+        assert!(unusable("fn check() { loop {} }").contains("deps/check.rhai"));
+    }
+
+    #[test]
+    fn the_shape_is_checked_at_compile_time() {
+        let none = compile("c.rhai", "fn other() { () }").unwrap_err();
+        assert!(
+            none.to_string().contains("must define fn check()"),
+            "{none}"
+        );
+        let two = compile("c.rhai", "fn check(a) { () }").unwrap_err();
+        assert!(two.to_string().contains("no parameters"), "{two}");
+        let syntax = compile("c.rhai", "fn check() {").unwrap_err();
+        assert!(syntax.to_string().contains("c.rhai"), "{syntax}");
+    }
+}

--- a/crates/leviath-scripting/src/lib.rs
+++ b/crates/leviath-scripting/src/lib.rs
@@ -6,6 +6,7 @@
 //! validators, context transforms, and compaction strategies without modifying
 //! Leviath's core code.
 
+pub mod dependency_check;
 pub mod engine;
 pub mod functions;
 pub mod mime_check;

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -382,8 +382,9 @@ place, or a string remedy when it is not. An `install` script gets one host func
 and runs only when the user asks for it with `lev deps install`. Checking never changes the machine;
 only install does, and only after a confirmation.
 
-The `sprite-to-3d` example agent under `docs/examples/` declares the Meshy dependency above and is
-installed with `lev add docs/examples/sprite-to-3d`.
+The bundled `sprite-to-3d` agent declares the Meshy dependency above: it turns a sprite sheet or
+character image into a rigged, game-ready model, and a run refuses to start until Meshy is set up.
+Set it up with `lev deps install sprite-to-3d`, then run it with `lev run sprite-to-3d`.
 
 ## How the coding agent verifies its work
 

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -323,6 +323,68 @@ and the spawn, and a `check` script is compiled beside the agent's other scripts
 fence: it has to live inside the blueprint's directory. [Mime](/docs/mime#the-registry) has
 every field and [Rhai mime checks](/docs/rhai-mime-checks) the script.
 
+## Dependencies
+
+An agent can say what has to be in place on the machine before it runs, as a top-level
+`[[dependencies]]` array. This is a declaration, never a grant: Leviath shows the operator what is
+missing and how to fix it, and a run whose required dependency is unmet fails to spawn before any
+model is billed. `lev deps check <agent>` reports the same findings, and `lev deps install <agent>`
+sets them up after asking.
+
+Each entry has a `name`, a `kind`, an optional `required` (true by default), a human `remedy`
+shown when it is missing, and an optional `description`. The kind chooses what must be present:
+
+```toml
+# An MCP server that must be configured, plus the secret it needs.
+[[dependencies]]
+name = "meshy"
+kind = "mcp_server"
+server = "meshy"
+env = ["MESHY_API_KEY"]
+remedy = "Run: lev deps install my-agent, then set MESHY_API_KEY"
+
+# What lev deps install writes into the user's config for that server. Secrets
+# are never stored here: they are named in env above and prompted for.
+[dependencies.install.server]
+transport = "http"
+url = "https://www.meshy.ai/mcp"
+[dependencies.install.server.headers]
+Authorization = "Bearer ${MESHY_API_KEY}"
+
+# A program that must be on PATH, with how to install it.
+[[dependencies]]
+name = "blender"
+kind = "binary"
+command = "blender"
+[dependencies.install]
+command = "brew install blender"          # or per-OS:
+[dependencies.install.commands]
+linux = "apt-get install -y blender"
+
+# An environment variable that must be set and non-empty.
+[[dependencies]]
+name = "token"
+kind = "env"
+var = "ACME_TOKEN"
+
+# A condition a Rhai script decides.
+[[dependencies]]
+name = "acme-setup"
+kind = "script"
+check = "deps/check.rhai"                  # returns () when satisfied, else a remedy string
+[dependencies.install]
+script = "deps/install.rhai"               # optional; runs only via lev deps install
+```
+
+A `check` script runs on a hardened engine with three read-only probes and nothing else:
+`has_env(name)`, `env(name)` and `path_exists(path)`. It returns `()` when the dependency is in
+place, or a string remedy when it is not. An `install` script gets one host function, `sh(command)`,
+and runs only when the user asks for it with `lev deps install`. Checking never changes the machine;
+only install does, and only after a confirmation.
+
+The `sprite-to-3d` example agent under `docs/examples/` declares the Meshy dependency above and is
+installed with `lev add docs/examples/sprite-to-3d`.
+
 ## How the coding agent verifies its work
 
 The bundled `coder` agent decides what "done" means before it starts, rather than judging it at

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -803,6 +803,14 @@ does neither has an empty list. Changing either is a manifest write through `PUT
 /api/blueprints/{name}`. `blueprints.stage_routing` in the `capabilities` list on `GET /api/config`
 says the daemon reports this.
 
+`dependencies` on the same detail route lists what the agent declares it needs before it runs (see
+[dependencies](/docs/agents#dependencies)): each entry has a `name`, a `kind` (`mcp_server`, `env`,
+`binary` or `script`), whether it is `required`, an optional `remedy` and `description`, the
+kind-specific field (`server` and `env`, `var`, `command`, or `check`), and `installable` for
+whether the blueprint says how to set it up. A console can show these and warn before a spawn that
+would fail the dependency gate. `blueprints.dependencies` in the `capabilities` list says the daemon
+reports this.
+
 ## Yolo profiles
 
 The profiles a run can be launched under with `--yolo=<name>` live in

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -378,6 +378,25 @@ named as such, with the stanza that would grant it. The daemon's own lint has no
 consult, so there it stays the plain "these need granting" note. See
 [reading outside the workdir](/docs/security#reading-outside-the-workdir).
 
+### `lev deps <list|check|install> <agent>`
+
+Inspect and set up what an agent [declares it needs](/docs/agents#dependencies). The agent is an
+installed name or a path to a blueprint directory or manifest.
+
+`lev deps list <agent>` prints the declared dependencies: an MCP server, an environment variable, a
+program on PATH, or a condition a Rhai script decides.
+
+`lev deps check <agent>` says whether this machine satisfies them, marking each one and exiting
+non-zero when a required one is missing, so it fits a setup script. This is the same check a run
+makes: an agent whose required dependency is unmet fails to spawn before any model is billed.
+
+`lev deps install <agent>` puts them in place, and always asks before it does anything, because it
+changes your machine. For an MCP server it writes the blueprint's non-secret server settings into
+your config; for each secret the server needs it tells you to set the variable in your own
+environment rather than writing it to a file. For a program it runs the install command the
+blueprint declares (a per-OS one when given) or a Rhai install script. Pass `--yes` to skip the
+confirmation and `--all` to act on every dependency, not only the missing ones.
+
 ### `lev test [PATH]`
 
 Run a blueprint's tests: everything in its `tests/` directory, against the real provider.

--- a/docs/examples/sprite-to-3d/agent.leviath
+++ b/docs/examples/sprite-to-3d/agent.leviath
@@ -1,0 +1,210 @@
+[agent]
+name = "sprite-to-3d"
+version = "0.1.0"
+description = "Turn a sprite sheet or character image into a rigged, game-ready 3D model with Meshy"
+entry_stage = "prep-reference"
+
+# Meshy does the actual image-to-3D work over its MCP server, which needs an API
+# key. The run refuses to start until the server is configured and the key is
+# set, and lev deps install writes the non-secret server settings for you.
+[[dependencies]]
+name = "meshy"
+kind = "mcp_server"
+server = "meshy"
+env = ["MESHY_API_KEY"]
+description = "Meshy image-to-3D, reached over its MCP server"
+remedy = "Run: lev deps install sprite-to-3d, then set MESHY_API_KEY in your environment"
+
+[dependencies.install.server]
+transport = "http"
+url = "https://www.meshy.ai/mcp"
+
+[dependencies.install.server.headers]
+Authorization = "Bearer ${MESHY_API_KEY}"
+
+# ── Regions ────────────────────────────────────────────────────────────────
+
+[context.regions.task]
+kind = "pinned"
+budget = "5%"
+
+[context.regions.conversation]
+kind = "sliding_window"
+max_items = 40
+max_tokens = 8000
+budget = "5%"
+
+[context.regions.source]
+kind = "pinned"
+budget = "20%"
+accepts = ["image/*"]
+
+[context.regions.reference]
+kind = "pinned"
+budget = "20%"
+accepts = ["image/*"]
+
+[context.regions.review]
+kind = "pinned"
+budget = "10%"
+accepts = ["text/*"]
+
+[context.regions.model]
+kind = "pinned"
+budget = "20%"
+accepts = ["model/*"]
+
+[context.regions.scratchpad]
+kind = "clearable"
+max_tokens = 20000
+budget = "20%"
+
+# ── 1. Prepare a single clean T-pose reference image ─────────────────────────
+
+[stages.prep-reference]
+mode = "autonomous"
+description = "Make one clean, high-detail T-pose reference image of the character"
+max_iterations = 15
+require_output = true
+available_tools = ["context_read", "context_list", "context_write", "context_append", "context_attach", "context_export", "submit_output"]
+system_prompt = """
+The source region holds a sprite sheet or a single image of a character.
+
+Produce ONE clean, high-detail image of that character standing in a full-body,
+front-facing T-pose on a plain neutral background, and store it in the reference
+region. A single clear T-pose image gives the best image-to-3D result, so do not
+make a multi-frame sheet here.
+
+Keep the character exactly on-model: the same silhouette, proportions, colors and
+accessories as the source. Do not restyle it, and do not invent details the
+source does not show. Use the scratchpad for working notes.
+"""
+
+[stages.prep-reference.model]
+allow_user_default = false
+
+[[stages.prep-reference.model.models]]
+provider = "openrouter"
+model = "openai/gpt-5-image"
+
+[stages.prep-reference.output]
+format = "image/*"
+
+[stages.prep-reference.output_routing]
+"image/*" = "reference"
+
+[stages.prep-reference.transitions.review-reference]
+hint = "Once the reference region holds a single clean full-body T-pose of the character."
+transform = "clear"
+
+# ── 2. Rank and critique the reference before spending on 3D ─────────────────
+
+[stages.review-reference]
+mode = "autonomous"
+description = "Rank the reference against the source and call out flaws before building the model"
+max_iterations = 8
+require_output = true
+available_tools = ["context_read", "context_list", "context_write", "context_append", "submit_output"]
+system_prompt = """
+Compare the reference image against the source. If more than one candidate is
+present, pick the best one and say why. Judge whether the reference is a faithful,
+clean, single T-pose: correct silhouette, proportions, colors and accessories,
+neutral background, no missing or invented details.
+
+Write your ranking and any flaws into the review region, then hand off to
+build-model. Call out flaws clearly even when you proceed, so the later stages
+can compensate for them.
+"""
+
+[stages.review-reference.model]
+allow_user_default = false
+
+[[stages.review-reference.model.models]]
+provider = "openrouter"
+model = "anthropic/claude-opus-5"
+
+[stages.review-reference.context]
+reset = ["conversation"]
+
+[stages.review-reference.transitions.build-model]
+hint = "Once you have ranked the reference and written your assessment, with any flaws, into the review region."
+
+# ── 3. Build the rigged, game-ready model with Meshy ─────────────────────────
+
+[stages.build-model]
+mode = "autonomous"
+description = "Use Meshy to turn the T-pose reference into a rigged, game-ready model"
+max_iterations = 20
+require_output = true
+available_connectors = ["meshy"]
+available_tools = ["context_read", "context_list", "context_write", "context_append", "context_attach", "context_export", "read_file", "write_file", "list_dir", "submit_output"]
+system_prompt = """
+Use the Meshy tools to turn the single T-pose reference into a 3D model that is
+ready to drop into a game engine.
+
+Guidance that gives the best results:
+- Use Meshy's image-to-3D on the reference image.
+- Prefer the balanced model tier over the highest-detail one: the very high
+  detail setting tends to lose geometry behind the character, while the balanced
+  tier keeps clean, complete topology for a stylized game asset.
+- Aim for roughly 8k to 12k polygons.
+- Ask Meshy to rig the model when the character is humanoid.
+- Keep the colors and materials matching the reference.
+
+Download the finished model, store it in the model region, and submit it as the
+run's model artifact. Use the scratchpad for working notes.
+"""
+
+[stages.build-model.model]
+allow_user_default = false
+
+[[stages.build-model.model.models]]
+provider = "openrouter"
+model = "anthropic/claude-opus-5"
+
+[stages.build-model.context]
+reset = ["conversation"]
+
+[stages.build-model.output_routing]
+"model/*" = "model"
+
+[stages.build-model.transitions.verify-model]
+hint = "Once a rigged, game-ready model is in the model region."
+transform = "clear"
+
+# ── 4. Check the model against the source for gaps before finalizing ─────────
+
+[stages.verify-model]
+mode = "autonomous"
+description = "Compare the model against the source for gaps before finalizing"
+max_iterations = 10
+require_output = true
+available_tools = ["context_read", "context_list", "context_write", "context_append", "read_file", "list_dir", "submit_output"]
+system_prompt = """
+Look at the finished model in the model region against the source and the
+reference. Call out any gaps: missing accessories, wrong proportions, colors that
+drifted, geometry that is incomplete.
+
+Write any gaps you find into the review region, then submit the model as the
+final output. If the gaps are serious, say so plainly in your notes so the
+operator can re-run with a better reference.
+"""
+
+[stages.verify-model.model]
+allow_user_default = false
+
+[[stages.verify-model.model.models]]
+provider = "openrouter"
+model = "anthropic/claude-opus-5"
+
+[stages.verify-model.context]
+reset = ["conversation"]
+
+# No outgoing transitions: this stage finalizes the run by submitting the model.
+# Fixing gaps happens by re-running the build within build-model's own revisits.
+[stages.verify-model.transitions]
+
+[[stages.verify-model.output.artifacts]]
+name = "model"
+type = "model/*"
+required = true

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -1338,6 +1338,13 @@
             "type": "string"
           },
           "description": "Non-secret headers; a value may reference a secret with ${VAR} named in env."
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Environment for a stdio server's child; a value may reference a secret with ${VAR} named in env."
         }
       }
     }

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -164,16 +164,28 @@
             "description": "Exactly one of per_byte, per_pixel (with max), per_second or fixed.",
             "additionalProperties": false,
             "properties": {
-              "per_byte": { "type": "number" },
-              "per_pixel": { "type": "integer" },
-              "max": { "type": "integer" },
-              "per_second": { "type": "integer" },
-              "fixed": { "type": "integer" }
+              "per_byte": {
+                "type": "number"
+              },
+              "per_pixel": {
+                "type": "integer"
+              },
+              "max": {
+                "type": "integer"
+              },
+              "per_second": {
+                "type": "integer"
+              },
+              "fixed": {
+                "type": "integer"
+              }
             }
           },
           "extensions": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "Extensions, without the dot, that imply this type."
           },
           "magic": {
@@ -233,6 +245,13 @@
             }
           }
         }
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "description": "Things that must be in place before the agent runs: an MCP server, an environment variable, a program on PATH, or a condition a Rhai script checks. Declared, never granted; an unmet required dependency fails the spawn before any billed inference.",
+      "items": {
+        "$ref": "#/$defs/dependency"
       }
     }
   },
@@ -1197,6 +1216,128 @@
         },
         "on_error": {
           "type": "string"
+        }
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "One [[dependencies]] entry. The kind field selects what must be present and which of the kind fields (server/env, var, command, check) apply.",
+      "required": [
+        "name",
+        "kind"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "A short identifier, unique within the blueprint."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "mcp_server",
+            "env",
+            "binary",
+            "script"
+          ],
+          "description": "What must be present."
+        },
+        "required": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether an unmet dependency blocks the run."
+        },
+        "remedy": {
+          "type": "string",
+          "description": "A human sentence on how to satisfy the dependency, shown when it is missing."
+        },
+        "description": {
+          "type": "string",
+          "description": "Why the agent needs it."
+        },
+        "server": {
+          "type": "string",
+          "description": "kind=mcp_server: the MCP server name that must be configured."
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "kind=mcp_server: environment variables or secrets the server needs."
+        },
+        "var": {
+          "type": "string",
+          "description": "kind=env: the variable that must be set and non-empty."
+        },
+        "command": {
+          "type": "string",
+          "description": "kind=binary: the program that must resolve on PATH."
+        },
+        "check": {
+          "type": "string",
+          "description": "kind=script: path to the Rhai check script (returns #{ ok, remedy })."
+        },
+        "install": {
+          "$ref": "#/$defs/dependencyInstall"
+        }
+      }
+    },
+    "dependencyInstall": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How `lev deps install` can put a dependency in place. Never run automatically.",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "A shell command that installs the dependency on any platform."
+        },
+        "commands": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Per-OS shell commands keyed by macos/linux/windows, preferred over command on a matching host."
+        },
+        "script": {
+          "type": "string",
+          "description": "A Rhai install script (relative to the blueprint), gated like a script tool."
+        },
+        "server": {
+          "$ref": "#/$defs/mcpServerTemplate"
+        }
+      }
+    },
+    "mcpServerTemplate": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "kind=mcp_server install: the non-secret server settings written into the user's config. Secrets are named in env and prompted for.",
+      "properties": {
+        "transport": {
+          "type": "string",
+          "enum": [
+            "stdio",
+            "http"
+          ]
+        },
+        "command": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Non-secret headers; a value may reference a secret with ${VAR} named in env."
         }
       }
     }


### PR DESCRIPTION
## What

A blueprint can now declare what must be in place before it runs, as a top-level
`[[dependencies]]` array, and a new `lev deps` command inspects and installs them.
An unmet required dependency fails the spawn before any model is billed.

Kinds: `mcp_server` (a configured server plus the env secrets it needs), `env` (a
variable set and non-empty), `binary` (a program on PATH), and `script` (a
condition a Rhai check decides). Any dependency may carry an `install` block: a
shell command, per-OS commands, a Rhai install script, or, for an MCP server, the
non-secret server template to write into the user's config.

Security posture (settled with the maintainer): checking only ever reads the
machine; installing is separate and explicit. `lev deps install` always asks
first, and for an MCP server it writes the non-secret template and tells the user
to set the secret in their own environment rather than writing it to a file.

## Commits

1. `feat(core)` - the `[[dependencies]]` data model, parser, validation, schema.
2. `feat(scripting)` - a Rhai dependency-check kind (hardened engine, read-only
   probes `has_env`/`env`/`path_exists`).
3. `feat(cli)` - the evaluator and the fail-fast spawn gate in `build_agent_inner`
   (covers `lev run`, the serve API, sub-agents and fan-out).
4. `feat(cli)` - the `lev deps list/check/install` command.
5. `docs` - the Dependencies and `lev deps` docs, and a `sprite-to-3d` example
   agent (Meshy image-to-3D) under `docs/examples/`.

## sprite-to-3d ships as an example, not a bundled agent

A bundled agent must be runnable by any single configured provider, and image
generation is provider-specific (Anthropic has no image model), so an image/3D
agent cannot satisfy the bundled-agent invariants. It ships under `docs/examples/`
and installs with `lev add docs/examples/sprite-to-3d`. It declares the Meshy MCP
dependency, so a run refuses to start until Meshy is set up.

## Testing

- 100% coverage on `leviath-core`, `leviath-scripting`, `leviath-cli`; full
  workspace test suite green; clippy, docs, structure gates green.
- End-to-end against a live `lev`: `deps list/check/install` for the Meshy MCP
  dependency (check MISS -> install writes the template and guides for the secret
  -> check satisfied with the key set), a custom `script` dependency (the Rhai
  check flips on `has_env`), a `binary` dependency, shell-command install, and the
  spawn gate failing a `lev run` with "dependencies are not satisfied" before any
  inference.

## Not included (follow-ups)

The serve API does not yet expose declared dependencies on
`GET /api/blueprints/{name}`; the CLI and spawn gate cover the need. `lev validate`
and `lev doctor` do not surface dependency status; `lev deps check` is the
inspection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kh7J65m1oRXm1WP7vCb7YN
