### PR TITLE
feat: one shared source for model token limits (context + output)

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/new_run_inputs.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run_inputs.rs
@@ -197,8 +197,10 @@ impl Dashboard {
         self.new_run_inputs = blueprint
             .map(|bp| {
                 // Resolve each region's percentage budget against the entry
-                // model's window, so a slot knows the token room it really has.
-                let window = entry_stage_window(&bp, &config_path);
+                // stage's effective (smallest) model window, so a slot knows the
+                // token room it really has.
+                let cache_path = leviath_core::paths::capability_cache_path();
+                let window = entry_stage_window(&bp, &config_path, cache_path.as_deref());
                 let layout = bp.context_layout.resolved(window);
                 layout
                     .regions
@@ -444,26 +446,53 @@ fn fit(text: &str, room: usize) -> String {
     cut
 }
 
-/// The context window of the blueprint's entry stage, resolved offline: a
-/// `[model_capabilities]` override wins, else the compiled catalog, else the
-/// same 8192-token default the runtime falls back to. Region percentage budgets
-/// resolve against this, so the picker's token room matches what a run will get.
-fn entry_stage_window(blueprint: &leviath_core::blueprint::Blueprint, config_path: &Path) -> usize {
+/// The effective context window of the blueprint's entry stage, resolved
+/// offline: the **smallest** window across the stage's declared models, since a
+/// region's percentage budget must fit the tightest of them. Each model
+/// resolves through [`offline_model_window`]. Region percentage budgets resolve
+/// against this, so the picker's token room matches the tightest a run will get.
+fn entry_stage_window(
+    blueprint: &leviath_core::blueprint::Blueprint,
+    config_path: &Path,
+    cache_path: Option<&Path>,
+) -> usize {
     const DEFAULT_WINDOW: usize = 8192;
     let entry = blueprint.resolve_entry_stage_name();
-    let Some(model) = blueprint
+    let config = crate::config::Config::load_from_path_public(config_path).ok();
+    let cache = cache_path.and_then(leviath_providers::CapabilityCache::load);
+    // A missing entry stage and a stage that names no models both fold into an
+    // empty iterator, so both take the `unwrap_or` default without a dead arm.
+    blueprint
         .stages
         .iter()
         .find(|s| s.name == entry)
-        .and_then(|s| s.model.models.first())
-    else {
-        return DEFAULT_WINDOW;
-    };
-    // An override for this model, under either the `provider/model` or the bare
-    // `model` key, is the last word.
-    if let Ok(config) = crate::config::Config::load_from_path_public(config_path) {
-        let qualified = format!("{}/{}", model.provider, model.model);
-        for key in [qualified.as_str(), model.model.as_str()] {
+        .map(|s| &s.model.models)
+        .into_iter()
+        .flatten()
+        .map(|m| offline_model_window(&m.provider, &m.model, config.as_ref(), cache.as_ref()))
+        .min()
+        .unwrap_or(DEFAULT_WINDOW)
+}
+
+/// One model's context window, resolved without a network call, preferring the
+/// most authoritative source available:
+/// 1. a `[model_capabilities]` override in config (under `provider/model` or the
+///    bare `model` key),
+/// 2. the shared capability cache the daemon wrote from live listings (this is
+///    how an OpenRouter model absent from the compiled table gets its real
+///    window offline),
+/// 3. the compiled catalogue,
+/// 4. the same 8192-token default the runtime falls back to.
+fn offline_model_window(
+    provider: &str,
+    model: &str,
+    config: Option<&crate::config::Config>,
+    cache: Option<&leviath_providers::CapabilityCache>,
+) -> usize {
+    const DEFAULT_WINDOW: usize = 8192;
+    if let Some(config) = config {
+        let qualified = format!("{provider}/{model}");
+        for key in [qualified.as_str(), model] {
             if let Some(window) = config
                 .model_capabilities
                 .get(key)
@@ -473,8 +502,11 @@ fn entry_stage_window(blueprint: &leviath_core::blueprint::Blueprint, config_pat
             }
         }
     }
+    if let Some(window) = cache.and_then(|c| c.context_window(provider, model)) {
+        return window;
+    }
     crate::commands::models::builtin_model_windows()
-        .get(&(model.provider.clone(), model.model.clone()))
+        .get(&(provider.to_string(), model.to_string()))
         .copied()
         .unwrap_or(DEFAULT_WINDOW)
 }
@@ -908,12 +940,12 @@ mod tests {
             .copied()
             .expect("claude-sonnet-5 is in the catalog");
         let bp = super::super::graph::load_blueprint(agent_path).unwrap();
-        assert_eq!(entry_stage_window(&bp, &missing), builtin);
+        assert_eq!(entry_stage_window(&bp, &missing, None), builtin);
 
         // A stage that names no model falls back to the default window.
         let mut bp = super::super::graph::load_blueprint(agent_path).unwrap();
         bp.stages[0].model.models.clear();
-        assert_eq!(entry_stage_window(&bp, &missing), 8192);
+        assert_eq!(entry_stage_window(&bp, &missing, None), 8192);
 
         // A `[model_capabilities]` override for this model wins.
         let bp = super::super::graph::load_blueprint(agent_path).unwrap();
@@ -923,7 +955,7 @@ mod tests {
             "[model_capabilities.\"anthropic/claude-sonnet-5\"]\nmax_context_tokens = 4321\n",
         )
         .unwrap();
-        assert_eq!(entry_stage_window(&bp, &config), 4321);
+        assert_eq!(entry_stage_window(&bp, &config, None), 4321);
 
         // An unknown model, checked against a config that loads but has no entry
         // for it, falls past the override lookup to the catalog and then to the
@@ -931,14 +963,60 @@ mod tests {
         let mut bp = super::super::graph::load_blueprint(agent_path).unwrap();
         bp.stages[0].model.models[0].provider = "acme".to_string();
         bp.stages[0].model.models[0].model = "mystery".to_string();
-        assert_eq!(entry_stage_window(&bp, &config), 8192);
+        assert_eq!(entry_stage_window(&bp, &config, None), 8192);
 
         // A config file that cannot be parsed is ignored, and the window comes
         // from the catalog.
         let bp = super::super::graph::load_blueprint(agent_path).unwrap();
         let bad = dir.path().join("bad.toml");
         std::fs::write(&bad, "this is not [valid toml").unwrap();
-        assert_eq!(entry_stage_window(&bp, &bad), builtin);
+        assert_eq!(entry_stage_window(&bp, &bad, None), builtin);
+
+        // The shared capability cache supplies a window for a model absent from
+        // the compiled table - the offline OpenRouter case #810 is about.
+        let mut bp = super::super::graph::load_blueprint(agent_path).unwrap();
+        bp.stages[0].model.models[0].provider = "openrouter".to_string();
+        bp.stages[0].model.models[0].model = "x-ai/grok-4".to_string();
+        let cache_file = dir.path().join("model_capabilities.json");
+        let cache = {
+            let mut c = leviath_providers::CapabilityCache::new(1);
+            c.set(
+                "openrouter",
+                std::collections::BTreeMap::from([(
+                    "x-ai/grok-4".to_string(),
+                    leviath_providers::LearnedModel {
+                        max_context_tokens: Some(256_000),
+                        ..Default::default()
+                    },
+                )]),
+            );
+            c
+        };
+        cache.save(&cache_file).unwrap();
+        assert_eq!(
+            entry_stage_window(&bp, &missing, Some(&cache_file)),
+            256_000
+        );
+        // A cache path that does not exist loads nothing and falls to the
+        // default.
+        let no_cache = dir.path().join("absent.json");
+        assert_eq!(entry_stage_window(&bp, &missing, Some(&no_cache)), 8192);
+
+        // The smallest window across several models wins: a second, narrower
+        // model pulls the effective window down.
+        let mut bp = super::super::graph::load_blueprint(agent_path).unwrap();
+        bp.stages[0].model.models[0].provider = "anthropic".to_string();
+        bp.stages[0].model.models[0].model = "claude-sonnet-5".to_string();
+        bp.stages[0]
+            .model
+            .models
+            .push(leviath_core::blueprint::ModelEntry::new(
+                "acme".to_string(),
+                "tiny".to_string(),
+            ));
+        // acme/tiny is unknown everywhere → 8192, smaller than the sonnet
+        // window, so it is the effective window.
+        assert_eq!(entry_stage_window(&bp, &missing, None), 8192);
     }
 
     /// A choice that would not fit the region's token budget stops the start

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -175,6 +175,16 @@ pub(crate) async fn setup_daemon_host_with(
             &[config.default_provider.as_str()],
         )
         .await;
+    // Write what the prime learned to the shared capability cache, so a
+    // short-lived `lev models`, `lev validate` or serve handler answers a
+    // model's real limits from the same numbers instead of re-priming to its own
+    // conservative default. Best-effort: a home that does not resolve (path is
+    // `None`), or a file that cannot be written, just leaves the pre-cache
+    // behaviour in place.
+    providers.save_capability_cache(
+        leviath_core::paths::capability_cache_path().as_deref(),
+        chrono::Utc::now().timestamp(),
+    );
     // Keeps that registry in step with `config.toml` from here on: a run
     // started after a `lev setup`, a `PUT /api/config` or a hand edit resolves
     // against the providers the file names now, without a daemon restart.

--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -377,11 +377,18 @@ impl Blueprint {
     ///
     /// Its own `[context.regions]` when it declares one, the blueprint's
     /// otherwise, plus the regions the runtime carries visible whatever a stage
-    /// says. Narrower than [`known_region_names`](Self::known_region_names),
-    /// which asks only whether a name exists somewhere - the difference being
+    /// says. Narrower than `known_region_names`, which asks only whether a name
+    /// exists somewhere - the difference being
     /// that a region another stage declares exists, and is still not readable
     /// from here.
-    fn regions_visible_to<'a>(&'a self, stage: &'a Stage) -> std::collections::HashSet<&'a str> {
+    ///
+    /// Public so the runtime can size each region's percentage budget against
+    /// the smallest window among the stages that actually see it - a region a
+    /// narrow-window stage never reads must not be shrunk to fit that stage.
+    pub fn regions_visible_to<'a>(
+        &'a self,
+        stage: &'a Stage,
+    ) -> std::collections::HashSet<&'a str> {
         let layout = stage
             .context_layout
             .as_ref()

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -250,12 +250,25 @@ impl ContextLayout {
             );
         }
 
-        // Ensure the layout leaves a minimum working budget once the fixed,
-        // non-evictable regions are full. Pinned / HashMap / CompactHistory
-        // regions persist for the whole run and consume budget; if they leave
-        // too little room, the conversation/tool-result (evictable) regions have
-        // almost no space and the agent operates "blind". Fail loudly at load
-        // instead of degrading silently at runtime.
+        // Ensure the fixed, non-evictable regions leave working room, judged
+        // against the whole budget.
+        self.validate_working_room(self.total_budget_tokens)
+    }
+
+    /// Fail when the fixed (non-evictable) regions would leave less than
+    /// `MIN_WORKING_TOKENS` of `window` for the evictable ones.
+    ///
+    /// Split out from [`validate`](Self::validate) so a caller can judge each
+    /// stage against that stage's own context window over just the regions it
+    /// can see, rather than one window for the whole layout: a region budgeted
+    /// against a wide-window stage must not be counted against a narrow-window
+    /// stage that never sees it. Pinned / HashMap / CompactHistory / persistent
+    /// custom regions persist for the whole run and consume budget; if they
+    /// leave too little, the evictable regions operate "blind", so fail loudly
+    /// at load instead of degrading silently at runtime. The floor is only
+    /// enforced on realistically-sized windows (`BUDGET_CHECK_MIN_TOTAL`); a toy
+    /// fixture's tiny window is left alone.
+    pub fn validate_working_room(&self, window: usize) -> std::result::Result<(), ValidationError> {
         let fixed_tokens: usize = self
             .regions
             .iter()
@@ -272,25 +285,17 @@ impl ContextLayout {
                 )
             })
             .fold(0usize, |acc, r| acc.saturating_add(r.max_tokens));
-        // Only enforce the absolute working-budget floor on realistically-sized
-        // layouts. Tiny illustrative layouts (toy examples, unit-test fixtures)
-        // have small budgets by design and are not real agent runs; applying an
-        // absolute floor to them would be nonsensical.
-        let working_tokens = self.total_budget_tokens.saturating_sub(fixed_tokens);
-        if self.total_budget_tokens >= Self::BUDGET_CHECK_MIN_TOTAL
-            && working_tokens < Self::MIN_WORKING_TOKENS
-        {
+        let working_tokens = window.saturating_sub(fixed_tokens);
+        if window >= Self::BUDGET_CHECK_MIN_TOTAL && working_tokens < Self::MIN_WORKING_TOKENS {
             return Err(ValidationError::Layout(format!(
                 "context layout leaves only {working_tokens} working tokens after fixed \
                  regions (pinned/hashmap/compact_history/persistent custom) consume \
-                 {fixed_tokens} of the {} \
-                 total budget; at least {} are needed for the agent to operate. Reduce the \
-                 fixed regions' max_tokens or increase the total budget.",
-                self.total_budget_tokens,
+                 {fixed_tokens} of the {window} \
+                 window; at least {} are needed for the agent to operate. Reduce the \
+                 fixed regions' max_tokens or increase the window.",
                 Self::MIN_WORKING_TOKENS
             )));
         }
-
         Ok(())
     }
 
@@ -370,6 +375,90 @@ impl ContextLayout {
             regions,
             total_budget_tokens,
             eviction_order: self.eviction_order.clone(),
+        }
+    }
+
+    /// Like [`resolved`](Self::resolved), but each region's percentage budget
+    /// is sized against a window chosen per region rather than one window for
+    /// the whole layout.
+    ///
+    /// `window_for(region_name)` gives the window a region is budgeted against:
+    /// the caller passes the smallest context window among the stages that can
+    /// actually see that region, so a region used only in wide-window stages
+    /// keeps a wide budget even when a narrow-window stage exists that never
+    /// sees it. The layout's `total_budget_tokens` becomes the largest of those
+    /// per-region windows; the authoritative fit check is per stage, done by the
+    /// caller against each stage's own window over the regions it sees.
+    ///
+    /// An absolute layout has nothing to resolve, so this is a no-op for it, the
+    /// same as [`resolved`](Self::resolved).
+    pub fn resolved_per_region(&self, window_for: &dyn Fn(&str) -> usize) -> ContextLayout {
+        let regions: Vec<RegionDefinition> = self
+            .regions
+            .iter()
+            .map(|r| {
+                let window = window_for(&r.name);
+                let max_tokens = r.budget.resolve(window);
+                let kind = match &r.kind {
+                    RegionKind::Compacting { threshold_tokens } => RegionKind::Compacting {
+                        threshold_tokens: Self::resolve_compacting_threshold(
+                            r.compact_at,
+                            *threshold_tokens,
+                            max_tokens,
+                        ),
+                    },
+                    other => other.clone(),
+                };
+                RegionDefinition {
+                    kind,
+                    max_tokens,
+                    budget: BudgetSpec::Absolute(max_tokens),
+                    compact_at: None,
+                    ..r.clone()
+                }
+            })
+            .collect();
+
+        let total_budget_tokens = if self.has_percent_budgets() {
+            self.regions
+                .iter()
+                .map(|r| window_for(&r.name))
+                .max()
+                .unwrap_or(self.total_budget_tokens)
+        } else {
+            self.total_budget_tokens
+        };
+
+        ContextLayout {
+            regions,
+            total_budget_tokens,
+            eviction_order: self.eviction_order.clone(),
+        }
+    }
+
+    /// A copy holding only the regions (and eviction-order entries) whose name
+    /// satisfies `keep`.
+    ///
+    /// The runtime carries some always-visible regions (conversation, tool
+    /// results) that no layout declares, so a stage's visible-region set may
+    /// name regions absent here; those are simply not present in the result.
+    /// Used to judge a stage's working room over exactly the regions it can see,
+    /// rather than every region the layout declares.
+    pub fn retaining<F: Fn(&str) -> bool>(&self, keep: F) -> ContextLayout {
+        ContextLayout {
+            regions: self
+                .regions
+                .iter()
+                .filter(|r| keep(&r.name))
+                .cloned()
+                .collect(),
+            total_budget_tokens: self.total_budget_tokens,
+            eviction_order: self
+                .eviction_order
+                .iter()
+                .filter(|n| keep(n))
+                .cloned()
+                .collect(),
         }
     }
 
@@ -852,6 +941,27 @@ mod tests {
         });
     }
 
+    #[test]
+    fn validate_working_room_judges_fixed_regions_against_the_passed_window() {
+        // The same layout passes against a wide window and fails against a
+        // narrow one: the fixed region is fine when the stage seeing it has room
+        // and starves the working budget when the stage's window is small. This
+        // is what lets each stage be judged against its own model's window over
+        // just the regions it can see.
+        let regions = vec![
+            RegionDefinition::new("task".to_string(), RegionKind::Pinned, 30_000),
+            RegionDefinition::new("work".to_string(), RegionKind::Temporary, 10_000),
+        ];
+        let layout = ContextLayout::new(regions, 200_000);
+        with_tracing(|| {
+            assert!(layout.validate_working_room(200_000).is_ok());
+            let err = layout.validate_working_room(32_000).unwrap_err();
+            assert!(err.to_string().contains("working tokens"), "{err}");
+            // A tiny (toy-sized) window below the check floor is left alone.
+            assert!(layout.validate_working_room(10_000).is_ok());
+        });
+    }
+
     fn custom_kind(script: &str, persistent: bool) -> RegionKind {
         RegionKind::Custom {
             script: script.to_string(),
@@ -1148,6 +1258,94 @@ mod tests {
         assert_eq!(resolved.total_budget_tokens, 1_000_000);
         // eviction order carried through.
         assert_eq!(resolved.eviction_order, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn resolved_per_region_sizes_each_region_against_its_own_window() {
+        let pct = || BudgetSpec::Percent {
+            percent: 0.10,
+            min: None,
+            max: None,
+        };
+        // A Compacting region whose threshold is a fraction of its resolved
+        // budget, so the per-region path must recompute it against the region's
+        // own window like `resolved()` does.
+        let mut compact = RegionDefinition::new(
+            "roll".to_string(),
+            RegionKind::Compacting {
+                threshold_tokens: usize::MAX,
+            },
+            0,
+        )
+        .with_budget(pct());
+        compact.compact_at = Some(0.5);
+        let layout = ContextLayout::new(
+            vec![
+                RegionDefinition::new("wide".to_string(), RegionKind::Pinned, 0).with_budget(pct()),
+                RegionDefinition::new("narrow".to_string(), RegionKind::Pinned, 0)
+                    .with_budget(pct()),
+                compact,
+            ],
+            0,
+        );
+        let resolved = layout.resolved_per_region(&|name| match name {
+            "wide" => 200_000,
+            _ => 32_768,
+        });
+        let max_of = |n: &str| {
+            resolved
+                .regions
+                .iter()
+                .find(|r| r.name == n)
+                .unwrap()
+                .max_tokens
+        };
+        assert_eq!(max_of("wide"), 20_000); // 10% of 200k
+        assert_eq!(max_of("narrow"), 3_277); // 10% of 32768, rounded
+        // roll: 10% of 32768 = 3277 budget; threshold = 50% of that, sized
+        // against the region's own window, not the widest.
+        assert_eq!(max_of("roll"), 3_277);
+        let roll = resolved.regions.iter().find(|r| r.name == "roll").unwrap();
+        assert!(
+            matches!(roll.kind, RegionKind::Compacting { threshold_tokens } if threshold_tokens == 1_639),
+            "compacting threshold resolved per region: {:?}",
+            roll.kind
+        );
+        // The total is the largest per-region window; the real fit check is per
+        // stage, done by the caller.
+        assert_eq!(resolved.total_budget_tokens, 200_000);
+
+        // An absolute layout has nothing to resolve, so this is a no-op.
+        let absolute = ContextLayout::new(
+            vec![RegionDefinition::new(
+                "x".to_string(),
+                RegionKind::Pinned,
+                5_000,
+            )],
+            5_000,
+        );
+        let same = absolute.resolved_per_region(&|_| 999_999);
+        assert_eq!(same.regions[0].max_tokens, 5_000);
+        assert_eq!(same.total_budget_tokens, 5_000);
+    }
+
+    #[test]
+    fn retaining_keeps_only_the_named_regions_and_eviction_entries() {
+        let layout = ContextLayout {
+            regions: vec![
+                RegionDefinition::new("keep".to_string(), RegionKind::Pinned, 1_000),
+                RegionDefinition::new("drop".to_string(), RegionKind::Temporary, 1_000),
+            ],
+            total_budget_tokens: 10_000,
+            eviction_order: vec!["keep".to_string(), "drop".to_string()],
+        };
+        let kept = layout.retaining(|name| name == "keep");
+        assert_eq!(kept.regions.len(), 1);
+        assert_eq!(kept.regions[0].name, "keep");
+        assert_eq!(kept.eviction_order, vec!["keep".to_string()]);
+        // total_budget rides along unchanged; the working-room check judges
+        // against a window the caller passes, not this field.
+        assert_eq!(kept.total_budget_tokens, 10_000);
     }
 
     #[test]

--- a/crates/leviath-core/src/paths.rs
+++ b/crates/leviath-core/src/paths.rs
@@ -54,6 +54,17 @@ pub fn agents_dir() -> Option<PathBuf> {
     data_dir().map(|d| d.join("agents"))
 }
 
+/// The shared on-disk model-capability cache: `<home>/.leviath/model_capabilities.json`.
+///
+/// One path so every surface reads and writes the same file - the daemon writes
+/// it after priming, and a short-lived `lev models`, `lev validate` or serve
+/// handler fills a freshly built registry from it instead of each re-priming to
+/// its own conservative default. Read and written through
+/// `leviath_providers::CapabilityCache`.
+pub fn capability_cache_path() -> Option<PathBuf> {
+    data_dir().map(|d| d.join("model_capabilities.json"))
+}
+
 /// Whether `name` is safe to use as a single path component.
 ///
 /// Accepts `[A-Za-z0-9._-]+` and nothing else. Everything a caller supplies as
@@ -170,6 +181,10 @@ mod tests {
             assert_eq!(tools_dir(), Some(data.join("tools")));
             assert_eq!(providers_dir(), Some(data.join("providers")));
             assert_eq!(agents_dir(), Some(data.join("agents")));
+            assert_eq!(
+                capability_cache_path(),
+                Some(data.join("model_capabilities.json"))
+            );
         });
     }
 

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -941,6 +941,10 @@ impl Provider for AnthropicProvider {
             .or_else(|| crate::pricing::published_rates("anthropic", model))
     }
 
+    fn learned_models(&self) -> Option<&crate::learned::LearnedModels> {
+        Some(&self.learned)
+    }
+
     fn capabilities(&self, model: &str) -> ModelCapabilities {
         // Three answers, narrowest first: what the user wrote, what the API
         // says, what this build was compiled with.
@@ -1099,6 +1103,7 @@ mod tests {
             overrides,
             None,
         );
+        assert!(provider.learned_models().is_some());
 
         // Configured: the operator's number, not the table's.
         let configured = provider.pricing("claude-opus-5").expect("configured");

--- a/crates/leviath-providers/src/capability_cache.rs
+++ b/crates/leviath-providers/src/capability_cache.rs
@@ -66,6 +66,27 @@ impl CapabilityCache {
         self.providers.get(provider)
     }
 
+    /// The context window a primed listing recorded for `model` under
+    /// `provider`, matched whole or by its last path segment.
+    ///
+    /// A gateway namespaces its ids (`x-ai/grok-4`) while a blueprint may name
+    /// the bare model, so both spellings find the entry - the same rule
+    /// [`LearnedModels::find_by_key`](crate::learned::LearnedModels::find_by_key)
+    /// uses. `None` when the cache holds no such model, or recorded no window
+    /// for it.
+    pub fn context_window(&self, provider: &str, model: &str) -> Option<usize> {
+        let models = self.providers.get(provider)?;
+        models
+            .get(model)
+            .or_else(|| {
+                models
+                    .iter()
+                    .find(|(id, _)| id.rsplit('/').next() == Some(model))
+                    .map(|(_, m)| m)
+            })
+            .and_then(|m| m.max_context_tokens)
+    }
+
     /// Its age in seconds at `now` (Unix seconds), saturating at 0 for a file
     /// stamped in the future (a clock that moved back).
     pub fn age_secs(&self, now: i64) -> i64 {
@@ -153,6 +174,40 @@ mod tests {
         std::fs::write(&file, "x").unwrap();
         let path = file.join("sub").join("cache.json");
         assert!(CapabilityCache::new(1).save(&path).is_err());
+    }
+
+    #[test]
+    fn context_window_matches_whole_or_by_last_segment() {
+        let mut cache = CapabilityCache::new(1);
+        cache.set(
+            "openrouter",
+            BTreeMap::from([
+                (
+                    "x-ai/grok-4".to_string(),
+                    LearnedModel {
+                        max_context_tokens: Some(256_000),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    // A model the listing named but recorded no window for.
+                    "vendor/no-window".to_string(),
+                    LearnedModel::default(),
+                ),
+            ]),
+        );
+        // Whole-id match.
+        assert_eq!(
+            cache.context_window("openrouter", "x-ai/grok-4"),
+            Some(256_000)
+        );
+        // Last-segment match: a blueprint naming the bare model still resolves.
+        assert_eq!(cache.context_window("openrouter", "grok-4"), Some(256_000));
+        // A model with no recorded window.
+        assert_eq!(cache.context_window("openrouter", "no-window"), None);
+        // An unknown model, and an unknown provider.
+        assert_eq!(cache.context_window("openrouter", "nope"), None);
+        assert_eq!(cache.context_window("anthropic", "x-ai/grok-4"), None);
     }
 
     #[test]

--- a/crates/leviath-providers/src/capability_cache.rs
+++ b/crates/leviath-providers/src/capability_cache.rs
@@ -1,0 +1,174 @@
+//! A shared on-disk cache of what each provider's live listing said about its
+//! models.
+//!
+//! Priming a provider means one network call to its `/models`-style endpoint,
+//! and it fills that provider's in-memory [`LearnedModels`](crate::learned).
+//! Only a long-lived process (the daemon) keeps that warm; every short-lived
+//! surface - `lev models`, `lev validate`, a serve handler, the dashboard - used
+//! to build its own provider registry and re-prime, and when its prime timed out
+//! it fell back to the compiled table's conservative defaults. So the same model
+//! reported one context window inside the daemon and another from `lev models
+//! show`.
+//!
+//! This is the shared source. The daemon writes it after a successful prime; any
+//! process fills a freshly built registry from it before running, so all of them
+//! answer a model's limits from the same numbers without each re-fetching. It is
+//! only ever a convenience over the network, never authoritative: a missing,
+//! unreadable, stale-versioned or out-of-date file just means "prime instead",
+//! which is exactly what happened before a cache existed.
+
+use crate::learned::LearnedModel;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// The on-disk format version. A file written by a newer or unrecognised
+/// version is ignored rather than misread.
+const CACHE_VERSION: u32 = 1;
+
+/// The primed catalogue of every provider, keyed by provider name then model id.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CapabilityCache {
+    /// The format version; a file whose version is not [`CACHE_VERSION`] is
+    /// treated as absent.
+    version: u32,
+    /// When it was written, Unix seconds, so a reader can judge staleness.
+    saved_at: i64,
+    /// provider name -> (model id -> what that provider's listing said).
+    providers: BTreeMap<String, BTreeMap<String, LearnedModel>>,
+}
+
+impl CapabilityCache {
+    /// An empty cache stamped `saved_at` (Unix seconds).
+    pub fn new(saved_at: i64) -> Self {
+        Self {
+            version: CACHE_VERSION,
+            saved_at,
+            providers: BTreeMap::new(),
+        }
+    }
+
+    /// The cache at `path`, or `None` when there is no readable, parseable file
+    /// of the current version. Never an error: `None` means "prime instead".
+    pub fn load(path: &Path) -> Option<Self> {
+        let text = std::fs::read_to_string(path).ok()?;
+        let cache: Self = serde_json::from_str(&text).ok()?;
+        (cache.version == CACHE_VERSION).then_some(cache)
+    }
+
+    /// Record one provider's primed catalogue, replacing any it held.
+    pub fn set(&mut self, provider: &str, models: BTreeMap<String, LearnedModel>) {
+        self.providers.insert(provider.to_string(), models);
+    }
+
+    /// One provider's catalogue, if the cache holds it.
+    pub fn get(&self, provider: &str) -> Option<&BTreeMap<String, LearnedModel>> {
+        self.providers.get(provider)
+    }
+
+    /// Its age in seconds at `now` (Unix seconds), saturating at 0 for a file
+    /// stamped in the future (a clock that moved back).
+    pub fn age_secs(&self, now: i64) -> i64 {
+        now.saturating_sub(self.saved_at).max(0)
+    }
+
+    /// Whether it is younger than `max_age_secs` at `now`.
+    pub fn is_fresh(&self, now: i64, max_age_secs: i64) -> bool {
+        self.age_secs(now) < max_age_secs
+    }
+
+    /// Write to `path` atomically, creating parent directories. The file is
+    /// world-unreadable (`0o600`): a primed listing can carry per-account
+    /// pricing, and a cache is not the place to widen who can read it.
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        // `map(...).transpose()?` rather than `if let Some`: the no-parent case
+        // is `None` flowing through, not a dead `else` arm a test must reach.
+        path.parent().map(std::fs::create_dir_all).transpose()?;
+        // Every field serializes, so this cannot fail; the fallible part is the
+        // file write below, which is what the caller's `Result` is for.
+        let json = serde_json::to_vec_pretty(self).expect("a CapabilityCache always serializes");
+        leviath_sys::write_atomic(path, &json, Some(0o600))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> CapabilityCache {
+        let mut cache = CapabilityCache::new(1_000);
+        cache.set(
+            "openrouter",
+            BTreeMap::from([(
+                "anthropic/claude-opus-5".to_string(),
+                LearnedModel {
+                    max_context_tokens: Some(200_000),
+                    max_output_tokens: Some(64_000),
+                    ..Default::default()
+                },
+            )]),
+        );
+        cache
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("caps").join("model_capabilities.json");
+        let cache = sample();
+        cache.save(&path).unwrap();
+        let loaded = CapabilityCache::load(&path).unwrap();
+        assert_eq!(loaded, cache);
+        assert_eq!(
+            loaded.get("openrouter").unwrap()["anthropic/claude-opus-5"].max_context_tokens,
+            Some(200_000)
+        );
+        assert!(loaded.get("anthropic").is_none());
+    }
+
+    #[test]
+    fn a_missing_or_unparseable_or_wrong_version_file_loads_as_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.json");
+        assert!(CapabilityCache::load(&missing).is_none());
+
+        let bad = dir.path().join("bad.json");
+        std::fs::write(&bad, "{not json").unwrap();
+        assert!(CapabilityCache::load(&bad).is_none());
+
+        let old = dir.path().join("old.json");
+        std::fs::write(
+            &old,
+            serde_json::json!({ "version": 999, "saved_at": 1, "providers": {} }).to_string(),
+        )
+        .unwrap();
+        assert!(CapabilityCache::load(&old).is_none());
+    }
+
+    #[test]
+    fn save_reports_the_io_error_when_a_parent_cannot_be_made() {
+        let dir = tempfile::tempdir().unwrap();
+        // A file sits where a directory would have to be, so create_dir_all fails.
+        let file = dir.path().join("in-the-way");
+        std::fs::write(&file, "x").unwrap();
+        let path = file.join("sub").join("cache.json");
+        assert!(CapabilityCache::new(1).save(&path).is_err());
+    }
+
+    #[test]
+    fn set_replaces_a_providers_entry() {
+        let mut cache = sample();
+        cache.set("openrouter", BTreeMap::new());
+        assert!(cache.get("openrouter").unwrap().is_empty());
+    }
+
+    #[test]
+    fn age_and_freshness_read_the_clock_the_caller_passes() {
+        let cache = CapabilityCache::new(1_000);
+        assert_eq!(cache.age_secs(1_600), 600);
+        // A clock that moved back never reports a negative age.
+        assert_eq!(cache.age_secs(900), 0);
+        assert!(cache.is_fresh(1_600, 3_600));
+        assert!(!cache.is_fresh(5_000, 3_600));
+    }
+}

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -375,6 +375,10 @@ impl Provider for GeminiProvider {
             .or_else(|| crate::pricing::published_rates("google", model))
     }
 
+    fn learned_models(&self) -> Option<&crate::learned::LearnedModels> {
+        Some(&self.learned)
+    }
+
     fn capabilities(&self, model: &str) -> ModelCapabilities {
         let base = self
             .learned
@@ -616,6 +620,7 @@ mod tests {
             overrides,
             None,
         );
+        assert!(provider.learned_models().is_some());
 
         // Configured: the operator's number, not the table's.
         let configured = provider.pricing("gemini-3.5-flash").expect("configured");

--- a/crates/leviath-providers/src/learned.rs
+++ b/crates/leviath-providers/src/learned.rs
@@ -19,14 +19,19 @@
 use crate::capabilities::{LimitsSource, ModelCapabilities};
 use crate::pricing::ModelPricing;
 use crate::provider::ModelInfo;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 /// One model as its provider's listing described it.
 ///
 /// See the module doc for what `None` means. Not `Eq` because a rate is an
-/// `f64`.
-#[derive(Debug, Clone, Default, PartialEq)]
+/// `f64`. `Serialize`/`Deserialize` so a primed catalogue can be written to a
+/// shared on-disk cache and read back by a process that did not prime it;
+/// `#[serde(default)]` so a field this build added is a missing key, not a
+/// parse error, when it reads a cache an older build wrote.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct LearnedModel {
     /// The name the provider shows people, when it publishes one.
     pub display_name: Option<String>,
@@ -108,6 +113,15 @@ impl LearnedModels {
     /// Replace the whole catalogue with what a listing just said.
     pub fn replace(&self, models: HashMap<String, LearnedModel>) {
         *leviath_core::sync::lock(&self.0) = models;
+    }
+
+    /// A copy of the whole catalogue, for writing to the shared cache. Sorted
+    /// into a `BTreeMap` so two saves of the same data produce the same bytes.
+    pub fn snapshot(&self) -> std::collections::BTreeMap<String, LearnedModel> {
+        leviath_core::sync::lock(&self.0)
+            .iter()
+            .map(|(id, m)| (id.clone(), m.clone()))
+            .collect()
     }
 
     /// What the listing said about `id`, if it mentioned it.
@@ -380,6 +394,14 @@ mod tests {
                 .max_context_tokens,
             1_050_000
         );
+    }
+
+    #[test]
+    fn snapshot_copies_the_whole_catalogue_sorted() {
+        let snap = store().snapshot();
+        let keys: Vec<&str> = snap.keys().map(String::as_str).collect();
+        assert_eq!(keys, ["claude-sonnet-5", "openai/gpt-5.5"]);
+        assert_eq!(snap["openai/gpt-5.5"].max_context_tokens, Some(1_050_000));
     }
 
     #[test]

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod anthropic;
 pub mod capabilities;
+pub mod capability_cache;
 pub mod claude_code;
 pub mod codex;
 #[cfg(feature = "debug-http")]
@@ -40,6 +41,7 @@ mod test_support;
 
 pub use anthropic::AnthropicProvider;
 pub use capabilities::{LimitsSource, ModelCapabilities, ModelCapabilityOverride, ModelMime};
+pub use capability_cache::CapabilityCache;
 pub use claude_code::ClaudeCodeProvider;
 pub use codex::{CodexProvider, ProviderAuthStore, ProviderGrant};
 pub use endpoint::EndpointProvider;

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -737,6 +737,10 @@ impl Provider for OllamaProvider {
         Some(crate::ModelPricing::flat(0.0, 0.0))
     }
 
+    fn learned_models(&self) -> Option<&crate::learned::LearnedModels> {
+        Some(&self.learned)
+    }
+
     fn capabilities(&self, model: &str) -> ModelCapabilities {
         // Three answers, narrowest first: what the user wrote, what the server
         // says, what this build was compiled with.
@@ -1021,6 +1025,7 @@ mod tests {
         let provider = OllamaProvider::new(
             crate::provider::build_http_client(None).expect("a test client builds"),
         );
+        assert!(provider.learned_models().is_some());
         let p = provider.pricing("qwen3.5:9b").expect("a known zero");
         assert_eq!(p.input_per_mtok, 0.0);
         assert_eq!(p.output_per_mtok, 0.0);

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -441,6 +441,10 @@ impl Provider for OpenAIProvider {
             .or_else(|| crate::pricing::published_rates("openai", model))
     }
 
+    fn learned_models(&self) -> Option<&crate::learned::LearnedModels> {
+        Some(&self.learned)
+    }
+
     fn capabilities(&self, model: &str) -> ModelCapabilities {
         // The listing says nothing about size or shape (see
         // `prime_capabilities`), so the table is the base and the operator's
@@ -604,6 +608,7 @@ mod tests {
             overrides,
             None,
         );
+        assert!(provider.learned_models().is_some());
 
         // Configured: the operator's number, not the table's.
         let configured = provider.pricing("gpt-5.5").expect("configured");

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -688,6 +688,10 @@ impl Provider for OpenRouterProvider {
         "openrouter"
     }
 
+    fn learned_models(&self) -> Option<&crate::learned::LearnedModels> {
+        Some(&self.learned)
+    }
+
     fn capabilities(&self, model: &str) -> ModelCapabilities {
         // Three answers, narrowest first: what the user wrote, what OpenRouter
         // says, what this build was compiled with.
@@ -870,6 +874,7 @@ mod tests {
             crate::provider::build_http_client(None).expect("a test client builds"),
             "k".to_string(),
         );
+        assert!(p.learned_models().is_some());
         assert_eq!(p.pricing("x-ai/grok-4.6"), None);
     }
     use super::*;

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -1032,6 +1032,17 @@ pub trait Provider: Send + Sync {
         None
     }
 
+    /// This provider's primed catalogue, so a registry can read it into the
+    /// shared on-disk cache after priming and fill it from that cache on a
+    /// build that has not primed.
+    ///
+    /// `None` for a provider that keeps no learned store: a script provider,
+    /// and any whose listing this build never reads. Such a provider answers
+    /// from its compiled table either way, so there is nothing to cache.
+    fn learned_models(&self) -> Option<&crate::learned::LearnedModels> {
+        None
+    }
+
     /// Why this provider will not serve `model_key`, when it has something
     /// more useful to say than "it is not in my catalogue".
     ///
@@ -2162,6 +2173,9 @@ mod tests {
             .prime_capabilities()
             .await
             .expect("a provider that needs no priming reports success");
+        // A provider whose limits come from its compiled table keeps no learned
+        // store, so it neither writes to nor is filled from the shared cache.
+        assert!(MinimalProvider.learned_models().is_none());
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/pipeline/spawn.rs
+++ b/crates/leviath-runtime/src/pipeline/spawn.rs
@@ -310,23 +310,50 @@ pub fn spawn_agent_seeded(world: &mut World, spawn: SeededSpawn) -> Result<Entit
             blueprint.stages.len()
         ));
     }
-    // Resolve any percentage region budgets against each stage's model context
-    // window (the only place the model - and hence the window - is known). The
-    // global layout resolves against the entry stage (stage 0); each per-stage
-    // layout resolves against that stage's own model. Absolute layouts resolve to
-    // themselves, so this is a no-op for legacy blueprints.
+    // Resolve any percentage region budgets against a real model context window
+    // (the only place the model - and hence the window - is known). Absolute
+    // layouts resolve to themselves, so this is a no-op for legacy blueprints.
+    //
+    // The subtlety is *which* window sizes each region. A region's percentage
+    // budget is sized against the smallest context window among the stages that
+    // actually see it - not the entry stage's window, and not a stage that never
+    // reads the region. So the GLOBAL layout is resolved per region: for each
+    // region, the smallest window over the stages that use the global layout
+    // (declare no layout of their own) and can see the region. A per-stage
+    // layout's regions are private to that stage, so its own window is the only
+    // one that uses them.
     let stage_windows: Vec<usize> = stages
         .iter()
         .map(|rs| context_window_tokens(world, &rs.provider_name, &rs.model))
         .collect();
-    blueprint.context_layout = blueprint.context_layout.resolved(stage_windows[0]);
+    let resolved_global = {
+        let smallest_window_seeing = |region: &str| -> usize {
+            blueprint
+                .stages
+                .iter()
+                .enumerate()
+                .filter(|(_, s)| {
+                    s.context_layout.is_none() && blueprint.regions_visible_to(s).contains(region)
+                })
+                .map(|(i, _)| stage_windows[i])
+                .min()
+                // No stage uses the global layout for this region (every stage
+                // has its own, or all hide it); the entry window is a harmless
+                // default for a budget nothing at runtime consults.
+                .unwrap_or(stage_windows[0])
+        };
+        blueprint
+            .context_layout
+            .resolved_per_region(&smallest_window_seeing)
+    };
+    blueprint.context_layout = resolved_global;
     for (i, stage) in blueprint.stages.iter_mut().enumerate() {
         if let Some(layout) = &stage.context_layout {
             stage.context_layout = Some(layout.resolved(stage_windows[i]));
         }
     }
-    // Validate the resolved (fully-absolute) layouts, now that percentages are
-    // concrete numbers judged against the real model window.
+    // Structural validation (duplicate names, eviction order, custom scripts)
+    // once per distinct layout, now that percentages are concrete numbers.
     blueprint
         .context_layout
         .validate()
@@ -335,6 +362,24 @@ pub fn spawn_agent_seeded(world: &mut World, spawn: SeededSpawn) -> Result<Entit
         if let Some(layout) = &stage.context_layout {
             layout.validate().map_err(|e| e.to_string())?;
         }
+    }
+    // Then the working-room floor, per stage: each stage must keep enough
+    // evictable room after its fixed regions, judged against *its* model window
+    // over just the regions *it* sees. A region budgeted generously for a
+    // wide-window stage must not be counted against a narrow-window stage that
+    // never reads it - the check a single-window `validate()` cannot make, and
+    // the footgun that let a small entry-stage image model cap every later
+    // stage.
+    for (i, stage) in blueprint.stages.iter().enumerate() {
+        let layout = stage
+            .context_layout
+            .as_ref()
+            .unwrap_or(&blueprint.context_layout);
+        let visible = blueprint.regions_visible_to(stage);
+        layout
+            .retaining(|name| visible.contains(name))
+            .validate_working_room(stage_windows[i])
+            .map_err(|e| e.to_string())?;
     }
 
     // Kept before `stages` is consumed, so each stage's setup can fold the same

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -3788,6 +3788,171 @@ fn spawn_agent_seeded_errors_when_resolved_per_stage_layout_is_invalid() {
     assert!(err.contains("working tokens"), "{err}");
 }
 
+/// A provider that reports a fixed context window, so a test can register two
+/// stages with different windows and exercise the per-region sizing.
+struct FixedWindow(usize);
+#[async_trait::async_trait]
+impl Provider for FixedWindow {
+    async fn infer(
+        &self,
+        _r: &InferenceRequest,
+    ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
+        Ok(leviath_providers::InferenceResponse {
+            content: "ok".to_string(),
+            tool_calls: vec![],
+            tokens_used: leviath_providers::TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+                cached_tokens: 0,
+                cache_write_tokens: 0,
+                reported_cost_usd: None,
+            },
+            finish_reason: leviath_providers::FinishReason::Complete,
+            reasoning: None,
+            parts: Vec::new(),
+        })
+    }
+    async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        1
+    }
+    fn max_context_tokens(&self, _m: &str) -> usize {
+        self.0
+    }
+    fn name(&self) -> &str {
+        "fixed"
+    }
+    fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
+        leviath_providers::ModelCapabilities::default()
+    }
+}
+
+/// Two stages, a wide entry model and a narrow later one, sharing the global
+/// layout. This is the world the two footgun tests below spawn into.
+fn world_with_wide_and_narrow() -> World {
+    let mut world = World::new();
+    let mut reg = ProviderRegistry::new();
+    reg.register("wide".to_string(), Arc::new(FixedWindow(100_000)));
+    reg.register("narrow".to_string(), Arc::new(FixedWindow(20_000)));
+    world.insert_resource(Providers(reg));
+    world
+}
+
+fn pct_region(name: &str, percent: f64) -> leviath_core::layout::RegionDefinition {
+    leviath_core::layout::RegionDefinition::new(name.to_string(), RegionKind::Pinned, 0)
+        .with_budget(leviath_core::BudgetSpec::Percent {
+            percent,
+            min: None,
+            max: None,
+        })
+}
+
+fn wide_then_narrow_stages() -> Vec<ResolvedStage> {
+    vec![
+        ResolvedStage {
+            provider_name: "wide".to_string(),
+            model: "m".to_string(),
+            tools: vec![],
+            fallbacks: Vec::new(),
+            output: None,
+            notes: Vec::new(),
+        },
+        ResolvedStage {
+            provider_name: "narrow".to_string(),
+            model: "m".to_string(),
+            tools: vec![],
+            fallbacks: Vec::new(),
+            output: None,
+            notes: Vec::new(),
+        },
+    ]
+}
+
+#[test]
+fn spawn_sizes_a_region_against_the_smallest_window_that_actually_sees_it() {
+    // The footgun fix. A region only the wide stage reads (the narrow stage
+    // hides it) is sized against the wide window - not shrunk to the narrow
+    // stage that never sees it - and the narrow stage's working-room floor is
+    // judged over just the regions it does see, so the spawn succeeds.
+    let mut world = world_with_wide_and_narrow();
+    let layout = leviath_core::layout::ContextLayout::new(
+        vec![pct_region("big", 0.80), pct_region("small", 0.05)],
+        0,
+    );
+    let mk = |name: &str, provider: &str| {
+        leviath_core::Stage::new(
+            name.to_string(),
+            leviath_core::blueprint::ModelConfig::new(provider.to_string(), "m".to_string()),
+        )
+    };
+    let mut narrow = mk("b", "narrow");
+    // The narrow stage never reads the big region.
+    narrow.context_hide = vec!["big".to_string()];
+    let bp = leviath_core::Blueprint::new(
+        "t".to_string(),
+        "d".to_string(),
+        vec![mk("a", "wide"), narrow],
+        layout,
+    );
+    let e = spawn_agent(
+        &mut world,
+        "run".to_string(),
+        bp,
+        "task",
+        wide_then_narrow_stages(),
+        hints(true),
+    )
+    .expect("the narrow stage does not see the big region, so it fits");
+    let w = world.get::<ContextWindow>(e).expect("window");
+    // big: 80% of the wide window (100k), because only the wide stage sees it.
+    assert_eq!(w.get_region("big").unwrap().max_tokens, 80_000);
+    // small: 5% of the narrow window (20k), the smallest of the two stages that
+    // both see it.
+    assert_eq!(w.get_region("small").unwrap().max_tokens, 1_000);
+}
+
+#[test]
+fn spawn_fails_when_a_shared_region_starves_the_narrow_stage() {
+    // Now the narrow stage also sees a shared region sized at 80%. Against the
+    // narrow window (80% of 20k = 16k) that leaves the narrow stage only 4k
+    // working tokens. A wide-only region keeps the resolved total budget large
+    // enough that the single-window global validate() passes - so it is the
+    // per-stage floor, judged over just the narrow stage's visible regions,
+    // that catches the starvation. This is the branch the single-window check
+    // cannot make.
+    let mut world = world_with_wide_and_narrow();
+    let layout = leviath_core::layout::ContextLayout::new(
+        vec![pct_region("shared", 0.80), pct_region("wideonly", 0.10)],
+        0,
+    );
+    let mk = |name: &str, provider: &str| {
+        leviath_core::Stage::new(
+            name.to_string(),
+            leviath_core::blueprint::ModelConfig::new(provider.to_string(), "m".to_string()),
+        )
+    };
+    let mut narrow = mk("b", "narrow");
+    // The narrow stage never sees the wide-only region, so it does not count
+    // against its floor - only the shared region does.
+    narrow.context_hide = vec!["wideonly".to_string()];
+    let bp = leviath_core::Blueprint::new(
+        "t".to_string(),
+        "d".to_string(),
+        vec![mk("a", "wide"), narrow],
+        layout,
+    );
+    let err = spawn_agent(
+        &mut world,
+        "run".to_string(),
+        bp,
+        "task",
+        wide_then_narrow_stages(),
+        hints(true),
+    )
+    .expect_err("the narrow stage is starved by the shared region");
+    assert!(err.contains("working tokens"), "{err}");
+}
+
 #[test]
 fn collect_drops_outcome_for_non_awaiting_agent() {
     let (mut world, tx) = world_with_results();

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -189,7 +189,14 @@ impl ProviderRegistry {
     /// a successful prime so short-lived processes read the same numbers. A
     /// provider that keeps no learned store (a script provider) contributes
     /// nothing; a cache that could not be written is a warning, never fatal.
-    pub fn save_capability_cache(&self, path: &std::path::Path, now: i64) {
+    ///
+    /// `path` is an `Option` so a caller whose home did not resolve (the cache
+    /// path is unknown) passes `None` and this no-ops, keeping the caller
+    /// branch-free rather than each guarding an untestable `None`.
+    pub fn save_capability_cache(&self, path: Option<&std::path::Path>, now: i64) {
+        let Some(path) = path else {
+            return;
+        };
         let mut cache = leviath_providers::CapabilityCache::new(now);
         for (name, provider) in &self.providers {
             if let Some(learned) = provider.learned_models() {
@@ -1103,7 +1110,7 @@ mod tests {
         );
         // and one with no store at all (a script provider; skipped).
         primed.register("storeless".to_string(), Arc::new(StubProvider::storeless()));
-        primed.save_capability_cache(&path, 1_000);
+        primed.save_capability_cache(Some(&path), 1_000);
 
         // A fresh registry reads it back.
         let mut fresh = ProviderRegistry::new();
@@ -1167,6 +1174,8 @@ mod tests {
             Arc::new(StubProvider::with_learned(&[("m", 1)])),
         );
         // The failure is logged, not propagated: a cache is a convenience.
-        reg.save_capability_cache(&unwritable, 1);
+        reg.save_capability_cache(Some(&unwritable), 1);
+        // No path (home did not resolve) is a silent no-op, not a panic.
+        reg.save_capability_cache(None, 1);
     }
 }

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -184,6 +184,50 @@ impl ProviderRegistry {
         }
     }
 
+    /// Write every native provider's primed catalogue to the shared capability
+    /// cache at `path`, stamped `now` (Unix seconds). Called by the daemon after
+    /// a successful prime so short-lived processes read the same numbers. A
+    /// provider that keeps no learned store (a script provider) contributes
+    /// nothing; a cache that could not be written is a warning, never fatal.
+    pub fn save_capability_cache(&self, path: &std::path::Path, now: i64) {
+        let mut cache = leviath_providers::CapabilityCache::new(now);
+        for (name, provider) in &self.providers {
+            if let Some(learned) = provider.learned_models() {
+                let snapshot = learned.snapshot();
+                if !snapshot.is_empty() {
+                    cache.set(name, snapshot);
+                }
+            }
+        }
+        if let Err(e) = cache.save(path) {
+            tracing::warn!(error = %e, "could not write the model-capability cache");
+        }
+    }
+
+    /// Fill each native provider's learned store from the cache at `path`, for
+    /// the providers it holds an entry for, and report whether anything loaded.
+    ///
+    /// Lets a freshly built registry answer a model's real limits without its own
+    /// network prime, as long as some process (the daemon) has primed and written
+    /// the cache. A missing or stale-versioned file loads nothing and returns
+    /// false, which is the pre-cache behaviour: fall back to priming or the table.
+    pub fn load_capability_cache(&self, path: &std::path::Path) -> bool {
+        let Some(cache) = leviath_providers::CapabilityCache::load(path) else {
+            return false;
+        };
+        let mut loaded = false;
+        for (name, provider) in &self.providers {
+            let Some(learned) = provider.learned_models() else {
+                continue;
+            };
+            if let Some(models) = cache.get(name) {
+                learned.replace(models.clone().into_iter().collect());
+                loaded = true;
+            }
+        }
+        loaded
+    }
+
     /// Get every model a run is about to use ready, before it starts.
     ///
     /// `models` is what the blueprint names, bare and deduplicated. Every
@@ -375,6 +419,11 @@ mod tests {
         catalog: Option<Vec<String>>,
         /// What it says about refusing anything outside that catalogue.
         refusal: Option<String>,
+        /// The learned store the capability cache reads and fills.
+        learned: leviath_providers::LearnedModels,
+        /// When true, [`Provider::learned_models`] returns `None`, standing in
+        /// for a provider (a script provider) that keeps no learned store.
+        no_store: bool,
     }
 
     impl StubProvider {
@@ -385,7 +434,38 @@ mod tests {
                 warmed: Arc::new(std::sync::Mutex::new(Vec::new())),
                 catalog: None,
                 refusal: None,
+                learned: leviath_providers::LearnedModels::default(),
+                no_store: false,
             }
+        }
+
+        /// A stub that keeps no learned store, like a script provider.
+        fn storeless() -> Self {
+            Self {
+                no_store: true,
+                ..Self::new(PrimeOutcome::Ok)
+            }
+        }
+
+        /// A stub whose learned store already holds `models` (id → context
+        /// window), as if it had primed.
+        fn with_learned(models: &[(&str, usize)]) -> Self {
+            let stub = Self::new(PrimeOutcome::Ok);
+            stub.learned.replace(
+                models
+                    .iter()
+                    .map(|(id, ctx)| {
+                        (
+                            (*id).to_string(),
+                            leviath_providers::LearnedModel {
+                                max_context_tokens: Some(*ctx),
+                                ..Default::default()
+                            },
+                        )
+                    })
+                    .collect(),
+            );
+            stub
         }
 
         /// The same stub, publishing a complete catalogue.
@@ -459,6 +539,10 @@ mod tests {
         }
         fn served_catalog(&self) -> Option<Vec<String>> {
             self.catalog.clone()
+        }
+
+        fn learned_models(&self) -> Option<&leviath_providers::LearnedModels> {
+            (!self.no_store).then_some(&self.learned)
         }
 
         fn refusal_reason(&self, _model_key: &str) -> Option<String> {
@@ -998,5 +1082,91 @@ mod tests {
             request_timeout_secs: None,
         };
         assert!(p.infer(&request).await.is_err());
+    }
+
+    #[test]
+    fn the_capability_cache_round_trips_and_skips_every_other_shape() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("caps").join("model_capabilities.json");
+
+        // A primed registry with all three provider shapes:
+        let mut primed = ProviderRegistry::new();
+        // one that learned a real window (cached),
+        primed.register(
+            "learned".to_string(),
+            Arc::new(StubProvider::with_learned(&[("big-model", 200_000)])),
+        );
+        // one with a store that primed nothing (empty snapshot, not cached),
+        primed.register(
+            "empty".to_string(),
+            Arc::new(StubProvider::new(PrimeOutcome::Ok)),
+        );
+        // and one with no store at all (a script provider; skipped).
+        primed.register("storeless".to_string(), Arc::new(StubProvider::storeless()));
+        primed.save_capability_cache(&path, 1_000);
+
+        // A fresh registry reads it back.
+        let mut fresh = ProviderRegistry::new();
+        // this one is in the cache, so it is filled,
+        fresh.register(
+            "learned".to_string(),
+            Arc::new(StubProvider::new(PrimeOutcome::Ok)),
+        );
+        // this one has a store but no cache entry, so it is left alone,
+        fresh.register(
+            "unknown".to_string(),
+            Arc::new(StubProvider::new(PrimeOutcome::Ok)),
+        );
+        // and this one has no store, so it is skipped.
+        fresh.register("storeless".to_string(), Arc::new(StubProvider::storeless()));
+        assert!(
+            fresh
+                .get("learned")
+                .unwrap()
+                .learned_models()
+                .unwrap()
+                .is_empty(),
+            "nothing learned before the cache is loaded"
+        );
+        assert!(fresh.load_capability_cache(&path));
+        assert_eq!(
+            fresh
+                .get("learned")
+                .unwrap()
+                .learned_models()
+                .unwrap()
+                .get("big-model")
+                .unwrap()
+                .max_context_tokens,
+            Some(200_000),
+        );
+        assert!(
+            fresh
+                .get("unknown")
+                .unwrap()
+                .learned_models()
+                .unwrap()
+                .is_empty(),
+            "a provider with no cache entry is left as it was"
+        );
+
+        // A missing (or stale-versioned) cache loads nothing and says so.
+        assert!(!fresh.load_capability_cache(&dir.path().join("nope.json")));
+    }
+
+    #[test]
+    fn saving_the_cache_where_it_cannot_be_written_warns_but_does_not_panic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A file where a directory would have to be makes the write fail.
+        let file = dir.path().join("in-the-way");
+        std::fs::write(&file, "x").expect("write the blocker");
+        let unwritable = file.join("sub").join("model_capabilities.json");
+        let mut reg = ProviderRegistry::new();
+        reg.register(
+            "stub".to_string(),
+            Arc::new(StubProvider::with_learned(&[("m", 1)])),
+        );
+        // The failure is logged, not propagated: a cache is a convenience.
+        reg.save_capability_cache(&unwritable, 1);
     }
 }


### PR DESCRIPTION
## What

Makes a model's token limits (`max_context_tokens` in, `max_output_tokens` out) come from **one consistent source** across every surface, instead of each rebuilding a provider registry and re-priming the network on its own.

### The problem (measured)
Only the runtime spawn path read the daemon's primed registry. `lev models`, `GET /api/models`, `lev validate` and the TUI each **built their own registry and re-primed** (5s timeout vs the daemon's 10s), and there was **no persisted cache**. So `lev models show openrouter/anthropic/claude-opus-5` reported the `8192` default while the daemon had the real window — and `lev models show` also mismatched provider-prefixed ids. Leviath *does* fetch OpenRouter's 445 model windows correctly; the numbers just weren't shared.

### This PR so far — the shared foundation (done, 100% covered)
- `LearnedModel` is `Serialize`/`Deserialize`; each native provider exposes its learned catalogue via a new `Provider::learned_models` seam.
- `leviath_providers::CapabilityCache` — a versioned, atomically-written (`0o600`) on-disk cache of every provider's primed catalogue, with an age for staleness.
- `ProviderRegistry::save_capability_cache` / `load_capability_cache` — the daemon writes it after priming; any freshly built registry fills its providers from it, so a short-lived process answers real limits without its own prime.

### Remaining (increment 3 — CLI/HTTP/TUI wiring)
- Daemon saves the cache after its startup prime; every `build_provider_registry_*` loads it first (cache path = `control_dir()/model_capabilities.json`).
- `GET /api/models` reads the daemon's live World registry (the hybrid part).
- `lev models show` id-matching fix (use `find_by_key`/last-segment; handle the `openrouter/` prefix) — the direct fix for the 8192 symptom.
- TUI `entry_stage_window` reads the shared source instead of the compiled table + 8192.
- Unify the fallback constants (8192 / 32768 / 128000) and per-surface prime timeouts.

Architecture decision (with the maintainer): **hybrid** — disk cache as the shared foundation that works standalone, plus HTTP reading the daemon's live registry when it's up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kh7J65m1oRXm1WP7vCb7YN
